### PR TITLE
Bump spotless version to support java 21

### DIFF
--- a/java/common/src/main/java/org/apache/tsfile/utils/Constants.java
+++ b/java/common/src/main/java/org/apache/tsfile/utils/Constants.java
@@ -43,14 +43,19 @@ public final class Constants {
 
   /** The value of <tt>System.getProperty("os.name")</tt>. * */
   public static final String OS_NAME = System.getProperty("os.name");
+
   /** True iff running on Linux. */
   public static final boolean LINUX = OS_NAME.startsWith("Linux");
+
   /** True iff running on Windows. */
   public static final boolean WINDOWS = OS_NAME.startsWith("Windows");
+
   /** True iff running on SunOS. */
   public static final boolean SUN_OS = OS_NAME.startsWith("SunOS");
+
   /** True iff running on Mac OS X */
   public static final boolean MAC_OS_X = OS_NAME.startsWith("Mac OS X");
+
   /** True iff running on FreeBSD */
   public static final boolean FREE_BSD = OS_NAME.startsWith("FreeBSD");
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/common/conf/TSFileConfig.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/conf/TSFileConfig.java
@@ -63,6 +63,7 @@ public class TSFileConfig implements Serializable {
   public static final String MAGIC_STRING = "TsFile";
   public static final String VERSION_NUMBER_V2 = "000002";
   public static final String VERSION_NUMBER_V1 = "000001";
+
   /** version number is changed to use 1 byte to represent since version 3. */
   public static final byte VERSION_NUMBER = 0x03;
 
@@ -73,25 +74,34 @@ public class TSFileConfig implements Serializable {
 
   /** The primitive array capacity threshold. */
   public static final int ARRAY_CAPACITY_THRESHOLD = 1000;
+
   /** Memory size threshold for flushing to disk, default value is 128MB. */
   private int groupSizeInByte = 128 * 1024 * 1024;
+
   /** The memory size for each series writer to pack page, default value is 64KB. */
   private int pageSizeInByte = 64 * 1024;
+
   /** The maximum number of data points in a page, default value is 10000. */
   private int maxNumberOfPointsInPage = 10_000;
+
   /** The maximum degree of a metadataIndex node, default value is 256. */
   private int maxDegreeOfIndexNode = 256;
+
   /** Data type for input timestamp, TsFile supports INT64. */
   private TSDataType timeSeriesDataType = TSDataType.INT64;
+
   /** Max length limitation of input string. */
   private int maxStringLength = 128;
+
   /** Floating-point precision. */
   private int floatPrecision = 2;
+
   /**
    * Encoder of time column, TsFile supports TS_2DIFF, PLAIN and RLE(run-length encoding) Default
    * value is TS_2DIFF.
    */
   private String timeEncoding = "TS_2DIFF";
+
   /**
    * Encoder of value series. default value is PLAIN. For int, long data type, TsFile also supports
    * TS_2DIFF, REGULAR, GORILLA and RLE(run-length encoding). For float, double data type, TsFile
@@ -99,54 +109,77 @@ public class TSFileConfig implements Serializable {
    * supports PLAIN.
    */
   private String valueEncoder = "PLAIN";
+
   /** Default bit width of RLE encoding is 8. */
   private int rleBitWidth = 8;
+
   /** Default block size of two-diff. delta encoding is 128. */
   private int deltaBlockSize = 128;
+
   /** Default frequency type is SINGLE_FREQ. */
   private String freqType = "SINGLE_FREQ";
+
   /** Default PLA max error is 100. */
   private double plaMaxError = 100;
+
   /** Default SDT max error is 100. */
   private double sdtMaxError = 100;
+
   /** Default DFT satisfy rate is 0.1 */
   private double dftSatisfyRate = 0.1;
+
   /** Data compression method, TsFile supports UNCOMPRESSED, SNAPPY, ZSTD or LZ4. */
   private CompressionType compressor = CompressionType.LZ4;
+
   /** Line count threshold for checking page memory occupied size. */
   private int pageCheckSizeThreshold = 100;
+
   /** Default endian value is BIG_ENDIAN. */
   private String endian = "BIG_ENDIAN";
+
   /** Default storage is in local file system. */
   private FSType[] tSFileStorageFs = new FSType[] {FSType.LOCAL};
+
   /** Default core-site.xml file path is /etc/hadoop/conf/core-site.xml */
   private String coreSitePath = "/etc/hadoop/conf/core-site.xml";
+
   /** Default hdfs-site.xml file path is /etc/hadoop/conf/hdfs-site.xml */
   private String hdfsSitePath = "/etc/hadoop/conf/hdfs-site.xml";
+
   /** Default hdfs ip is localhost. */
   private String hdfsIp = "localhost";
+
   /** Default hdfs port is 9000. */
   private String hdfsPort = "9000";
+
   /** Default DFS NameServices is hdfsnamespace. */
   private String dfsNameServices = "hdfsnamespace.";
+
   /** Default DFS HA name nodes are nn1 and nn2. */
   private String dfsHaNamenodes = "nn1,nn2";
+
   /** Default DFS HA automatic failover is enabled. */
   private boolean dfsHaAutomaticFailoverEnabled = true;
+
   /**
    * Default DFS client failover proxy provider is
    * "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
    */
   private String dfsClientFailoverProxyProvider =
       "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider";
+
   /** whether use kerberos to authenticate hdfs. */
   private boolean useKerberos = false;
+
   /** full path of kerberos keytab file. */
   private String kerberosKeytabFilePath = "/path";
+
   /** kerberos pricipal. */
   private String kerberosPrincipal = "principal";
+
   /** The acceptable error rate of bloom filter. */
   private double bloomFilterErrorRate = 0.05;
+
   /** The amount of data iterate each time. */
   private int batchSize = 1000;
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/compress/ICompressor.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/compress/ICompressor.java
@@ -291,7 +291,9 @@ public interface ICompressor extends Serializable {
       return GZIPCompress.compress(dataBefore);
     }
 
-    /** @exception GZIPCompressOverflowException if compressed byte array is too small. */
+    /**
+     * @exception GZIPCompressOverflowException if compressed byte array is too small.
+     */
     @Override
     public int compress(byte[] data, int offset, int length, byte[] compressed) throws IOException {
       byte[] dataBefore = new byte[length];
@@ -304,7 +306,9 @@ public interface ICompressor extends Serializable {
       return res.length;
     }
 
-    /** @exception GZIPCompressOverflowException if compressed ByteBuffer is too small. */
+    /**
+     * @exception GZIPCompressOverflowException if compressed ByteBuffer is too small.
+     */
     @Override
     public int compress(ByteBuffer data, ByteBuffer compressed) throws IOException {
       int length = data.remaining();

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/bitpacking/IntPacker.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/bitpacking/IntPacker.java
@@ -38,6 +38,7 @@ public class IntPacker {
    */
   /** Number of Integers for each pack operation. */
   private static final int NUM_OF_INTS = 8;
+
   /** bit-width. */
   private int width;
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/bitpacking/LongPacker.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/bitpacking/LongPacker.java
@@ -39,6 +39,7 @@ public class LongPacker {
    */
   /** Number of Long values for each pack operation. */
   private static final int NUM_OF_LONGS = 8;
+
   /** bit-width. */
   private int width;
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/DeltaBinaryDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/DeltaBinaryDecoder.java
@@ -43,8 +43,10 @@ public abstract class DeltaBinaryDecoder extends Decoder {
   protected int readIntTotalCount = 0;
 
   protected int nextReadIndex = 0;
+
   /** max bit length of all value in a pack. */
   protected int packWidth;
+
   /** data number in this pack. */
   protected int packNum;
 
@@ -81,6 +83,7 @@ public abstract class DeltaBinaryDecoder extends Decoder {
     private int firstValue;
     private int[] data;
     private int previous;
+
     /** minimum value for all difference. */
     private int minDeltaBase;
 
@@ -165,6 +168,7 @@ public abstract class DeltaBinaryDecoder extends Decoder {
     private long firstValue;
     private long[] data;
     private long previous;
+
     /** minimum value for all difference. */
     private long minDeltaBase;
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/RegularDataDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/RegularDataDecoder.java
@@ -40,6 +40,7 @@ public abstract class RegularDataDecoder extends Decoder {
   protected int readIntTotalCount = 0;
 
   protected int nextReadIndex = 0;
+
   /** data number in this pack. */
   protected int packNum;
 
@@ -66,6 +67,7 @@ public abstract class RegularDataDecoder extends Decoder {
     private boolean isMissingPoint;
     private BitSet bitmap;
     private int bitmapIndex;
+
     /** minimum value for all difference. */
     private int minDeltaBase;
 
@@ -177,6 +179,7 @@ public abstract class RegularDataDecoder extends Decoder {
     private boolean isMissingPoint;
     private BitSet bitmap;
     private int bitmapIndex;
+
     /** minimum value for all difference. */
     private long minDeltaBase;
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/RleDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/RleDecoder.java
@@ -38,23 +38,30 @@ import java.nio.ByteBuffer;
 public abstract class RleDecoder extends Decoder {
 
   protected TSFileConfig config = TSFileDescriptor.getInstance().getConfig();
+
   /** mode to indicate current encoding type 0 - RLE 1 - BIT_PACKED. */
   protected Mode mode;
+
   /** bit width for bit-packing and rle to decode. */
   protected int bitWidth;
+
   /** number of data left for reading in current buffer. */
   protected int currentCount;
+
   /**
    * how many bytes for all encoded data like [{@code <bitwidth> <encoded-data>}] in inputstream.
    */
   protected int length;
+
   /**
    * a flag to indicate whether current pattern is end. false - need to start reading a new page
    * true - current page isn't over.
    */
   protected boolean isLengthAndBitWidthReaded;
+
   /** buffer to save data format like [{@code <bitwidth> <encoded-data>}] for decoder. */
   protected ByteBuffer byteCache;
+
   /** number of bit-packing group in which is saved in header. */
   protected int bitPackingNum;
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/ITimeSeriesMetadata.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/ITimeSeriesMetadata.java
@@ -43,6 +43,8 @@ public interface ITimeSeriesMetadata extends IMetadata {
 
   void setChunkMetadataLoader(IChunkMetadataLoader chunkMetadataLoader);
 
-  /** @return true if data type is matched, otherwise false */
+  /**
+   * @return true if data type is matched, otherwise false
+   */
   boolean typeMatch(List<TSDataType> dataTypes);
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/Statistics.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/Statistics.java
@@ -49,6 +49,7 @@ import java.util.Objects;
 public abstract class Statistics<T extends Serializable> {
 
   private static final Logger LOG = LoggerFactory.getLogger(Statistics.class);
+
   /**
    * isEmpty being false means this statistic has been initialized and the max and min is not null.
    */

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/RowRecord.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/RowRecord.java
@@ -28,6 +28,7 @@ public class RowRecord {
 
   private long timestamp;
   private final List<Field> fields;
+
   /** if any column is null, this field should be set to true; otherwise false */
   private boolean hasNullField = false;
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/TsBlock.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/TsBlock.java
@@ -359,7 +359,9 @@ public class TsBlock {
       return rowIndex < positionCount;
     }
 
-    /** @return A row in the TsBlock. The timestamp is at the last column. */
+    /**
+     * @return A row in the TsBlock. The timestamp is at the last column.
+     */
     @Override
     public Object[] next() {
       if (!hasNext()) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/type/Type.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/type/Type.java
@@ -54,6 +54,7 @@ public interface Type {
   default Binary getBinary(Column c, int position) {
     throw new UnsupportedOperationException(getClass().getName());
   }
+
   /** Gets a Object at {@code position}. */
   default Object getObject(Column c, int position) {
     return c.getObject(position);

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/reader/page/PageReader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/reader/page/PageReader.java
@@ -145,7 +145,9 @@ public class PageReader implements IPageReader {
     }
   }
 
-  /** @return the returned BatchData may be empty, but never be null */
+  /**
+   * @return the returned BatchData may be empty, but never be null
+   */
   @SuppressWarnings("squid:S3776") // Suppress high Cognitive Complexity warning
   @Override
   public BatchData getAllSatisfiedPageData(boolean ascending) throws IOException {

--- a/java/tsfile/src/main/java/org/apache/tsfile/utils/StringContainer.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/utils/StringContainer.java
@@ -32,8 +32,10 @@ public class StringContainer {
   private StringBuilder stringBuilder;
   private ArrayList<String> sequenceList;
   private ArrayList<String> reverseList;
+
   /** the summation length of all string segments. */
   private int totalLength = 0;
+
   /** the count of string segments. */
   private int count = 0;
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/TsFileWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/TsFileWriter.java
@@ -61,8 +61,10 @@ public class TsFileWriter implements AutoCloseable {
 
   protected static final TSFileConfig config = TSFileDescriptor.getInstance().getConfig();
   private static final Logger LOG = LoggerFactory.getLogger(TsFileWriter.class);
+
   /** schema of this TsFile. */
   protected final Schema schema;
+
   /** IO writer of this TsFile. */
   private final TsFileIOWriter fileWriter;
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
@@ -74,6 +74,7 @@ public class ChunkWriterImpl implements IChunkWriter {
 
   /** SDT parameters */
   private boolean isSdtEncoding;
+
   // When the ChunkWriter WILL write the last data point in the chunk, set it to true to tell SDT
   // saves the point.
   private boolean isLastPoint;
@@ -92,7 +93,9 @@ public class ChunkWriterImpl implements IChunkWriter {
 
   private Statistics<?> firstPageStatistics;
 
-  /** @param schema schema of this measurement */
+  /**
+   * @param schema schema of this measurement
+   */
   public ChunkWriterImpl(IMeasurementSchema schema) {
     this.measurementSchema = schema;
     this.compressor = ICompressor.getCompressor(schema.getCompressor());

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/record/TSRecord.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/record/TSRecord.java
@@ -34,8 +34,10 @@ public class TSRecord {
 
   /** timestamp of this TSRecord. */
   public long time;
+
   /** deviceId of this TSRecord. */
   public String deviceId;
+
   /** all value of this TSRecord. */
   public List<DataPoint> dataPointList = new ArrayList<>();
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/record/Tablet.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/record/Tablet.java
@@ -66,12 +66,16 @@ public class Tablet {
 
   /** Timestamps in this {@link Tablet} */
   public long[] timestamps;
+
   /** Each object is a primitive type array, which represents values of one measurement */
   public Object[] values;
+
   /** Each {@link BitMap} represents the existence of each value in the current column. */
   public BitMap[] bitMaps;
+
   /** The number of rows to include in this {@link Tablet} */
   public int rowSize;
+
   /** The maximum number of rows for this {@link Tablet} */
   private final int maxRowNumber;
 
@@ -326,7 +330,9 @@ public class Tablet {
     return rowSize * 8;
   }
 
-  /** @return Total bytes of values */
+  /**
+   * @return Total bytes of values
+   */
   public int getTotalValueOccupation() {
     int valueOccupation = 0;
     int columnIndex = 0;

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/BooleanDataPoint.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/BooleanDataPoint.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 public class BooleanDataPoint extends DataPoint {
 
   private static final Logger LOG = LoggerFactory.getLogger(BooleanDataPoint.class);
+
   /** actual value. */
   private boolean value;
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/DataPoint.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/DataPoint.java
@@ -38,6 +38,7 @@ public abstract class DataPoint {
 
   /** value type of this DataPoint. */
   protected final TSDataType type;
+
   /** measurementId of this DataPoint. */
   protected final String measurementId;
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/DoubleDataPoint.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/DoubleDataPoint.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 public class DoubleDataPoint extends DataPoint {
 
   private static final Logger LOG = LoggerFactory.getLogger(DoubleDataPoint.class);
+
   /** actual value. */
   private double value;
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/FloatDataPoint.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/FloatDataPoint.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 public class FloatDataPoint extends DataPoint {
 
   private static final Logger LOG = LoggerFactory.getLogger(FloatDataPoint.class);
+
   /** actual value. */
   private float value;
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/IntDataPoint.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/IntDataPoint.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 public class IntDataPoint extends DataPoint {
 
   private static final Logger LOG = LoggerFactory.getLogger(IntDataPoint.class);
+
   /** actual value. */
   private int value;
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/LongDataPoint.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/LongDataPoint.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 public class LongDataPoint extends DataPoint {
 
   private static final Logger LOG = LoggerFactory.getLogger(LongDataPoint.class);
+
   /** actual value. */
   private long value;
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/StringDataPoint.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/StringDataPoint.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 public class StringDataPoint extends DataPoint {
 
   private static final Logger LOG = LoggerFactory.getLogger(StringDataPoint.class);
+
   /** actual value. */
   private Binary value;
 

--- a/java/tsfile/src/test/java/org/apache/tsfile/utils/ReadWriteStreamUtilsTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/utils/ReadWriteStreamUtilsTest.java
@@ -115,15 +115,21 @@ public class ReadWriteStreamUtilsTest {
     }
   }
 
-  /** @see {@link #testReadUnsignedVarInt()} */
+  /**
+   * @see {@link #testReadUnsignedVarInt()}
+   */
   @Test
   public void testWriteUnsignedVarInt() {}
 
-  /** @see {@link #testReadIntLittleEndianPaddedOnBitWidth()} */
+  /**
+   * @see {@link #testReadIntLittleEndianPaddedOnBitWidth()}
+   */
   @Test
   public void testWriteIntLittleEndianPaddedOnBitWidth() {}
 
-  /** @see {@link #testReadLongLittleEndianPaddedOnBitWidth()} */
+  /**
+   * @see {@link #testReadLongLittleEndianPaddedOnBitWidth()}
+   */
   @Test
   public void testWriteLongLittleEndianPaddedOnBitWidth() {}
 

--- a/java/tsfile/src/test/java/org/apache/tsfile/write/MetadataIndexConstructorTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/write/MetadataIndexConstructorTest.java
@@ -326,6 +326,7 @@ public class MetadataIndexConstructorTest {
       fail(e.getMessage());
     }
   }
+
   /** DFS in measurement level load actual measurements */
   private void measurementDFS(
       int deviceIndex,

--- a/pom.xml
+++ b/pom.xml
@@ -602,6 +602,13 @@
             <properties>
                 <!-- TODO: This seems to break the build on everything above Java 8 -->
                 <maven.compiler.release>8</maven.compiler.release>
+                <!--
+                    Add argLine for Java 9 and above, due to
+                    [JEP 260: Encapsulate Most Internal APIs],
+                    [JEP 396: Strongly Encapsulate JDK Internals by Default],
+                    [JEP 403: Strongly Encapsulate JDK Internals]
+                -->
+                <argLine>--add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</argLine>
             </properties>
         </profile>
         <!-- Current version of spotless cannot support JDK11 below -->
@@ -615,32 +622,6 @@
                 <spotless.version>2.27.1</spotless.version>
                 <!-- To avoid format conflicts -->
                 <spotless.skip>true</spotless.skip>
-            </properties>
-        </profile>
-        <!--
-            Add argLine for Java 16 and above, due to [JEP 396: Strongly Encapsulate JDK Internals by Default]
-            (https://openjdk.java.net/jeps/396)
-        -->
-        <profile>
-            <id>.java-16</id>
-            <activation>
-                <jdk>16</jdk>
-            </activation>
-            <properties>
-                <argLine>--illegal-access=permit --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</argLine>
-            </properties>
-        </profile>
-        <!--
-            Add argLine for Java 16 and above, due to [JEP 396: Strongly Encapsulate JDK Internals by Default]
-            (https://openjdk.java.net/jeps/396)
-        -->
-        <profile>
-            <id>.java-17-and-above</id>
-            <activation>
-                <jdk>[17,)</jdk>
-            </activation>
-            <properties>
-                <argLine>--add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</argLine>
             </properties>
         </profile>
         <!-- Profile for linux x86_64 (mainly Intel Processors) (Self-Enabling) -->

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,8 @@
         <argLine/>
         <spotless.skip>false</spotless.skip>
         <cmake.version>3.29.3-b2</cmake.version>
+        <spotless.version>2.43.0</spotless.version>
+        <google.java.format.version>1.22.0</google.java.format.version>
     </properties>
     <build>
         <pluginManagement>
@@ -128,7 +130,7 @@
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>
-                    <version>2.27.1</version>
+                    <version>${spotless.version}</version>
                     <configuration>
                         <java>
                             <googleJavaFormat>
@@ -602,18 +604,17 @@
                 <maven.compiler.release>8</maven.compiler.release>
             </properties>
         </profile>
-        <!-- Some APIs were removed in Java 11, so we need to add replacements -->
+        <!-- Current version of spotless cannot support JDK11 below -->
         <profile>
-            <id>.java-11-and-above</id>
+            <id>.java-11-below</id>
             <activation>
-                <jdk>[11,)</jdk>
+                <jdk>(,11]</jdk>
             </activation>
             <properties>
-                <!--
-                    Change to 1.15.0 will modify many codes (all are javadocs), we change it to 1.15.0
-                    until: iotdb decides to do not support jdk8.
-                -->
-                <google.java.format.version>1.7</google.java.format.version>
+                <!-- This was the last version to support Java 8, Just for run -->
+                <spotless.version>2.27.1</spotless.version>
+                <!-- To avoid format conflicts -->
+                <spotless.skip>true</spotless.skip>
             </properties>
         </profile>
         <!--
@@ -640,16 +641,6 @@
             </activation>
             <properties>
                 <argLine>--add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</argLine>
-            </properties>
-        </profile>
-        <!-- Current version of spotless cannot support JDK21 -->
-        <profile>
-            <id>.java-21-and-above</id>
-            <activation>
-                <jdk>[21,)</jdk>
-            </activation>
-            <properties>
-                <spotless.skip>true</spotless.skip>
             </properties>
         </profile>
         <!-- Profile for linux x86_64 (mainly Intel Processors) (Self-Enabling) -->


### PR DESCRIPTION
IoTDB has upgraded spotless to 2.43.0 in order to support java 21. Applying the same change to TsFile.