### PR TITLE
Fix the mistaken argument in LZ4Uncompressor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <argLine />
+        <argLine/>
         <spotless.skip>false</spotless.skip>
     </properties>
     <dependencyManagement>
@@ -202,7 +202,7 @@
                             <importOrder>
                                 <order>org.apache.tsfile,,javax,java,\#</order>
                             </importOrder>
-                            <removeUnusedImports />
+                            <removeUnusedImports/>
                         </java>
                         <lineEndings>UNIX</lineEndings>
                     </configuration>
@@ -301,7 +301,7 @@
                         <phase>validate</phase>
                         <configuration>
                             <rules>
-                                <dependencyConvergence />
+                                <dependencyConvergence/>
                             </rules>
                         </configuration>
                     </execution>

--- a/tsfile/src/main/java/org/apache/tsfile/compress/IUnCompressor.java
+++ b/tsfile/src/main/java/org/apache/tsfile/compress/IUnCompressor.java
@@ -238,7 +238,7 @@ public interface IUnCompressor {
     public int uncompress(byte[] byteArray, int offset, int length, byte[] output, int outOffset)
         throws IOException {
       try {
-        return decompressor.decompress(byteArray, offset, length, output, offset);
+        return decompressor.decompress(byteArray, offset, length, output, outOffset);
       } catch (RuntimeException e) {
         logger.error(UNCOMPRESS_INPUT_ERROR, e);
         throw new IOException(e);

--- a/tsfile/src/test/java/org/apache/tsfile/compress/LZ4Test.java
+++ b/tsfile/src/test/java/org/apache/tsfile/compress/LZ4Test.java
@@ -80,4 +80,25 @@ public class LZ4Test {
     byte[] uncompressed = unCompressor.uncompress(compressed);
     Assert.assertArrayEquals(uncom, uncompressed);
   }
+
+  @Test
+  public void testBytes3() throws IOException {
+    LZ4Compressor compressor = new LZ4Compressor();
+    IUnCompressor.LZ4UnCompressor unCompressor = new IUnCompressor.LZ4UnCompressor();
+
+    int n = 500000;
+    int offset = 100;
+    String input = randomString(n);
+    byte[] origin = input.getBytes(StandardCharsets.UTF_8);
+    byte[] compressed = new byte[origin.length * 2];
+    int compressedLength = compressor.compress(origin, 0, origin.length, compressed);
+    System.arraycopy(compressed, 0, compressed, offset, compressedLength);
+    for (int i = 0; i < offset; i++) {
+      compressed[i] = 0;
+    }
+
+    byte[] uncompressed = new byte[origin.length];
+    unCompressor.uncompress(compressed, offset, compressedLength, uncompressed, 0);
+    Assert.assertArrayEquals(origin, uncompressed);
+  }
 }


### PR DESCRIPTION
The LZ4Uncompress used the wrong argument for the offset of the output buffer, which is corrected in this PR.