### PR TITLE
fix/plain_decoder

### DIFF
--- a/cpp/src/encoding/plain_decoder.h
+++ b/cpp/src/encoding/plain_decoder.h
@@ -20,6 +20,8 @@
 #ifndef ENCODING_PLAIN_DECODER_H
 #define ENCODING_PLAIN_DECODER_H
 
+#include "decoder.h"
+
 namespace storage {
 
 class PlainDecoder : public Decoder {


### PR DESCRIPTION
`plain_decoder.h` doesn't include the necessary header files