### PR TITLE
fix get_cur_timestamp

### DIFF
--- a/cpp/src/utils/db_utils.h
+++ b/cpp/src/utils/db_utils.h
@@ -349,7 +349,7 @@ FORCE_INLINE int64_t get_cur_timestamp() {
     int64_t timestamp = 0;
     struct timeval tv;
     if (gettimeofday(&tv, NULL) >= 0) {
-        timestamp = tv.tv_sec * 1000 + tv.tv_usec / 1000;
+        timestamp = (int64_t)tv.tv_sec * 1000 + tv.tv_usec / 1000;
     }
     return timestamp;
 }


### PR DESCRIPTION
The issue arose because the tv_sec (long) used to represent the seconds timestamp is stored as a 32-bit value under MinGW. When we calculate the milliseconds timestamp using tv_sec * 1000, an overflow occurs. This overflow problem was detected during unit testing. Coincidentally, the calculation of the seconds timestamp a few days ago did not result in an overflow.