### PR TITLE
Add null guards for TsFileExecutor constructor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <argLine />
+        <argLine/>
         <spotless.skip>false</spotless.skip>
     </properties>
     <dependencyManagement>
@@ -202,7 +202,7 @@
                             <importOrder>
                                 <order>org.apache.tsfile,,javax,java,\#</order>
                             </importOrder>
-                            <removeUnusedImports />
+                            <removeUnusedImports/>
                         </java>
                         <lineEndings>UNIX</lineEndings>
                     </configuration>
@@ -301,7 +301,7 @@
                         <phase>validate</phase>
                         <configuration>
                             <rules>
-                                <dependencyConvergence />
+                                <dependencyConvergence/>
                             </rules>
                         </configuration>
                     </execution>

--- a/tsfile/src/main/java/org/apache/tsfile/read/query/executor/TsFileExecutor.java
+++ b/tsfile/src/main/java/org/apache/tsfile/read/query/executor/TsFileExecutor.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class TsFileExecutor implements QueryExecutor {
 
@@ -50,8 +51,8 @@ public class TsFileExecutor implements QueryExecutor {
   private IChunkLoader chunkLoader;
 
   public TsFileExecutor(IMetadataQuerier metadataQuerier, IChunkLoader chunkLoader) {
-    this.metadataQuerier = metadataQuerier;
-    this.chunkLoader = chunkLoader;
+    this.metadataQuerier = Objects.requireNonNull(metadataQuerier, "metadataQuerier");
+    this.chunkLoader = Objects.requireNonNull(chunkLoader, "chunkLoader");
   }
 
   @Override

--- a/tsfile/src/test/java/org/apache/tsfile/read/query/executor/TsFileExecutorTest.java
+++ b/tsfile/src/test/java/org/apache/tsfile/read/query/executor/TsFileExecutorTest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iotdb.tsfile.read.query.executor;
+package org.apache.tsfile.read.query.executor;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -25,8 +25,10 @@ import org.junit.Test;
 public class TsFileExecutorTest {
   @Test
   public void constructorNullTest() {
-    Assert.assertThrows(NullPointerException.class, () -> {
-        new TsFileExecutor(null, null);
-    });
+    Assert.assertThrows(
+        NullPointerException.class,
+        () -> {
+          new TsFileExecutor(null, null);
+        });
   }
 }

--- a/tsfile/src/test/java/org/apache/tsfile/read/query/executor/TsFileExecutorTest.java
+++ b/tsfile/src/test/java/org/apache/tsfile/read/query/executor/TsFileExecutorTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.tsfile.read.query.executor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TsFileExecutorTest {
+  @Test
+  public void constructorNullTest() {
+    Assert.assertThrows(NullPointerException.class, () -> {
+        new TsFileExecutor(null, null);
+    });
+  }
+}


### PR DESCRIPTION

## Description
(Copied from [Apache IoTDB PR#12013](https://github.com/apache/iotdb/pull/12013).)

This PR intends to provide `null` guards in the `TsFileExecutor`'s constructors.
The inputs to the constructor of `TsFileExecutor` are immediately saved to the executor's private properties, which cannot neither be changed elsewhere nor are they guarded against `null` in other methods of the class.
Even though `null` inputs to the constructor make little sense, allowing them to be `null` makes debugging any subsequent `NullPointerException`s convoluted.
This PR uses the `Object.requireNonNull` method for a fail-fast guard against `null` inputs.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design 
(or naming) decision point and compare the alternatives with the designs that you've implemented 
(or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere 
(e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), 
link to that discussion from this PR description and explain what have changed in your final design 
compared to your original proposal or the consensus version in the end of the discussion. 
If something hasn't changed since the original discussion, you can omit a detailed discussion of 
those aspects of the design here, perhaps apart from brief mentioning for the sake of readability 
of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
