### PR TITLE
Fix ZstdUncompressor

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/compress/IUnCompressor.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/compress/IUnCompressor.java
@@ -336,8 +336,7 @@ public interface IUnCompressor {
     public int uncompress(byte[] byteArray, int offset, int length, byte[] output, int outOffset)
         throws IOException {
       return (int)
-          Zstd.decompressByteArray(
-              output, outOffset, output.length, byteArray, offset, byteArray.length);
+          Zstd.decompressByteArray(output, outOffset, output.length, byteArray, offset, length);
     }
 
     /**

--- a/java/tsfile/src/test/java/org/apache/tsfile/compress/ZstdTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/compress/ZstdTest.java
@@ -85,4 +85,25 @@ public class ZstdTest {
     byte[] uncompressed = unCompressor.uncompress(compressed);
     Assert.assertArrayEquals(uncom, uncompressed);
   }
+
+  @Test
+  public void testBytes3() throws IOException {
+    ICompressor.ZstdCompressor compressor = new ICompressor.ZstdCompressor();
+    IUnCompressor.ZstdUnCompressor unCompressor = new IUnCompressor.ZstdUnCompressor();
+
+    int n = 500000;
+    int offset = 100;
+    String input = randomString(n);
+    byte[] origin = input.getBytes(StandardCharsets.UTF_8);
+    byte[] compressed = new byte[origin.length * 2];
+    int compressedLength = compressor.compress(origin, 0, origin.length, compressed);
+    System.arraycopy(compressed, 0, compressed, offset, compressedLength);
+    for (int i = 0; i < offset; i++) {
+      compressed[i] = 0;
+    }
+
+    byte[] uncompressed = new byte[origin.length];
+    unCompressor.uncompress(compressed, offset, compressedLength, uncompressed, 0);
+    Assert.assertArrayEquals(origin, uncompressed);
+  }
 }


### PR DESCRIPTION
Zstd#decompressByteArray uses the compressed length as the final parameter rather than the length of inputArray.
I added a UT to verify the fix.