### PR TITLE
[CPP] Support alternative gtest url

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -74,5 +74,8 @@ configure_file(
   "${PROJECT_BINARY_DIR}/cmake_config.h"
 )
 
+set(TESTS_ENABLED OFF)
 add_subdirectory(test)
-add_dependencies(TsFile_Test tsfile)
+if(TESTS_ENABLED)
+    add_dependencies(TsFile_Test tsfile)
+endif()

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -17,12 +17,45 @@ specific language governing permissions and limitations
 under the License.
 ]]
 include(FetchContent)
-FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/archive/refs/tags/v1.12.0.zip
+
+set(URL_LIST
+    "https://github.com/google/googletest/archive/refs/tags/v1.12.0.zip"
+    "https://hub.nuaa.cf/google/googletest/archive/refs/tags/v1.12.0.zip"
+    "https://hub.yzuu.cf/google/googletest/archive/refs/tags/v1.12.0.zip"
 )
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
+
+set(DOWNLOADED 0)
+set(GTEST_URL "")
+set(TIMEOUT 30)
+
+foreach(URL ${URL_LIST})
+    message(STATUS "Trying to download from ${URL}")
+    file(DOWNLOAD ${URL} "${CMAKE_BINARY_DIR}/googletest-1.12.0.zip" STATUS DOWNLOAD_STATUS TIMEOUT ${TIMEOUT})
+
+    list(GET DOWNLOAD_STATUS 0 DOWNLOAD_RESULT)
+    if(${DOWNLOAD_RESULT} EQUAL 0)
+        set(DOWNLOADED 1)
+        set(GTEST_URL ${URL})
+        break()
+    endif()
+endforeach()
+
+if(${DOWNLOADED})
+    message(STATUS "Successfully downloaded googletest from ${GTEST_URL}")
+    FetchContent_Declare(
+      googletest
+      URL ${GTEST_URL}
+    )
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
+    set(TESTS_ENABLED ON PARENT_SCOPE)
+else()
+    message(WARNING "Failed to download googletest from all provided URLs, setting TESTS_ENABLED to OFF")
+    set(TESTS_ENABLED OFF PARENT_SCOPE)
+    return()
+endif()
+
+message(STATUS "Adding test configurations...")
 
 set(SDK_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/../src)
 message("SDK_INCLUDE_DIR: ${SDK_INCLUDE_DIR}")

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -19,9 +19,9 @@ under the License.
 include(FetchContent)
 
 set(URL_LIST
-    "https://github.com/google/googletest/archive/refs/tags/v1.12.0.zip"
-    "https://hub.nuaa.cf/google/googletest/archive/refs/tags/v1.12.0.zip"
-    "https://hub.yzuu.cf/google/googletest/archive/refs/tags/v1.12.0.zip"
+    "https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip"
+    "https://hub.nuaa.cf/google/googletest/archive/refs/tags/release-1.12.1.zip"
+    "https://hub.yzuu.cf/google/googletest/archive/refs/tags/release-1.12.1.zip"
 )
 
 set(DOWNLOADED 0)
@@ -30,7 +30,7 @@ set(TIMEOUT 30)
 
 foreach(URL ${URL_LIST})
     message(STATUS "Trying to download from ${URL}")
-    file(DOWNLOAD ${URL} "${CMAKE_BINARY_DIR}/googletest-1.12.0.zip" STATUS DOWNLOAD_STATUS TIMEOUT ${TIMEOUT})
+    file(DOWNLOAD ${URL} "${CMAKE_BINARY_DIR}/googletest-release-1.12.1.zip" STATUS DOWNLOAD_STATUS TIMEOUT ${TIMEOUT})
 
     list(GET DOWNLOAD_STATUS 0 DOWNLOAD_RESULT)
     if(${DOWNLOAD_RESULT} EQUAL 0)


### PR DESCRIPTION
1. Support alternative GTEST URL for users in China
2. Unit tests will be skipped if the download fails