### PR TITLE
Fix/fix the cpp build on windows

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -91,8 +91,4 @@ jobs:
       - name: Build and test with Maven (All others)
         shell: bash
         run: |
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            ./mvnw${{ steps.platform_suffix.outputs.platform_suffix }} -P with-java clean verify
-          else
-            ./mvnw${{ steps.platform_suffix.outputs.platform_suffix }} -P with-java,with-cpp clean verify
-          fi
+          ./mvnw${{ steps.platform_suffix.outputs.platform_suffix }} -P with-java,with-cpp clean verify

--- a/cpp/pom.xml
+++ b/cpp/pom.xml
@@ -62,39 +62,77 @@
                 Do the actual build.
             -->
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>1.6.0</version>
+                <groupId>com.googlecode.cmake-maven-project</groupId>
+                <artifactId>cmake-maven-plugin</artifactId>
                 <executions>
-                    <!-- run build script -->
+                    <!-- Generate the configuration for the main compilation -->
+                    <!--execution>
+                      <id>cmake-generate-compile</id>
+                      <phase>compile</phase>
+                      <goals>
+                        <goal>generate</goal>
+                      </goals>
+                    </execution>
+                    <!- Compile the main code ->
                     <execution>
-                        <id>execute-compile-shell-script</id>
-                        <phase>compile</phase>
+                      <id>cmake-execute-compile</id>
+                      <phase>compile</phase>
+                      <goals>
+                        <goal>compile</goal>
+                      </goals>
+                    </execution-->
+                    <!-- Generate the configuration for the test compilation -->
+                    <execution>
+                        <id>cmake-generate-test-compile</id>
+                        <phase>generate-test-sources</phase>
                         <goals>
-                            <goal>exec</goal>
+                            <goal>generate</goal>
                         </goals>
                         <configuration>
-                            <executable>bash</executable>
-                            <arguments>
-                                <argument>build.sh</argument>
-                            </arguments>
+                            <options>
+                                <option>-DUNITY_VERSION:STRING=${unity.version}</option>
+                                <option>-DBUILD_PHASE=test-compile</option>
+                            </options>
                         </configuration>
                     </execution>
-                    <!-- run test_all.sh script -->
+                    <!-- Compile the test code -->
                     <execution>
-                        <id>execute-test-shell-script</id>
+                        <id>cmake-execute-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <!-- Execute the tests -->
+                    <execution>
+                        <id>cmake-run-tests</id>
                         <phase>test</phase>
                         <goals>
-                            <goal>exec</goal>
+                            <goal>test</goal>
                         </goals>
                         <configuration>
-                            <executable>bash</executable>
-                            <arguments>
-                                <argument>test_all.sh</argument>
-                            </arguments>
+                            <buildDirectory>${project.build.directory}/build</buildDirectory>
                         </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <!--
+                        Actually the path to the CMakeList.txt file which then again
+                        tells to tool where to find the sources.
+                    -->
+                    <sourcePath>${project.basedir}</sourcePath>
+                    <!--
+                        Path to where the build configuration is generated
+                        (This directory is then used in the compile step to actually perform the build)
+                    -->
+                    <targetPath>${project.build.directory}/build</targetPath>
+                    <!--
+                        Name of the generator the compile step will be executing.
+                    -->
+                    <generator>${cmake.generator}</generator>
+                    <!-- The directory where the "generate" step generated the build configuration -->
+                    <projectDirectory>${project.build.directory}/build</projectDirectory>
+                </configuration>
             </plugin>
             <!-- Overwrite test config-->
             <plugin>

--- a/cpp/pom.xml
+++ b/cpp/pom.xml
@@ -28,7 +28,6 @@
     <packaging>pom</packaging>
     <name>TsFile: C++</name>
     <properties>
-        <unity.version>2.6.0</unity.version>
         <groovy.version>4.0.21</groovy.version>
         <!-- Tell Sonar where to find the sources -->
         <sonar.sources>common,examples,tsfile</sonar.sources>
@@ -37,27 +36,6 @@
     <build>
         <sourceDirectory>${project.basedir}</sourceDirectory>
         <plugins>
