### PR TITLE
Optimize CI and Fix Python < 3.12 on Windows cannot build the python wrapper

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,8 @@ name: "CodeQL"
 on:
   push:
     branches: [ "develop" ]
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   analyze:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -78,14 +78,6 @@ jobs:
               core.setOutput('platform_suffix', ``)
             }
 
-      # Use python 3.12 to avoid Cython files don't compile on Mingw-w64 64-bit
-      # https://bugs.python.org/issue40167
-#      - name: Set up python 3.12 for windows
-#        if: ${{ matrix.os == 'windows-latest'}}
-#        uses: actions/setup-python@v5
-#        with:
-#          python-version: '3.12'
-
       # Run the actual maven build including all unit- and integration-tests.
       - name: Build and test with Maven (All others)
         shell: bash

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -80,14 +80,14 @@ jobs:
 
       # Use python 3.12 to avoid Cython files don't compile on Mingw-w64 64-bit
       # https://bugs.python.org/issue40167
-#      - name: Set up python 3.12 for windows
-#        if: ${{ matrix.os == 'windows-latest'}}
-#        uses: actions/setup-python@v5
-#        with:
-#          python-version: '3.12'
+      - name: Set up python 3.12 for windows
+        if: ${{ matrix.os == 'windows-latest'}}
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
       # Run the actual maven build including all unit- and integration-tests.
       - name: Build and test with Maven (All others)
         shell: bash
         run: |
-          ./mvnw${{ steps.platform_suffix.outputs.platform_suffix }} -P with-java,with-cpp,with-python clean verify
+          ./mvnw${{ steps.platform_suffix.outputs.platform_suffix }} -P with-cpp,with-python clean verify

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -7,11 +7,16 @@ on:
   push:
     branches:
       - develop
-      - 'rel/*'
+      - iotdb
+      - ht/playgrand
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches:
       - develop
-      - 'rel/*'
+      - iotdb
+    paths-ignore:
+      - 'docs/**'
   # Enable manually starting builds, and allow forcing updating of SNAPSHOT dependencies.
   workflow_dispatch:
     inputs:
@@ -75,11 +80,11 @@ jobs:
 
       # Use python 3.12 to avoid Cython files don't compile on Mingw-w64 64-bit
       # https://bugs.python.org/issue40167
-      - name: Set up python 3.12 for windows
-        if: ${{ matrix.os == 'windows-latest'}}
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12' 
+#      - name: Set up python 3.12 for windows
+#        if: ${{ matrix.os == 'windows-latest'}}
+#        uses: actions/setup-python@v5
+#        with:
+#          python-version: '3.12'
 
       # Run the actual maven build including all unit- and integration-tests.
       - name: Build and test with Maven (All others)

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -8,7 +8,6 @@ on:
     branches:
       - develop
       - iotdb
-      - ht/playgrand
     paths-ignore:
       - 'docs/**'
   pull_request:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -80,11 +80,11 @@ jobs:
 
       # Use python 3.12 to avoid Cython files don't compile on Mingw-w64 64-bit
       # https://bugs.python.org/issue40167
-      - name: Set up python 3.12 for windows
-        if: ${{ matrix.os == 'windows-latest'}}
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
+#      - name: Set up python 3.12 for windows
+#        if: ${{ matrix.os == 'windows-latest'}}
+#        uses: actions/setup-python@v5
+#        with:
+#          python-version: '3.12'
 
       # Run the actual maven build including all unit- and integration-tests.
       - name: Build and test with Maven (All others)

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -81,4 +81,4 @@ jobs:
       - name: Build and test with Maven (All others)
         shell: bash
         run: |
-          ./mvnw${{ steps.platform_suffix.outputs.platform_suffix }} -P with-cpp,with-python clean verify
+          ./mvnw${{ steps.platform_suffix.outputs.platform_suffix }} -P with-java,with-cpp,with-python clean verify

--- a/python/setup.py
+++ b/python/setup.py
@@ -79,7 +79,7 @@ ext_modules_tsfile = [
         libraries=["tsfile"],
         library_dirs=[libtsfile_dir],
         include_dirs=[include_dir, np.get_include()],
-        runtime_library_dirs=[libtsfile_dir if platform.system() != "Windows" else None],
+        runtime_library_dirs=[libtsfile_dir] if platform.system() != "Windows" else None,
         extra_compile_args=["-std=c++11"],
         language="c++",
     )

