### PR TITLE
CPP.fix multi-flush SEGSEGV.

### DIFF
--- a/cpp/src/writer/tsfile_writer.cc
+++ b/cpp/src/writer/tsfile_writer.cc
@@ -489,6 +489,7 @@ int TsFileWriter::flush_chunk_group(MeasurementSchemaGroup *chunk_group) {
             return ret;
         } else {
             chunk_writer->destroy();
+            chunk_writer = nullptr;
         }
     }
     return ret;


### PR DESCRIPTION
In this pr:
Fix SEGSEGV when flush data again.
If manually calling flush, writers that are not nullptr will lead to access to already freed pointers.