### PR TITLE
fix ZigZagCodec

### DIFF
--- a/cpp/src/encoding/zigzag_decoder.h
+++ b/cpp/src/encoding/zigzag_decoder.h
@@ -112,7 +112,7 @@ class ZigzagDecoder {
     }
 
     int64_t zigzag_decoder(int64_t stored_value_) {
-        stored_value_ = (stored_value_ >> 1) ^ -(stored_value_ & 1);
+        stored_value_ = ((uint64_t)stored_value_ >> 1) ^ -(stored_value_ & 1);
         return stored_value_;
     }
 

--- a/cpp/src/encoding/zigzag_decoder.h
+++ b/cpp/src/encoding/zigzag_decoder.h
@@ -61,14 +61,8 @@ class ZigzagDecoder {
     }
 
     void read_header(common::ByteStream &in) {
-        flush_byte_if_empty(in);
-        zigzag_length_ = buffer_;
-        buffer_ = 0;
-        bits_left_ = 0;
-        flush_byte_if_empty(in);
-        int_length_ = buffer_;
-        buffer_ = 0;
-        bits_left_ = 0;
+        common::SerializationUtil::read_var_uint(zigzag_length_, in);
+        common::SerializationUtil::read_var_uint(int_length_, in);
     }
 
     void flush_byte_if_empty(common::ByteStream &in) {
@@ -127,8 +121,8 @@ class ZigzagDecoder {
     int first_bit_of_byte_;
     int num_of_sorts_of_zigzag_;
     bool first_read_;
-    uint8_t zigzag_length_;
-    uint8_t int_length_;
+    uint32_t zigzag_length_;
+    uint32_t int_length_;
     std::vector<uint8_t> list_transit_in_zd_;
 };
 
@@ -141,7 +135,7 @@ int32_t ZigzagDecoder<int32_t>::decode(common::ByteStream &in) {
         buffer_ = 0;
         first_read_ = false;
         list_transit_in_zd_.clear();
-        for (uint8_t i = 0; i < zigzag_length_; i++) {
+        for (uint32_t i = 0; i < zigzag_length_; i++) {
             flush_byte_if_empty(in);
             list_transit_in_zd_.push_back(buffer_);
             buffer_ = 0;
@@ -174,7 +168,7 @@ int64_t ZigzagDecoder<int64_t>::decode(common::ByteStream &in) {
         buffer_ = 0;
         first_read_ = false;
         list_transit_in_zd_.clear();
-        for (uint8_t i = 0; i < zigzag_length_; i++) {
+        for (uint32_t i = 0; i < zigzag_length_; i++) {
             flush_byte_if_empty(in);
             list_transit_in_zd_.push_back(buffer_);
             buffer_ = 0;

--- a/cpp/src/encoding/zigzag_encoder.h
+++ b/cpp/src/encoding/zigzag_encoder.h
@@ -97,15 +97,15 @@ int ZigzagEncoder<int32_t>::encode(int32_t value) {
     int32_t value_zigzag = (value << 1) ^ (value >> 31);
     if ((value_zigzag & ~0x7F) != 0) {
         write_byte_with_subsequence(value_zigzag);
-        value_zigzag = value_zigzag >> 7;
+        value_zigzag = (uint32_t)value_zigzag >> 7;
         while ((value_zigzag & ~0x7F) != 0) {
             write_byte_with_subsequence(value_zigzag);
-            value_zigzag = value_zigzag >> 7;
+            value_zigzag = (uint32_t)value_zigzag >> 7;
         }
     }
 
     write_byte_without_subsequence(value_zigzag);
-    value_zigzag = value_zigzag >> 7;
+    value_zigzag = (uint32_t)value_zigzag >> 7;
 
     return common::E_OK;
 }
@@ -120,15 +120,15 @@ int ZigzagEncoder<int64_t>::encode(int64_t value) {
     int64_t value_zigzag = (value << 1) ^ (value >> 63);
     if ((value_zigzag & ~0x7F) != 0) {
         write_byte_with_subsequence(value_zigzag);
-        value_zigzag = value_zigzag >> 7;
+        value_zigzag = (uint64_t)value_zigzag >> 7;
         while ((value_zigzag & ~0x7F) != 0) {
             write_byte_with_subsequence(value_zigzag);
-            value_zigzag = value_zigzag >> 7;
+            value_zigzag = (uint64_t)value_zigzag >> 7;
         }
     }
 
     write_byte_without_subsequence(value_zigzag);
-    value_zigzag = value_zigzag >> 7;
+    value_zigzag = (uint64_t)value_zigzag >> 7;
 
     return common::E_OK;
 }

--- a/cpp/src/encoding/zigzag_encoder.h
+++ b/cpp/src/encoding/zigzag_encoder.h
@@ -135,11 +135,9 @@ int ZigzagEncoder<int64_t>::encode(int64_t value) {
 
 template <>
 int ZigzagEncoder<int32_t>::flush(common::ByteStream &out) {
-    buffer_ = (uint8_t)(length_of_encode_bytestream_);
-    flush_byte(out);
-
-    buffer_ = (uint8_t)(length_of_input_bytestream_);
-    flush_byte(out);
+    common::SerializationUtil::write_var_uint(length_of_encode_bytestream_,
+                                              out);
+    common::SerializationUtil::write_var_uint(length_of_input_bytestream_, out);
 
     for (int i = 0; i < length_of_encode_bytestream_; i++) {
         buffer_ = (uint8_t)(list_transit_in_ze_[i]);
@@ -151,11 +149,9 @@ int ZigzagEncoder<int32_t>::flush(common::ByteStream &out) {
 
 template <>
 int ZigzagEncoder<int64_t>::flush(common::ByteStream &out) {
-    buffer_ = (uint8_t)(length_of_encode_bytestream_);
-    flush_byte(out);
-
-    buffer_ = (uint8_t)(length_of_input_bytestream_);
-    flush_byte(out);
+    common::SerializationUtil::write_var_uint(length_of_encode_bytestream_,
+                                              out);
+    common::SerializationUtil::write_var_uint(length_of_input_bytestream_, out);
 
     for (int i = 0; i < length_of_encode_bytestream_; i++) {
         buffer_ = (uint8_t)(list_transit_in_ze_[i]);


### PR DESCRIPTION
The ZigZag encoder is inconsistent with the Java Edition.
In C++ Edition, explicit type casting is required for unsigned right shifts.

Here are unit tests:
```
class ZigzagEncoderTest : public ::testing::Test {};

TEST_F(ZigzagEncoderTest, EncodeInt32) {
    IntZigzagEncoder encoder;
    common::ByteStream stream(1024, common::MOD_ZIGZAG_OBJ);
    int data[] = {1, -1, 12345, -12345, 0, INT32_MAX, INT32_MIN};
    for (auto value : data) {
        EXPECT_EQ(encoder.encode(value), common::E_OK);
    }
    encoder.flush(stream);

    ASSERT_GT(stream.total_size(), 0);

    uint32_t want_len = 21, read_len;
    uint8_t real_buf[21] = {};
    stream.read_buf(real_buf, want_len, read_len);
    EXPECT_EQ(want_len, read_len);
    // Generated using Java Edition
    uint8_t expected_buf[] = {19,  7,   2,   1,   242, 192, 1,   241, 192, 1, 0,
                              254, 255, 255, 255, 15,  255, 255, 255, 255, 15};
    for (int i = 0; i < 21; i++) {
        EXPECT_EQ(real_buf[i], expected_buf[i]);
    }
}

TEST_F(ZigzagEncoderTest, EncodeInt64) {
    LongZigzagEncoder encoder;
    common::ByteStream stream(1024, common::MOD_ZIGZAG_OBJ);
    int64_t data[] = {1, -1, 12345, -12345, 0, INT64_MAX, INT64_MIN};
    for (auto value : data) {
        EXPECT_EQ(encoder.encode(value), common::E_OK);
    }
    encoder.flush(stream);

    ASSERT_GT(stream.total_size(), 0);

    uint32_t want_len = 31, read_len;
    uint8_t real_buf[31] = {};
    stream.read_buf(real_buf, want_len, read_len);
    EXPECT_EQ(want_len, read_len);
    // Generated using Java Edition
    uint8_t expected_buf[] = {29,  7,   2,   1,   242, 192, 1,   241,
                              192, 1,   0,   254, 255, 255, 255, 255,
                              255, 255, 255, 255, 1,   255, 255, 255,
                              255, 255, 255, 255, 255, 255, 1};
    for (int i = 0; i < 31; i++) {
        EXPECT_EQ(real_buf[i], expected_buf[i]);
    }
}

class ZigzagDecoderTest : public ::testing::Test {};

TEST_F(ZigzagDecoderTest, DecodeInt32) {
    IntZigzagEncoder encoder;
    common::ByteStream stream(1024, common::MOD_ZIGZAG_OBJ);
    int32_t data[] = {1, -1, 12345, -12345, 0, INT32_MAX, INT32_MIN};
    for (auto value : data) {
        EXPECT_EQ(encoder.encode(value), common::E_OK);
    }
    encoder.flush(stream);

    IntZigzagDecoder decoder;
    for (int i = 0; i < sizeof(data) / sizeof(int32_t); i++) {
        EXPECT_EQ(data[i], decoder.decode(stream));
    }
}

TEST_F(ZigzagDecoderTest, DecodeInt64) {
    LongZigzagEncoder encoder;
    common::ByteStream stream(1024, common::MOD_ZIGZAG_OBJ);
    int64_t data[] = {1, -1, 12345, -12345, 0, INT64_MAX, INT64_MIN};
    for (auto value : data) {
        EXPECT_EQ(encoder.encode(value), common::E_OK);
    }
    encoder.flush(stream);

    LongZigzagDecoder decoder;
    for (int i = 0; i < sizeof(data) / sizeof(int64_t); i++) {
        EXPECT_EQ(data[i], decoder.decode(stream));
    }
}

TEST_F(ZigzagDecoderTest, DecodeInt32LargeQuantities) {
    IntZigzagEncoder encoder;
    common::ByteStream stream(1024, common::MOD_ZIGZAG_OBJ);
    for (int32_t value = 0; value < 20000; value++) {
        EXPECT_EQ(encoder.encode(value), common::E_OK);
    }
    encoder.flush(stream);

    IntZigzagDecoder decoder;
    for (int32_t value = 0; value < 20000; value++) {
        EXPECT_EQ(value, decoder.decode(stream));
    }
}

TEST_F(ZigzagDecoderTest, DecodeInt64LargeQuantities) {
    LongZigzagEncoder encoder;
    common::ByteStream stream(1024, common::MOD_ZIGZAG_OBJ);
    for (int64_t value = 0; value < 50000; value++) {
        EXPECT_EQ(encoder.encode(value), common::E_OK);
    }
    encoder.flush(stream);

    LongZigzagDecoder decoder;
    for (int64_t value = 0; value < 50000; value++) {
        EXPECT_EQ(value, decoder.decode(stream));
    }
}
```