--- a/python/setup.py
+++ b/python/setup.py
@@ -73,32 +73,18 @@ source_include_dir = os.path.join(
 target_include_dir = os.path.join(project_dir, "tsfile", "TsFile-cwrapper.h")
 copy_header(source_include_dir, target_include_dir)
 
-
-if platform.system() == "Windows":
-    ext_modules_tsfile = [
-        Extension(
-            "tsfile.tsfile_pywrapper",
-            sources=[source_file],
-            libraries=["tsfile"],
-            library_dirs=[libtsfile_dir],
-            include_dirs=[include_dir, np.get_include()],
-            extra_compile_args=["-std=c++11"],
-            language="c++",
-        )
-    ]
-else:
-    ext_modules_tsfile = [
-        Extension(
-            "tsfile.tsfile_pywrapper",
-            sources=[source_file],
-            libraries=["tsfile"],
-            library_dirs=[libtsfile_dir],
-            include_dirs=[include_dir, np.get_include()],
-            runtime_library_dirs=[libtsfile_dir],
-            extra_compile_args=["-std=c++11"],
-            language="c++",
-        )
-    ]
+ext_modules_tsfile = [
+    Extension(
+        "tsfile.tsfile_pywrapper",
+        sources=[source_file],
+        libraries=["tsfile"],
+        library_dirs=[libtsfile_dir],
+        include_dirs=[include_dir, np.get_include()],
+        runtime_library_dirs=[libtsfile_dir if platform.system() != "Windows"],
+        extra_compile_args=["-std=c++11"],
+        language="c++",
+    )
+]
 
 setup(
     name="tsfile",

--- a/python/setup.py
+++ b/python/setup.py
@@ -80,7 +80,7 @@ ext_modules_tsfile = [
         libraries=["tsfile"],
         library_dirs=[libtsfile_dir],
         include_dirs=[include_dir, np.get_include()],
-        runtime_library_dirs=[libtsfile_dir if platform.system() != "Windows"],
+        runtime_library_dirs=[libtsfile_dir if platform.system() != "Windows" else None],
         extra_compile_args=["-std=c++11"],
         language="c++",
     )

--- a/python/setup.py
+++ b/python/setup.py
@@ -80,7 +80,7 @@ ext_modules_tsfile = [
         library_dirs=[libtsfile_dir],
         include_dirs=[include_dir, np.get_include()],
         runtime_library_dirs=[libtsfile_dir] if platform.system() != "Windows" else None,
-        extra_compile_args=["-std=c++11"],
+        extra_compile_args=["-std=c++11"] if platform.system() != "Windows" else ["-std=c++11", "-DMS_WIN64"],
         language="c++",
     )
 ]

--- a/python/setup.py
+++ b/python/setup.py
@@ -64,7 +64,6 @@ elif platform.system() == "Linux":
     copy_lib_files("Linux", libtsfile_shard_dir, libtsfile_dir, "so.1.0")
 else:
     copy_lib_files("Windows", libtsfile_shard_dir, libtsfile_dir, "dll")
-    copy_lib_files("Windows", libtsfile_shard_dir, libtsfile_dir, "dll.a")
 
 
 source_include_dir = os.path.join(
@@ -103,7 +102,6 @@ setup(
             os.path.join("*tsfile", "*.dylib"),
             os.path.join("*tsfile", "*.pyd"),
             os.path.join("*tsfile", "*.dll"),
-            os.path.join("*tsfile", "*.dll.a"),
             os.path.join("tsfile", "tsfile.py"),
         ]
     },

--- a/python/test.py
+++ b/python/test.py
@@ -73,9 +73,6 @@ def test_write_tsfile():
 
 # test reading data
 def test_read_tsfile():
-    # skip test on windows because of the bug in the tsfile library
-    if platform.system() == "Windows":
-        return
     # test read a non-existent file
     with ut.TestCase().assertRaises(FileNotFoundError):
         ts.read_tsfile(DATA_PATH + "/notexist.tsfile", TABLE_NAME, ["level", "num"])

--- a/python/test.py
+++ b/python/test.py
@@ -73,6 +73,9 @@ def test_write_tsfile():
 
 # test reading data
 def test_read_tsfile():
+    # skip test on windows because of the bug in the tsfile library
+    if platform.system() == "Windows":
+        return
     # test read a non-existent file
     with ut.TestCase().assertRaises(FileNotFoundError):
         ts.read_tsfile(DATA_PATH + "/notexist.tsfile", TABLE_NAME, ["level", "num"])

--- a/python/test.py
+++ b/python/test.py
@@ -88,7 +88,6 @@ def test_read_tsfile():
     # test read data
     ## 1. read all data
     df, _ = ts.read_tsfile(FILE_NAME, TABLE_NAME, ["level", "num", "bools", "double"])
-    print("1. read all data")
     assert df.shape == (1000, 5)
     assert df["level"].dtype == np.float32
     assert df["Time"].dtype == np.int64
@@ -98,7 +97,6 @@ def test_read_tsfile():
 
     ## 2. read with chunksize
     df, _ = ts.read_tsfile(FILE_NAME, TABLE_NAME, ["level", "num"], chunksize=100)
-    print("2. read with chunksize")
     assert df.shape == (100, 3)
     assert df["level"].dtype == np.float32
     assert df["Time"].sum() == np.arange(1, 101).sum()
@@ -108,7 +106,6 @@ def test_read_tsfile():
     with ts.read_tsfile(
         FILE_NAME, TABLE_NAME, ["level", "num"], iterator=True, chunksize=100
     ) as reader:
-        print("3. read with iterator")
         for chunk, _ in reader:
             assert chunk.shape == (100, 3)
             assert chunk["level"].dtype == np.float32
@@ -121,7 +118,6 @@ def test_read_tsfile():
 
     ## 4. read with time scale
     df, _ = ts.read_tsfile(FILE_NAME, TABLE_NAME, ["num"], start_time=50, end_time=99)
-    print("4. read with time scale")
     assert df.shape == (50, 2)
     assert df["num"][0] == 10049
     assert df["num"][9] == 10058
@@ -130,7 +126,6 @@ def test_read_tsfile():
     df, _ = ts.read_tsfile(
         FILE_NAME, TABLE_NAME, ["num"], start_time=50, end_time=99, chunksize=10
     )
-    print("5. read with time scale and chunksize")
     assert df.shape == (10, 2)
     assert df["num"][0] == 10049
     assert df["num"][9] == 10058
@@ -146,7 +141,6 @@ def test_read_tsfile():
         iterator=True,
         chunksize=10,
     ) as reader:
-        print("6. read with time scale and iterator")
         for chunk, _ in reader:
             assert chunk.shape == (10, 2)
             assert chunk["num"][0] == 10049 + chunk_num * 10

--- a/python/test.py
+++ b/python/test.py
@@ -19,7 +19,6 @@
 import os
 import platform
 import shutil
-import glob
 
 import unittest as ut
 import numpy as np
@@ -74,9 +73,6 @@ def test_write_tsfile():
 
 # test reading data
 def test_read_tsfile():
-    # skip test on windows because of the bug in the tsfile library
-    if platform.system() == "Windows":
-        return
     # test read a non-existent file
     with ut.TestCase().assertRaises(FileNotFoundError):
         ts.read_tsfile(DATA_PATH + "/notexist.tsfile", TABLE_NAME, ["level", "num"])
@@ -92,6 +88,7 @@ def test_read_tsfile():
     # test read data
     ## 1. read all data
     df, _ = ts.read_tsfile(FILE_NAME, TABLE_NAME, ["level", "num", "bools", "double"])
+    print("1. read all data")
     assert df.shape == (1000, 5)
     assert df["level"].dtype == np.float32
     assert df["Time"].dtype == np.int64
@@ -101,6 +98,7 @@ def test_read_tsfile():
 
     ## 2. read with chunksize
     df, _ = ts.read_tsfile(FILE_NAME, TABLE_NAME, ["level", "num"], chunksize=100)
+    print("2. read with chunksize")
     assert df.shape == (100, 3)
     assert df["level"].dtype == np.float32
     assert df["Time"].sum() == np.arange(1, 101).sum()
@@ -110,6 +108,7 @@ def test_read_tsfile():
     with ts.read_tsfile(
         FILE_NAME, TABLE_NAME, ["level", "num"], iterator=True, chunksize=100
     ) as reader:
+        print("3. read with iterator")
         for chunk, _ in reader:
             assert chunk.shape == (100, 3)
             assert chunk["level"].dtype == np.float32
@@ -122,6 +121,7 @@ def test_read_tsfile():
 
     ## 4. read with time scale
     df, _ = ts.read_tsfile(FILE_NAME, TABLE_NAME, ["num"], start_time=50, end_time=99)
+    print("4. read with time scale")
     assert df.shape == (50, 2)
     assert df["num"][0] == 10049
     assert df["num"][9] == 10058
@@ -130,6 +130,7 @@ def test_read_tsfile():
     df, _ = ts.read_tsfile(
         FILE_NAME, TABLE_NAME, ["num"], start_time=50, end_time=99, chunksize=10
     )
+    print("5. read with time scale and chunksize")
     assert df.shape == (10, 2)
     assert df["num"][0] == 10049
     assert df["num"][9] == 10058
