### PR TITLE
bugfix: bitmap clear method

### DIFF
--- a/cpp/src/common/container/bit_map.h
+++ b/cpp/src/common/container/bit_map.h
@@ -52,7 +52,7 @@ class BitMap {
 
         char *start_addr = bitmap_ + offset;
         uint8_t bit_mask = get_bit_mask(index);
-        *start_addr = (*start_addr) ^ (~bit_mask);
+        *start_addr = (*start_addr) & (~bit_mask);
     }
 
     FORCE_INLINE bool test(uint32_t index) {


### PR DESCRIPTION
TEST_F(BitMapTest, Clear) {
    common::BitMap bitmap;
    bitmap.init(100);
    bitmap.set(10);
    bitmap.set(20);
    bitmap.clear(10);
    EXPECT_FALSE(bitmap.test(10)); **// This line cannot execute correctly**
    EXPECT_TRUE(bitmap.test(20));
}