### PR TITLE
Fix SimpleListNode::remove

### DIFF
--- a/cpp/src/common/container/list.h
+++ b/cpp/src/common/container/list.h
@@ -119,10 +119,11 @@ class SimpleList {
         while (cur && cur->data_ != target) {
             cur = cur->next_;
         }
-        if (cur) {
+        if (!cur) {
             return common::E_NOT_EXIST;
         }
         prev->next_ = cur->next_;
+        size_--;
         // cur is allocated from PageArena, it should not reclaim now
         return common::E_OK;
     }


### PR DESCRIPTION
https://github.com/apache/tsfile/issues/116

The "remove" method misses updating the value of "size_", and incorrectly returns "common::E_NOT_EXIST" after finding the element.