-            <plugin>
-                <groupId>com.googlecode.maven-download-plugin</groupId>
-                <artifactId>download-maven-plugin</artifactId>
-                <executions>
-                    <!--
-                        Get additional stuff we need for the build.
-                    -->
-                    <execution>
-                        <id>get-unity</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>wget</goal>
-                        </goals>
-                        <configuration>
-                            <url>https://github.com/ThrowTheSwitch/Unity/archive/v${unity.version}.zip</url>
-                            <unpack>true</unpack>
-                            <outputDirectory>${project.build.directory}/dependency</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <!--
                 Do the actual build.
             -->
@@ -90,7 +68,6 @@
                         </goals>
                         <configuration>
                             <options>
-                                <option>-DUNITY_VERSION:STRING=${unity.version}</option>
                                 <option>-DBUILD_PHASE=test-compile</option>
                             </options>
                         </configuration>

--- a/cpp/src/common/allocator/mem_alloc.cc
+++ b/cpp/src/common/allocator/mem_alloc.cc
@@ -17,7 +17,9 @@
  * under the License.
  */
 
+#ifndef _WIN32
 #include <execinfo.h>
+#endif
 #include <string.h>
 
 #include <iostream>
@@ -102,6 +104,7 @@ void *mem_alloc(uint32_t size, AllocModID mid) {
     }
 }
 
+#ifndef _WIN32
 void printCallers() {
     int layers = 0, i = 0;
     char **symbols = NULL;
@@ -126,6 +129,7 @@ void printCallers() {
         printf("Failed to parse function names\n");
     }
 }
+#endif
 
 void mem_free(void *ptr) {
     // try as 4Byte header

--- a/cpp/src/common/global.cc
+++ b/cpp/src/common/global.cc
@@ -19,7 +19,9 @@
 
 #include "global.h"
 
+#ifndef _WIN32
 #include <execinfo.h>
+#endif
 #include <stdlib.h>
 
 #include "utils/injection.h"
@@ -166,6 +168,7 @@ void cols_to_json(ByteStream* byte_stream,
     // DEBUG_print_byte_stream(*byte_stream);  // for debug
 }
 
+#ifndef _WIN32
 void print_backtrace() {
     const int MAX_FRAMES = 32;
     int layers = 0;
@@ -182,6 +185,7 @@ void print_backtrace() {
         free(symbols);
     }
 }
+#endif
 
 Mutex g_all_inject_points_mutex;
 std::map<std::string, InjectPoint> g_all_inject_points;

--- a/cpp/src/cwrapper/TsFile-cwrapper.h
+++ b/cpp/src/cwrapper/TsFile-cwrapper.h
@@ -24,6 +24,9 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#ifdef _WIN32
+#include <sys/stat.h>
+#endif
 
 typedef long long SchemaInfo;
 typedef long long timestamp;

--- a/cpp/src/encoding/encoder_factory.h
+++ b/cpp/src/encoding/encoder_factory.h
@@ -104,6 +104,7 @@ class EncoderFactory {
             ASSERT(false);
             return nullptr;
         }
+        return nullptr;
     }
 
     static void free(Encoder *encoder) { common::mem_free(encoder); }

--- a/cpp/src/file/read_file.cc
+++ b/cpp/src/file/read_file.cc
@@ -132,8 +132,6 @@ int ReadFile::read(int32_t offset, char *buf, int32_t buf_size,
 
 }  // end namespace storage
 