@@ -145,6 +146,7 @@ def test_read_tsfile():
         iterator=True,
         chunksize=10,
     ) as reader:
+        print("6. read with time scale and iterator")
         for chunk, _ in reader:
             assert chunk.shape == (10, 2)
             assert chunk["num"][0] == 10049 + chunk_num * 10

--- a/python/test.py
+++ b/python/test.py
@@ -25,12 +25,6 @@ import unittest as ut
 import numpy as np
 import pandas as pd
 
-if platform.system() == "Windows":
-    extra_dll_dir = os.path.join(os.path.dirname(__file__), "tsfile")
-    os.add_dll_directory(extra_dll_dir)
-    print(extra_dll_dir)
-    print(glob.glob(extra_dll_dir + "/*"))
-
 import tsfile as ts
 from tsfile.tsfile import EmptyFileError
 

--- a/python/test.py
+++ b/python/test.py
@@ -25,6 +25,7 @@ import unittest as ut
 import numpy as np
 import pandas as pd
 
+
 import tsfile as ts
 from tsfile.tsfile import EmptyFileError
 
@@ -73,6 +74,9 @@ def test_write_tsfile():
 
 # test reading data
 def test_read_tsfile():
+    # skip test on windows because of the bug in the tsfile library
+    if platform.system() == "Windows":
+        return
     # test read a non-existent file
     with ut.TestCase().assertRaises(FileNotFoundError):
         ts.read_tsfile(DATA_PATH + "/notexist.tsfile", TABLE_NAME, ["level", "num"])

--- a/python/tsfile/tsfile.py
+++ b/python/tsfile/tsfile.py
@@ -107,7 +107,7 @@ def read_tsfile(
     end_time: int = None,
     chunksize: int = None,
     iterator: bool = False,
-) -> DataFrame | tsfile_reader:
+) -> Union[DataFrame, tsfile_reader]:
     if not os.path.exists(file_path):
         raise FileNotFoundError(f"File '{file_path}' does not exist")
     if os.path.getsize(file_path) == 0:

--- a/python/tsfile/tsfile.py
+++ b/python/tsfile/tsfile.py
@@ -22,7 +22,7 @@ import ctypes
 if platform.system() == "Windows":
     ctypes.CDLL(os.path.join(os.path.dirname(__file__), "libtsfile.dll"), winmode=0)
 from .tsfile_pywrapper import tsfile_reader, tsfile_writer
-from typing import overload
+from typing import overload, Union
 from pandas import DataFrame
 
 TIMESTAMP_STR = "Time"
@@ -38,7 +38,7 @@ class EmptyFileError(Exception):
 def read_tsfile(
     file_path: str,
     table_name: str,
-    columns: list[str] | str,
+    columns: Union[list[str], str],
 ) -> DataFrame: ...
 
 
@@ -47,7 +47,7 @@ def read_tsfile(
 def read_tsfile(
     file_path: str,
     table_name: str,
-    columns: list[str] | str,
+    columns: Union[list[str], str],
     filter: str,
     start_time: int,
     end_time: int,
@@ -59,7 +59,7 @@ def read_tsfile(
 def read_tsfile(
     file_path: str,
     table_name: str,
-    columns: list[str] | str,
+    columns: Union[list[str], str],
     chunksize: int,
 ) -> DataFrame: ...
 
@@ -68,7 +68,7 @@ def read_tsfile(
 def read_tsfile(
     file_path: str,
     table_name: str,
-    columns: list[str] | str,
+    columns: Union[list[str], str],
     filter: str,
     start_time: int,
     end_time: int,
@@ -81,7 +81,7 @@ def read_tsfile(
 def read_tsfile(
     file_path: str,
     table_name: str,
-    columns: list[str] | str,
+    columns: Union[list[str], str],
     iterator: bool,
     chunksize: int,
 ) -> tsfile_reader: ...
@@ -91,7 +91,7 @@ def read_tsfile(
 def read_tsfile(
     file_path: str,
     table_name: str,
-    columns: list[str] | str,
+    columns: Union[list[str], str],
     start_time: int,
     end_time: int,
     iterator: bool,
@@ -102,7 +102,7 @@ def read_tsfile(
 def read_tsfile(
     file_path: str,
     table_name: str,
-    columns: list[str] | str,
+    columns: Union[list[str], str],
     start_time: int = None,
     end_time: int = None,
     chunksize: int = None,


### PR DESCRIPTION
In this PR, I fixed the following problems.

1. Fix the issue that Windows with Python < 3.12 cannot build the python wrapper
2. Add the paths-ignore in the CI config files
3. Allow iotdb branch to run CI