### PR TITLE
[CPP] fix ts2diff decoder

### DIFF
--- a/cpp/src/encoding/ts2diff_decoder.h
+++ b/cpp/src/encoding/ts2diff_decoder.h
@@ -90,6 +90,9 @@ class TS2DIFFDecoder : public Decoder {
                 bits_left_ -= bits;
                 bits = 0;
             }
+            if (bits <= 0 && current_index_ == 0) {
+                break;
+            }
             read_byte_if_empty(in);
         }
         return value;
@@ -128,12 +131,12 @@ int32_t TS2DIFFDecoder<int32_t>::decode(common::ByteStream &in) {
         current_index_ = 1;
         return ret_value;
     }
-    stored_value_ = (int32_t)read_long(bit_width_, in);
-    ret_value = stored_value_ + first_value_ + delta_min_;
-    first_value_ = ret_value;
     if (current_index_++ >= write_index_) {
         current_index_ = 0;
     }
+    stored_value_ = (int32_t)read_long(bit_width_, in);
+    ret_value = stored_value_ + first_value_ + delta_min_;
+    first_value_ = ret_value;
 
     return ret_value;
 }


### PR DESCRIPTION
https://github.com/apache/tsfile/issues/104

The TS2Diff decoder reads an extra byte after processing each group of data（TS2DIFFEncoder.block_size_ = 128）, causing the header of the next group of data to be misaligned.

Here are the unit tests, and the encoder's output is also consistent with the output from Java.
```
TEST_F(TS2DIFFEncoderTest, TestIntEncoding) {
    common::ByteStream out_stream(1024, common::MOD_TS2DIFF_OBJ, false);
    const int row_num = 10000;
    int32_t data[row_num];
    memset(data, 0, sizeof(int32_t) * row_num);
    for (int i = 0; i < row_num; i++) {
        data[i] = i * i;
    }
    
    for (int i = 0; i < row_num; i++) {
        EXPECT_EQ(encoder_int_->encode(data[i], out_stream), common::E_OK);
    }
    EXPECT_EQ(encoder_int_->flush(out_stream), common::E_OK);

    for (int i = 0; i < row_num; i++) {
        int32_t x;
        EXPECT_EQ(decoder_int_->read_int32(x, out_stream), common::E_OK);
        EXPECT_EQ(x, data[i]);
    }
}

TEST_F(TS2DIFFEncoderTest, TestLongEncoding) {
    common::ByteStream out_stream(1024, common::MOD_TS2DIFF_OBJ, false);
    const int row_num = 10000;
    int64_t data[row_num];
    memset(data, 0, sizeof(int64_t) * row_num);
    for (int i = 0; i < row_num; i++) {
        data[i] = i * i;
    }
    
    for (int i = 0; i < row_num; i++) {
        EXPECT_EQ(encoder_long_->encode(data[i], out_stream), common::E_OK);
    }
    EXPECT_EQ(encoder_long_->flush(out_stream), common::E_OK);

    for (int i = 0; i < row_num; i++) {
        int64_t x;
        EXPECT_EQ(decoder_long_->read_int64(x, out_stream), common::E_OK);
        EXPECT_EQ(x, data[i]);
    }
}
```