-// https://github.com/aleitner/windows_pread/blob/master/src/pread.c
-// We need to find out which license this is under.
 #ifdef _WIN32
 ssize_t pread(int fd, void *buf, size_t count, uint64_t offset)
 {

--- a/cpp/src/file/write_file.cc
+++ b/cpp/src/file/write_file.cc
@@ -31,6 +31,10 @@
 #include "common/logger/elog.h"
 #include "utils/errno_define.h"
 
+#ifdef _WIN32
+int	 fsync(int);
+#endif
+
 using namespace common;
 
 namespace storage {
@@ -126,3 +130,10 @@ int WriteFile::close() {
 }
 
 }  // end namespace storage
+
+#ifdef _WIN32
+int fsync(int fd)
+{
+    return _commit(fd);
+}
+#endif

--- a/pom.xml
+++ b/pom.xml
@@ -724,8 +724,9 @@
             <properties>
                 <os.suffix>win</os.suffix>
                 <os.classifier>windows-x86_64</os.classifier>
+                <cmake.generator>MinGW Makefiles</cmake.generator>
                 <!-- The generated code relied on Boost and that relies on VS and can't be built with MinGW -->
-                <cmake.generator>Visual Studio 17 2022</cmake.generator>
+                <!--cmake.generator>Visual Studio 17 2022</cmake.generator-->
             </properties>
         </profile>
         <!-- profile for windows amd64 (mainly AMD Processors) (Self-Enabling) -->
@@ -740,8 +741,9 @@
             <properties>
                 <os.suffix>win</os.suffix>
                 <os.classifier>windows-amd64</os.classifier>
+                <cmake.generator>MinGW Makefiles</cmake.generator>
                 <!-- The generated code relied on Boost and that relies on VS and can't be built with MinGW -->
-                <cmake.generator>Visual Studio 17 2022</cmake.generator>
+                <!--cmake.generator>Visual Studio 17 2022</cmake.generator-->
             </properties>
         </profile>
         <!-- profile for windows aarch64 (mainly newer Mac or Raspberry PI Processors) (Self-Enabling) -->
@@ -756,8 +758,9 @@
             <properties>
                 <os.suffix>win</os.suffix>
                 <os.classifier>windows-aarch64</os.classifier>
+                <cmake.generator>MinGW Makefiles</cmake.generator>
                 <!-- The generated code relied on Boost and that relies on VS and can't be built with MinGW -->
-                <cmake.generator>Visual Studio 17 2022</cmake.generator>
+                <!--cmake.generator>Visual Studio 17 2022</cmake.generator-->
             </properties>
         </profile>
         <!-- Little helper profile that will disable running the cmake tests when the maven tests are being skipped -->

--- a/pom.xml
+++ b/pom.xml
@@ -724,7 +724,8 @@
             <properties>
                 <os.suffix>win</os.suffix>
                 <os.classifier>windows-x86_64</os.classifier>
-                <cmake.generator>MinGW Makefiles</cmake.generator>
+                <!-- The generated code relied on Boost and that relies on VS and can't be built with MinGW -->
+                <cmake.generator>Visual Studio 17 2022</cmake.generator>
             </properties>
         </profile>
         <!-- profile for windows amd64 (mainly AMD Processors) (Self-Enabling) -->
@@ -739,7 +740,8 @@
             <properties>
                 <os.suffix>win</os.suffix>
                 <os.classifier>windows-amd64</os.classifier>
-                <cmake.generator>MinGW Makefiles</cmake.generator>
+                <!-- The generated code relied on Boost and that relies on VS and can't be built with MinGW -->
+                <cmake.generator>Visual Studio 17 2022</cmake.generator>
             </properties>
         </profile>
         <!-- profile for windows aarch64 (mainly newer Mac or Raspberry PI Processors) (Self-Enabling) -->
@@ -754,7 +756,8 @@
             <properties>
                 <os.suffix>win</os.suffix>
                 <os.classifier>windows-aarch64</os.classifier>
-                <cmake.generator>MinGW Makefiles</cmake.generator>
+                <!-- The generated code relied on Boost and that relies on VS and can't be built with MinGW -->
+                <cmake.generator>Visual Studio 17 2022</cmake.generator>
             </properties>
         </profile>
         <!-- Little helper profile that will disable running the cmake tests when the maven tests are being skipped -->


### PR DESCRIPTION
This PR adds the usage of the cmake-maven-plugin back as well as addresses some code-level changes needed in order to compile TsFile CPP on Windows systems.

Manually tested with `mvnw -P with-cpp clean install` on:
- Windows aarch64
- Windows intel
- Linux aarch64
- Linux intel
- MacOS aarch64
- MacOS intel