### PR TITLE
Add an equivalent `.getLongs()` method to `.getTimes()` in TimeColumn.

### DIFF
--- a/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TimeColumn.java
+++ b/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TimeColumn.java
@@ -146,6 +146,11 @@ public class TimeColumn implements Column {
   }
 
   @Override
+  public long[] getLongs() {
+    return getTimes();
+  }
+
+  @Override
   public int getInstanceSize() {
     return INSTANCE_SIZE;
   }


### PR DESCRIPTION
Before this PR, a column can reference to TimeColumn object, but if user do not cast its type to TimeColumn, it would be impossible to get all time values from TimeColumn.

After this PR, if we already know one particular column is TimeColumn, we can direct call `.getLongs()` to acquire all time values, rather than first cast it to TimeColumn object, then call `.getTime()` method.