### PR TITLE
Use RamUsageEstimator instead of ClassLayout in ColumnBuilderStatus

### DIFF
--- a/common-api/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/ColumnBuilderStatus.java
+++ b/common-api/src/main/java/org/apache/iotdb/tsfile/read/common/block/column/ColumnBuilderStatus.java
@@ -20,6 +20,7 @@
 package org.apache.iotdb.tsfile.read.common.block.column;
 
 import org.apache.iotdb.tsfile.read.common.block.TsBlockBuilderStatus;
+import org.apache.iotdb.tsfile.utils.RamUsageEstimator;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -29,7 +30,7 @@ import static java.util.Objects.requireNonNull;
 
 public class ColumnBuilderStatus {
 
-  public static final int INSTANCE_SIZE = deepInstanceSize(ColumnBuilderStatus.class);
+  public static final long INSTANCE_SIZE = deepInstanceSize(ColumnBuilderStatus.class);
 
   private final TsBlockBuilderStatus tsBlockBuilderStatus;
 
@@ -57,7 +58,7 @@ public class ColumnBuilderStatus {
   /**
    * Computes the size of an instance of this class assuming that all reference fields are non-null
    */
-  private static int deepInstanceSize(Class<?> clazz) {
+  private static long deepInstanceSize(Class<?> clazz) {
     if (clazz.isArray()) {
       throw new IllegalArgumentException(
           format(
@@ -76,7 +77,7 @@ public class ColumnBuilderStatus {
               clazz.getSimpleName(), clazz.getSuperclass().getSimpleName()));
     }
 
-    int size = ClassLayout.parseClass(clazz).instanceSize();
+    long size = RamUsageEstimator.shallowSizeOf(clazz);
     for (Field field : clazz.getDeclaredFields()) {
       // if the field is not static and is a reference field and it's not synthetic
       if (!Modifier.isStatic(field.getModifiers())


### PR DESCRIPTION
fix the compilation error in ColumnBuilderStatus, just missed this replacing in previous [pr](https://github.com/apache/tsfile/pull/1) , but it seems that there still exist error in jdk 11, 17 and 21 like the following:

`sun.misc packages don't exist` 