### PR TITLE
Add some constructor for chunk capacity

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/utils/PublicBAOS.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/utils/PublicBAOS.java
@@ -71,6 +71,23 @@ public class PublicBAOS extends ByteArrayOutputStream {
     return (minCapacity > MAX_ARRAY_SIZE) ? Integer.MAX_VALUE : MAX_ARRAY_SIZE;
   }
 
+  /**
+   * Reserves the specified capacity for the byte array.
+   * If the current capacity is less than the argument, a new byte array is allocated.
+   * The method does nothing if the specified capacity is less than the current capacity.
+   * @param capacity
+   */
+  public void reserve(int capacity) {
+    if (capacity > buf.length) {
+      if (capacity > MAX_ARRAY_SIZE) {
+        throw new OutOfMemoryError();
+      }
+      byte[] buf = new byte[capacity];
+      System.arraycopy(this.buf, 0, buf, 0, count);
+      this.buf = buf;
+    }
+  }
+
   @Override
   public void write(int b) {
     ensureCapacity(count + 1);

--- a/java/tsfile/src/main/java/org/apache/tsfile/utils/PublicBAOS.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/utils/PublicBAOS.java
@@ -72,9 +72,10 @@ public class PublicBAOS extends ByteArrayOutputStream {
   }
 
   /**
-   * Reserves the specified capacity for the byte array.
-   * If the current capacity is less than the argument, a new byte array is allocated.
-   * The method does nothing if the specified capacity is less than the current capacity.
+   * Reserves the specified capacity for the byte array. If the current capacity is less than the
+   * argument, a new byte array is allocated. The method does nothing if the specified capacity is
+   * less than the current capacity.
+   *
    * @param capacity
    */
   public void reserve(int capacity) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/TsFileWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/TsFileWriter.java
@@ -357,7 +357,6 @@ public class TsFileWriter implements AutoCloseable {
       throws WriteProcessException, IOException {
     IChunkGroupWriter groupWriter =
         tryToInitialGroupWriter(new PlainDeviceID(tablet.deviceId), isAligned);
-
     Path devicePath = new Path(tablet.deviceId);
     List<MeasurementSchema> schemas = tablet.getSchemas();
     if (schema.containsDevice(devicePath)) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkGroupWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkGroupWriterImpl.java
@@ -208,12 +208,6 @@ public class AlignedChunkGroupWriterImpl implements IChunkGroupWriter {
     for (int columnIndex = 0; columnIndex < measurementSchemas.size(); ++columnIndex) {
       ValueChunkWriter valueChunkWriter =
           valueChunkWriterMap.get(measurementSchemas.get(columnIndex).getMeasurementId());
-      valueChunkWriter
-          .getPageWriter()
-          .getPageBuffer()
-          .reserve(
-              (tablet.getTotalValueOccupation() + measurementSchemas.size() - 1)
-                  / measurementSchemas.size());
     }
     for (int row = 0; row < tablet.rowSize; row++) {
       long time = tablet.timestamps[row];

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkGroupWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkGroupWriterImpl.java
@@ -103,7 +103,7 @@ public class AlignedChunkGroupWriterImpl implements IChunkGroupWriter {
     }
   }
 
-  public void tryToAddSeriesWriter(MeasurementSchema measurementSchema, int capacity)
+  public void tryToAddSeriesWriter(MeasurementSchema measurementSchema, int rowCount)
       throws IOException {
     if (!valueChunkWriterMap.containsKey(measurementSchema.getMeasurementId())) {
       ValueChunkWriter valueChunkWriter =
@@ -113,13 +113,13 @@ public class AlignedChunkGroupWriterImpl implements IChunkGroupWriter {
               measurementSchema.getType(),
               measurementSchema.getEncodingType(),
               measurementSchema.getValueEncoder(),
-              capacity);
+              rowCount);
       valueChunkWriterMap.put(measurementSchema.getMeasurementId(), valueChunkWriter);
       tryToAddEmptyPageAndData(valueChunkWriter);
     }
   }
 
-  public void tryToAddSeriesWriter(List<MeasurementSchema> measurementSchemas, int capacity)
+  public void tryToAddSeriesWriter(List<MeasurementSchema> measurementSchemas, int rowCount)
       throws IOException {
     for (MeasurementSchema schema : measurementSchemas) {
       if (!valueChunkWriterMap.containsKey(schema.getMeasurementId())) {
@@ -130,7 +130,7 @@ public class AlignedChunkGroupWriterImpl implements IChunkGroupWriter {
                 schema.getType(),
                 schema.getEncodingType(),
                 schema.getValueEncoder(),
-                capacity);
+                rowCount);
         valueChunkWriterMap.put(schema.getMeasurementId(), valueChunkWriter);
         tryToAddEmptyPageAndData(valueChunkWriter);
       }

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkGroupWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkGroupWriterImpl.java
@@ -103,32 +103,34 @@ public class AlignedChunkGroupWriterImpl implements IChunkGroupWriter {
     }
   }
 
-  public void tryToAddSeriesWriter(MeasurementSchema measurementSchema, int capacity) throws IOException {
+  public void tryToAddSeriesWriter(MeasurementSchema measurementSchema, int capacity)
+      throws IOException {
     if (!valueChunkWriterMap.containsKey(measurementSchema.getMeasurementId())) {
       ValueChunkWriter valueChunkWriter =
-              new ValueChunkWriter(
-                      measurementSchema.getMeasurementId(),
-                      measurementSchema.getCompressor(),
-                      measurementSchema.getType(),
-                      measurementSchema.getEncodingType(),
-                      measurementSchema.getValueEncoder(),
-                      capacity);
+          new ValueChunkWriter(
+              measurementSchema.getMeasurementId(),
+              measurementSchema.getCompressor(),
+              measurementSchema.getType(),
+              measurementSchema.getEncodingType(),
+              measurementSchema.getValueEncoder(),
+              capacity);
       valueChunkWriterMap.put(measurementSchema.getMeasurementId(), valueChunkWriter);
       tryToAddEmptyPageAndData(valueChunkWriter);
     }
   }
 
-  public void tryToAddSeriesWriter(List<MeasurementSchema> measurementSchemas, int capacity) throws IOException {
+  public void tryToAddSeriesWriter(List<MeasurementSchema> measurementSchemas, int capacity)
+      throws IOException {
     for (MeasurementSchema schema : measurementSchemas) {
       if (!valueChunkWriterMap.containsKey(schema.getMeasurementId())) {
         ValueChunkWriter valueChunkWriter =
-                new ValueChunkWriter(
-                        schema.getMeasurementId(),
-                        schema.getCompressor(),
-                        schema.getType(),
-                        schema.getEncodingType(),
-                        schema.getValueEncoder(),
-                        capacity);
+            new ValueChunkWriter(
+                schema.getMeasurementId(),
+                schema.getCompressor(),
+                schema.getType(),
+                schema.getEncodingType(),
+                schema.getValueEncoder(),
+                capacity);
         valueChunkWriterMap.put(schema.getMeasurementId(), valueChunkWriter);
         tryToAddEmptyPageAndData(valueChunkWriter);
       }
@@ -205,9 +207,13 @@ public class AlignedChunkGroupWriterImpl implements IChunkGroupWriter {
 
     for (int columnIndex = 0; columnIndex < measurementSchemas.size(); ++columnIndex) {
       ValueChunkWriter valueChunkWriter =
-              valueChunkWriterMap.get(measurementSchemas.get(columnIndex).getMeasurementId());
-      valueChunkWriter.getPageWriter().getPageBuffer().reserve((tablet.getTotalValueOccupation() + measurementSchemas.size() - 1) / measurementSchemas.size());
-
+          valueChunkWriterMap.get(measurementSchemas.get(columnIndex).getMeasurementId());
+      valueChunkWriter
+          .getPageWriter()
+          .getPageBuffer()
+          .reserve(
+              (tablet.getTotalValueOccupation() + measurementSchemas.size() - 1)
+                  / measurementSchemas.size());
     }
     for (int row = 0; row < tablet.rowSize; row++) {
       long time = tablet.timestamps[row];

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkWriterImpl.java
@@ -80,14 +80,8 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
     this.remainingPointsNumber = timeChunkWriter.getRemainingPointNumberForCurrentPage();
   }
 
-  public AlignedChunkWriterImpl(VectorMeasurementSchema schema, int bufCapacity) {
-    timeChunkWriter =
-            new TimeChunkWriter(
-                    schema.getMeasurementId(),
-                    schema.getCompressor(),
-                    schema.getTimeTSEncoding(),
-                    schema.getTimeEncoder(),
-                    bufCapacity);
+  public AlignedChunkWriterImpl(VectorMeasurementSchema schema, int[] bufCapacities) {
+
 
     List<String> valueMeasurementIdList = schema.getSubMeasurementsList();
     List<TSDataType> valueTSDataTypeList = schema.getSubMeasurementsTSDataTypeList();
@@ -95,6 +89,7 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
     List<Encoder> valueEncoderList = schema.getSubMeasurementsEncoderList();
 
     valueChunkWriterList = new ArrayList<>(valueMeasurementIdList.size());
+    int totcount = 0;
     for (int i = 0; i < valueMeasurementIdList.size(); i++) {
       valueChunkWriterList.add(
               new ValueChunkWriter(
@@ -103,8 +98,16 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
                       valueTSDataTypeList.get(i),
                       valueTSEncodingList.get(i),
                       valueEncoderList.get(i),
-                      bufCapacity));
+                      bufCapacities[i]));
+      totcount += bufCapacities[i];
     }
+    timeChunkWriter =
+            new TimeChunkWriter(
+                    schema.getMeasurementId(),
+                    schema.getCompressor(),
+                    schema.getTimeTSEncoding(),
+                    schema.getTimeEncoder(),
+                    totcount);
 
     this.valueIndex = 0;
     this.remainingPointsNumber = timeChunkWriter.getRemainingPointNumberForCurrentPage();

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkWriterImpl.java
@@ -80,6 +80,36 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
     this.remainingPointsNumber = timeChunkWriter.getRemainingPointNumberForCurrentPage();
   }
 
+  public AlignedChunkWriterImpl(VectorMeasurementSchema schema, int bufCapacity) {
+    timeChunkWriter =
+            new TimeChunkWriter(
+                    schema.getMeasurementId(),
+                    schema.getCompressor(),
+                    schema.getTimeTSEncoding(),
+                    schema.getTimeEncoder(),
+                    bufCapacity);
+
+    List<String> valueMeasurementIdList = schema.getSubMeasurementsList();
+    List<TSDataType> valueTSDataTypeList = schema.getSubMeasurementsTSDataTypeList();
+    List<TSEncoding> valueTSEncodingList = schema.getSubMeasurementsTSEncodingList();
+    List<Encoder> valueEncoderList = schema.getSubMeasurementsEncoderList();
+
+    valueChunkWriterList = new ArrayList<>(valueMeasurementIdList.size());
+    for (int i = 0; i < valueMeasurementIdList.size(); i++) {
+      valueChunkWriterList.add(
+              new ValueChunkWriter(
+                      valueMeasurementIdList.get(i),
+                      schema.getCompressor(),
+                      valueTSDataTypeList.get(i),
+                      valueTSEncodingList.get(i),
+                      valueEncoderList.get(i),
+                      bufCapacity));
+    }
+
+    this.valueIndex = 0;
+    this.remainingPointsNumber = timeChunkWriter.getRemainingPointNumberForCurrentPage();
+  }
+
   /**
    * This is used to rewrite file. The encoding and compression of the time column should be the
    * same as the source file.
@@ -105,6 +135,33 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
               valueSchemaList.get(i).getType(),
               valueSchemaList.get(i).getEncodingType(),
               valueSchemaList.get(i).getValueEncoder()));
+    }
+
+    this.valueIndex = 0;
+    this.remainingPointsNumber = timeChunkWriter.getRemainingPointNumberForCurrentPage();
+  }
+
+  public AlignedChunkWriterImpl(
+          IMeasurementSchema timeSchema, List<IMeasurementSchema> valueSchemaList,
+          int bufCapacity) {
+    timeChunkWriter =
+            new TimeChunkWriter(
+                    timeSchema.getMeasurementId(),
+                    timeSchema.getCompressor(),
+                    timeSchema.getEncodingType(),
+                    timeSchema.getTimeEncoder(),
+                    bufCapacity);
+
+    valueChunkWriterList = new ArrayList<>(valueSchemaList.size());
+    for (int i = 0; i < valueSchemaList.size(); i++) {
+      valueChunkWriterList.add(
+              new ValueChunkWriter(
+                      valueSchemaList.get(i).getMeasurementId(),
+                      valueSchemaList.get(i).getCompressor(),
+                      valueSchemaList.get(i).getType(),
+                      valueSchemaList.get(i).getEncodingType(),
+                      valueSchemaList.get(i).getValueEncoder(),
+                      bufCapacity));
     }
 
     this.valueIndex = 0;
@@ -139,6 +196,36 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
               schemaList.get(i).getType(),
               schemaList.get(i).getEncodingType(),
               schemaList.get(i).getValueEncoder()));
+    }
+
+    this.valueIndex = 0;
+
+    this.remainingPointsNumber = timeChunkWriter.getRemainingPointNumberForCurrentPage();
+  }
+
+  public AlignedChunkWriterImpl(List<IMeasurementSchema> schemaList, int bufCapacity) {
+    TSEncoding timeEncoding =
+            TSEncoding.valueOf(TSFileDescriptor.getInstance().getConfig().getTimeEncoder());
+    TSDataType timeType = TSFileDescriptor.getInstance().getConfig().getTimeSeriesDataType();
+    CompressionType timeCompression = TSFileDescriptor.getInstance().getConfig().getCompressor();
+    timeChunkWriter =
+            new TimeChunkWriter(
+                    "",
+                    timeCompression,
+                    timeEncoding,
+                    TSEncodingBuilder.getEncodingBuilder(timeEncoding).getEncoder(timeType),
+                    bufCapacity);
+
+    valueChunkWriterList = new ArrayList<>(schemaList.size());
+    for (int i = 0; i < schemaList.size(); i++) {
+      valueChunkWriterList.add(
+              new ValueChunkWriter(
+                      schemaList.get(i).getMeasurementId(),
+                      schemaList.get(i).getCompressor(),
+                      schemaList.get(i).getType(),
+                      schemaList.get(i).getEncodingType(),
+                      schemaList.get(i).getValueEncoder(),
+                      bufCapacity));
     }
 
     this.valueIndex = 0;

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkWriterImpl.java
@@ -80,7 +80,7 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
     this.remainingPointsNumber = timeChunkWriter.getRemainingPointNumberForCurrentPage();
   }
 
-  public AlignedChunkWriterImpl(VectorMeasurementSchema schema, int[] bufCapacities) {
+  public AlignedChunkWriterImpl(VectorMeasurementSchema schema, int rowCount) {
 
     List<String> valueMeasurementIdList = schema.getSubMeasurementsList();
     List<TSDataType> valueTSDataTypeList = schema.getSubMeasurementsTSDataTypeList();
@@ -88,7 +88,6 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
     List<Encoder> valueEncoderList = schema.getSubMeasurementsEncoderList();
 
     valueChunkWriterList = new ArrayList<>(valueMeasurementIdList.size());
-    int totcount = 0;
     for (int i = 0; i < valueMeasurementIdList.size(); i++) {
       valueChunkWriterList.add(
           new ValueChunkWriter(
@@ -97,8 +96,7 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
               valueTSDataTypeList.get(i),
               valueTSEncodingList.get(i),
               valueEncoderList.get(i),
-              bufCapacities[i]));
-      totcount += bufCapacities[i];
+              rowCount));
     }
     timeChunkWriter =
         new TimeChunkWriter(
@@ -106,7 +104,7 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
             schema.getCompressor(),
             schema.getTimeTSEncoding(),
             schema.getTimeEncoder(),
-            totcount);
+            rowCount);
 
     this.valueIndex = 0;
     this.remainingPointsNumber = timeChunkWriter.getRemainingPointNumberForCurrentPage();
@@ -144,12 +142,9 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
   }
 
   public AlignedChunkWriterImpl(
-      IMeasurementSchema timeSchema,
-      List<IMeasurementSchema> valueSchemaList,
-      int[] bufCapacities) {
+      IMeasurementSchema timeSchema, List<IMeasurementSchema> valueSchemaList, int rowCount) {
 
     valueChunkWriterList = new ArrayList<>(valueSchemaList.size());
-    int totcount = 0;
     for (int i = 0; i < valueSchemaList.size(); i++) {
       valueChunkWriterList.add(
           new ValueChunkWriter(
@@ -158,8 +153,7 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
               valueSchemaList.get(i).getType(),
               valueSchemaList.get(i).getEncodingType(),
               valueSchemaList.get(i).getValueEncoder(),
-              bufCapacities[i]));
-      totcount += bufCapacities[i];
+              rowCount));
     }
     timeChunkWriter =
         new TimeChunkWriter(
@@ -167,7 +161,7 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
             timeSchema.getCompressor(),
             timeSchema.getEncodingType(),
             timeSchema.getTimeEncoder(),
-            totcount);
+            rowCount);
 
     this.valueIndex = 0;
     this.remainingPointsNumber = timeChunkWriter.getRemainingPointNumberForCurrentPage();
@@ -208,13 +202,12 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
     this.remainingPointsNumber = timeChunkWriter.getRemainingPointNumberForCurrentPage();
   }
 
-  public AlignedChunkWriterImpl(List<IMeasurementSchema> schemaList, int[] bufCapacities) {
+  public AlignedChunkWriterImpl(List<IMeasurementSchema> schemaList, int rowCount) {
     TSEncoding timeEncoding =
         TSEncoding.valueOf(TSFileDescriptor.getInstance().getConfig().getTimeEncoder());
     TSDataType timeType = TSFileDescriptor.getInstance().getConfig().getTimeSeriesDataType();
     CompressionType timeCompression = TSFileDescriptor.getInstance().getConfig().getCompressor();
 
-    int totcount = 0;
     valueChunkWriterList = new ArrayList<>(schemaList.size());
     for (int i = 0; i < schemaList.size(); i++) {
       valueChunkWriterList.add(
@@ -224,8 +217,7 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
               schemaList.get(i).getType(),
               schemaList.get(i).getEncodingType(),
               schemaList.get(i).getValueEncoder(),
-              bufCapacities[i]));
-      totcount += bufCapacities[i];
+              rowCount));
     }
 
     timeChunkWriter =
@@ -234,7 +226,7 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
             timeCompression,
             timeEncoding,
             TSEncodingBuilder.getEncodingBuilder(timeEncoding).getEncoder(timeType),
-            totcount);
+            rowCount);
 
     this.valueIndex = 0;
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkWriterImpl.java
@@ -82,7 +82,6 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
 
   public AlignedChunkWriterImpl(VectorMeasurementSchema schema, int[] bufCapacities) {
 
-
     List<String> valueMeasurementIdList = schema.getSubMeasurementsList();
     List<TSDataType> valueTSDataTypeList = schema.getSubMeasurementsTSDataTypeList();
     List<TSEncoding> valueTSEncodingList = schema.getSubMeasurementsTSEncodingList();
@@ -92,22 +91,22 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
     int totcount = 0;
     for (int i = 0; i < valueMeasurementIdList.size(); i++) {
       valueChunkWriterList.add(
-              new ValueChunkWriter(
-                      valueMeasurementIdList.get(i),
-                      schema.getCompressor(),
-                      valueTSDataTypeList.get(i),
-                      valueTSEncodingList.get(i),
-                      valueEncoderList.get(i),
-                      bufCapacities[i]));
+          new ValueChunkWriter(
+              valueMeasurementIdList.get(i),
+              schema.getCompressor(),
+              valueTSDataTypeList.get(i),
+              valueTSEncodingList.get(i),
+              valueEncoderList.get(i),
+              bufCapacities[i]));
       totcount += bufCapacities[i];
     }
     timeChunkWriter =
-            new TimeChunkWriter(
-                    schema.getMeasurementId(),
-                    schema.getCompressor(),
-                    schema.getTimeTSEncoding(),
-                    schema.getTimeEncoder(),
-                    totcount);
+        new TimeChunkWriter(
+            schema.getMeasurementId(),
+            schema.getCompressor(),
+            schema.getTimeTSEncoding(),
+            schema.getTimeEncoder(),
+            totcount);
 
     this.valueIndex = 0;
     this.remainingPointsNumber = timeChunkWriter.getRemainingPointNumberForCurrentPage();
@@ -145,26 +144,25 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
   }
 
   public AlignedChunkWriterImpl(
-          IMeasurementSchema timeSchema, List<IMeasurementSchema> valueSchemaList,
-          int bufCapacity) {
+      IMeasurementSchema timeSchema, List<IMeasurementSchema> valueSchemaList, int bufCapacity) {
     timeChunkWriter =
-            new TimeChunkWriter(
-                    timeSchema.getMeasurementId(),
-                    timeSchema.getCompressor(),
-                    timeSchema.getEncodingType(),
-                    timeSchema.getTimeEncoder(),
-                    bufCapacity);
+        new TimeChunkWriter(
+            timeSchema.getMeasurementId(),
+            timeSchema.getCompressor(),
+            timeSchema.getEncodingType(),
+            timeSchema.getTimeEncoder(),
+            bufCapacity);
 
     valueChunkWriterList = new ArrayList<>(valueSchemaList.size());
     for (int i = 0; i < valueSchemaList.size(); i++) {
       valueChunkWriterList.add(
-              new ValueChunkWriter(
-                      valueSchemaList.get(i).getMeasurementId(),
-                      valueSchemaList.get(i).getCompressor(),
-                      valueSchemaList.get(i).getType(),
-                      valueSchemaList.get(i).getEncodingType(),
-                      valueSchemaList.get(i).getValueEncoder(),
-                      bufCapacity));
+          new ValueChunkWriter(
+              valueSchemaList.get(i).getMeasurementId(),
+              valueSchemaList.get(i).getCompressor(),
+              valueSchemaList.get(i).getType(),
+              valueSchemaList.get(i).getEncodingType(),
+              valueSchemaList.get(i).getValueEncoder(),
+              bufCapacity));
     }
 
     this.valueIndex = 0;
@@ -208,27 +206,27 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
 
   public AlignedChunkWriterImpl(List<IMeasurementSchema> schemaList, int bufCapacity) {
     TSEncoding timeEncoding =
-            TSEncoding.valueOf(TSFileDescriptor.getInstance().getConfig().getTimeEncoder());
+        TSEncoding.valueOf(TSFileDescriptor.getInstance().getConfig().getTimeEncoder());
     TSDataType timeType = TSFileDescriptor.getInstance().getConfig().getTimeSeriesDataType();
     CompressionType timeCompression = TSFileDescriptor.getInstance().getConfig().getCompressor();
     timeChunkWriter =
-            new TimeChunkWriter(
-                    "",
-                    timeCompression,
-                    timeEncoding,
-                    TSEncodingBuilder.getEncodingBuilder(timeEncoding).getEncoder(timeType),
-                    bufCapacity);
+        new TimeChunkWriter(
+            "",
+            timeCompression,
+            timeEncoding,
+            TSEncodingBuilder.getEncodingBuilder(timeEncoding).getEncoder(timeType),
+            bufCapacity);
 
     valueChunkWriterList = new ArrayList<>(schemaList.size());
     for (int i = 0; i < schemaList.size(); i++) {
       valueChunkWriterList.add(
-              new ValueChunkWriter(
-                      schemaList.get(i).getMeasurementId(),
-                      schemaList.get(i).getCompressor(),
-                      schemaList.get(i).getType(),
-                      schemaList.get(i).getEncodingType(),
-                      schemaList.get(i).getValueEncoder(),
-                      bufCapacity));
+          new ValueChunkWriter(
+              schemaList.get(i).getMeasurementId(),
+              schemaList.get(i).getCompressor(),
+              schemaList.get(i).getType(),
+              schemaList.get(i).getEncodingType(),
+              schemaList.get(i).getValueEncoder(),
+              bufCapacity));
     }
 
     this.valueIndex = 0;

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkWriterImpl.java
@@ -144,8 +144,9 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
   }
 
   public AlignedChunkWriterImpl(
-      IMeasurementSchema timeSchema, List<IMeasurementSchema> valueSchemaList, int[] bufCapacities) {
-
+      IMeasurementSchema timeSchema,
+      List<IMeasurementSchema> valueSchemaList,
+      int[] bufCapacities) {
 
     valueChunkWriterList = new ArrayList<>(valueSchemaList.size());
     int totcount = 0;
@@ -161,12 +162,12 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
       totcount += bufCapacities[i];
     }
     timeChunkWriter =
-            new TimeChunkWriter(
-                    timeSchema.getMeasurementId(),
-                    timeSchema.getCompressor(),
-                    timeSchema.getEncodingType(),
-                    timeSchema.getTimeEncoder(),
-                    totcount);
+        new TimeChunkWriter(
+            timeSchema.getMeasurementId(),
+            timeSchema.getCompressor(),
+            timeSchema.getEncodingType(),
+            timeSchema.getTimeEncoder(),
+            totcount);
 
     this.valueIndex = 0;
     this.remainingPointsNumber = timeChunkWriter.getRemainingPointNumberForCurrentPage();
@@ -228,12 +229,12 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
     }
 
     timeChunkWriter =
-            new TimeChunkWriter(
-                    "",
-                    timeCompression,
-                    timeEncoding,
-                    TSEncodingBuilder.getEncodingBuilder(timeEncoding).getEncoder(timeType),
-                    totcount);
+        new TimeChunkWriter(
+            "",
+            timeCompression,
+            timeEncoding,
+            TSEncodingBuilder.getEncodingBuilder(timeEncoding).getEncoder(timeType),
+            totcount);
 
     this.valueIndex = 0;
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
@@ -151,8 +151,7 @@ public class ChunkWriterImpl implements IChunkWriter {
     this.pageWriter.setTimeEncoder(measurementSchema.getTimeEncoder());
     this.pageWriter.setValueEncoder(measurementSchema.getValueEncoder());
     this.pageBuffer =
-        new PublicBAOS(rowCount * schema.getType().getDataTypeSize() + schema.serializedSize());
-
+        new PublicBAOS(bufferSize);
     // check if the measurement schema uses SDT
     checkSdtEncoding();
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
@@ -150,8 +150,7 @@ public class ChunkWriterImpl implements IChunkWriter {
 
     this.pageWriter.setTimeEncoder(measurementSchema.getTimeEncoder());
     this.pageWriter.setValueEncoder(measurementSchema.getValueEncoder());
-    this.pageBuffer =
-        new PublicBAOS(bufferSize);
+    this.pageBuffer = new PublicBAOS(bufferSize);
     // check if the measurement schema uses SDT
     checkSdtEncoding();
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
@@ -131,7 +131,7 @@ public class ChunkWriterImpl implements IChunkWriter {
 
     this.pageSizeThreshold = TSFileDescriptor.getInstance().getConfig().getPageSizeInByte();
     this.maxNumberOfPointsInPage =
-            TSFileDescriptor.getInstance().getConfig().getMaxNumberOfPointsInPage();
+        TSFileDescriptor.getInstance().getConfig().getMaxNumberOfPointsInPage();
     // initial check of memory usage. So that we have enough data to make an initial prediction
     this.valueCountInOnePageForNextCheck = MINIMUM_RECORD_COUNT_FOR_CHECK;
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
@@ -136,10 +136,13 @@ public class ChunkWriterImpl implements IChunkWriter {
 
     // init statistics for this chunk and page
     this.statistics = Statistics.getStatsByType(measurementSchema.getType());
+    int bufferSize = rowCount * schema.getType().getDataTypeSize();
+    bufferSize = (bufferSize + 31) >> 5;
     int pageSize =
-        Math.min(
-            Math.min(rowCount * schema.getType().getDataTypeSize(), (int) pageSizeThreshold),
-            MINIMUM_RECORD_COUNT_FOR_CHECK * schema.getType().getDataTypeSize());
+        Math.min(bufferSize, Math.min((int) pageSizeThreshold,
+            MINIMUM_RECORD_COUNT_FOR_CHECK * schema.getType().getDataTypeSize()));
+    // let the page size be multiple of 32
+    pageSize = (pageSize + 31) >> 5;
     this.pageWriter = new PageWriter(measurementSchema, pageSize);
 
     this.pageWriter.setTimeEncoder(measurementSchema.getTimeEncoder());

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
@@ -139,8 +139,11 @@ public class ChunkWriterImpl implements IChunkWriter {
     int bufferSize = rowCount * schema.getType().getDataTypeSize();
     bufferSize = (bufferSize + 31) >> 5;
     int pageSize =
-        Math.min(bufferSize, Math.min((int) pageSizeThreshold,
-            MINIMUM_RECORD_COUNT_FOR_CHECK * schema.getType().getDataTypeSize()));
+        Math.min(
+            bufferSize,
+            Math.min(
+                (int) pageSizeThreshold,
+                MINIMUM_RECORD_COUNT_FOR_CHECK * schema.getType().getDataTypeSize()));
     // let the page size be multiple of 32
     pageSize = (pageSize + 31) >> 5;
     this.pageWriter = new PageWriter(measurementSchema, pageSize);

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
@@ -296,10 +296,6 @@ public class ChunkWriterImpl implements IChunkWriter {
   private void checkPageSizeAndMayOpenANewPage() {
     if (pageWriter.getPointNumber() == maxNumberOfPointsInPage) {
       logger.debug("current line count reaches the upper bound, write page {}", measurementSchema);
-      logger.warn(
-          "current line count reaches the upper bound {}, write page {}",
-          maxNumberOfPointsInPage,
-          measurementSchema);
       writePageToPageBuffer();
     } else if (pageWriter.getPointNumber()
         >= valueCountInOnePageForNextCheck) { // need to check memory size
@@ -307,12 +303,7 @@ public class ChunkWriterImpl implements IChunkWriter {
       long currentPageSize = pageWriter.estimateMaxMemSize();
       if (currentPageSize > pageSizeThreshold) { // memory size exceeds threshold
         // we will write the current page
-        logger.warn(
-            "enough size, write page {}, pageSizeThreshold:{}, currentPateSize:{}, valueCountInOnePage:{}",
-            measurementSchema.getMeasurementId(),
-            pageSizeThreshold,
-            currentPageSize,
-            pageWriter.getPointNumber());
+
         logger.debug(
             "enough size, write page {}, pageSizeThreshold:{}, currentPateSize:{}, valueCountInOnePage:{}",
             measurementSchema.getMeasurementId(),

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
@@ -144,12 +144,6 @@ public class ChunkWriterImpl implements IChunkWriter {
 
     this.pageWriter.setTimeEncoder(measurementSchema.getTimeEncoder());
     this.pageWriter.setValueEncoder(measurementSchema.getValueEncoder());
-    // logger.warn(
-    //     "rowCount: {}; schemaSerilizedSize: {}; bufferSize: {}; estimateSerilizedSize(): {}",
-    //     rowCount,
-    //     schema.serializedSize(),
-    //     rowCount * schema.getType().getDataTypeSize() + schema.serializedSize(),
-    //     estimateMaxSeriesMemSize());
     this.pageBuffer =
         new PublicBAOS(rowCount * schema.getType().getDataTypeSize() + schema.serializedSize());
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
@@ -124,10 +124,9 @@ public class ChunkWriterImpl implements IChunkWriter {
     this.isMerging = isMerging;
   }
 
-  public ChunkWriterImpl(IMeasurementSchema schema, int bufCapacity) {
+  public ChunkWriterImpl(IMeasurementSchema schema, int rowCount) {
     this.measurementSchema = schema;
     this.compressor = ICompressor.getCompressor(schema.getCompressor());
-    this.pageBuffer = new PublicBAOS(bufCapacity);
 
     this.pageSizeThreshold = TSFileDescriptor.getInstance().getConfig().getPageSizeInByte();
     this.maxNumberOfPointsInPage =
@@ -142,13 +141,21 @@ public class ChunkWriterImpl implements IChunkWriter {
 
     this.pageWriter.setTimeEncoder(measurementSchema.getTimeEncoder());
     this.pageWriter.setValueEncoder(measurementSchema.getValueEncoder());
+    logger.warn(
+        "rowCount: {}; schemaSerilizedSize: {}; bufferSize: {}; estimateSerilizedSize(): {}",
+        rowCount,
+        schema.serializedSize(),
+        rowCount * schema.getType().getDataTypeSize() + schema.serializedSize(),
+        estimateMaxSeriesMemSize());
+    this.pageBuffer =
+        new PublicBAOS(rowCount * schema.getType().getDataTypeSize() + schema.serializedSize());
 
     // check if the measurement schema uses SDT
     checkSdtEncoding();
   }
 
-  public ChunkWriterImpl(IMeasurementSchema schema, boolean isMerging, int bufCapacity) {
-    this(schema, bufCapacity);
+  public ChunkWriterImpl(IMeasurementSchema schema, boolean isMerging, int rowCount) {
+    this(schema, rowCount);
     this.isMerging = isMerging;
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/NonAlignedChunkGroupWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/NonAlignedChunkGroupWriterImpl.java
@@ -66,9 +66,9 @@ public class NonAlignedChunkGroupWriterImpl implements IChunkGroupWriter {
     }
   }
 
-  public void tryToAddSeriesWriter(MeasurementSchema schema, int bufCapacity) {
+  public void tryToAddSeriesWriter(MeasurementSchema schema, int rowCount) {
     if (!chunkWriters.containsKey(schema.getMeasurementId())) {
-      this.chunkWriters.put(schema.getMeasurementId(), new ChunkWriterImpl(schema, bufCapacity));
+      this.chunkWriters.put(schema.getMeasurementId(), new ChunkWriterImpl(schema, rowCount));
     }
   }
 
@@ -81,10 +81,10 @@ public class NonAlignedChunkGroupWriterImpl implements IChunkGroupWriter {
     }
   }
 
-  public void tryToAddSeriesWriter(List<MeasurementSchema> schemas, int bufCapacity) {
+  public void tryToAddSeriesWriter(List<MeasurementSchema> schemas, int rowCount) {
     for (IMeasurementSchema schema : schemas) {
       if (!chunkWriters.containsKey(schema.getMeasurementId())) {
-        this.chunkWriters.put(schema.getMeasurementId(), new ChunkWriterImpl(schema, bufCapacity));
+        this.chunkWriters.put(schema.getMeasurementId(), new ChunkWriterImpl(schema, rowCount));
       }
     }
   }
@@ -113,8 +113,6 @@ public class NonAlignedChunkGroupWriterImpl implements IChunkGroupWriter {
       String measurementId = timeseries.get(column).getMeasurementId();
       TSDataType tsDataType = timeseries.get(column).getType();
       pointCount = 0;
-      int capacity = (tablet.getTotalValueOccupation() + timeseries.size() - 1) / timeseries.size();
-      chunkWriters.get(measurementId).getPageWriter().getPageBuffer().reserve(capacity);
       for (int row = 0; row < tablet.rowSize; row++) {
         // check isNull in tablet
         if (tablet.bitMaps != null

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/TimeChunkWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/TimeChunkWriter.java
@@ -133,7 +133,8 @@ public class TimeChunkWriter {
             MINIMUM_RECORD_COUNT_FOR_CHECK * TSDataType.TIMESTAMP.getDataTypeSize(),
             Math.min(bufferCount, (int) pageSizeThreshold));
     this.pageWriter =
-        new TimePageWriter(timeEncoder, ICompressor.getCompressor(compressionType), (pageSize + 31) >> 5);
+        new TimePageWriter(
+            timeEncoder, ICompressor.getCompressor(compressionType), (pageSize + 31) >> 5);
   }
 
   public void write(long time) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/TimeChunkWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/TimeChunkWriter.java
@@ -133,10 +133,7 @@ public class TimeChunkWriter {
             Math.min(bufferCount, (int) pageSizeThreshold));
     this.pageWriter =
         new TimePageWriter(timeEncoder, ICompressor.getCompressor(compressionType), pageSize);
-    // logger.warn(
-    //     "TimeChunkWriter: bufferCount = {}, pageBufferSize = {}",
-    //     bufferCount + (int) estimateMaxSeriesMemSize(),
-    //     pageSize + (int) pageWriter.estimateMaxMemSize());
+
   }
 
   public void write(long time) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/TimeChunkWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/TimeChunkWriter.java
@@ -123,19 +123,20 @@ public class TimeChunkWriter {
     // init statistics for this chunk and page
     this.statistics = new TimeStatistics();
 
-    this.pageWriter = new TimePageWriter(timeEncoder, ICompressor.getCompressor(compressionType));
     int bufferCount =
-        rowCount * TSDataType.TIMESTAMP.getDataTypeSize() + (int) estimateMaxSeriesMemSize();
+        rowCount * TSDataType.TIMESTAMP.getDataTypeSize()
+            + PageHeader.estimateMaxPageHeaderSizeWithoutStatistics();
     this.pageBuffer = new PublicBAOS(bufferCount);
-    int pageBufferSize =
+    int pageSize =
         Math.min(
             MINIMUM_RECORD_COUNT_FOR_CHECK * TSDataType.TIMESTAMP.getDataTypeSize(),
             Math.min(bufferCount, (int) pageSizeThreshold));
-    pageWriter.getPageBuffer().reserve(pageBufferSize + (int) pageWriter.estimateMaxMemSize());
-    logger.warn(
-        "TimeChunkWriter: bufferCount = {}, pageBufferSize = {}",
-        bufferCount + (int) estimateMaxSeriesMemSize(),
-        pageBufferSize + (int) pageWriter.estimateMaxMemSize());
+    this.pageWriter =
+        new TimePageWriter(timeEncoder, ICompressor.getCompressor(compressionType), pageSize);
+    // logger.warn(
+    //     "TimeChunkWriter: bufferCount = {}, pageBufferSize = {}",
+    //     bufferCount + (int) estimateMaxSeriesMemSize(),
+    //     pageSize + (int) pageWriter.estimateMaxMemSize());
   }
 
   public void write(long time) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/TimeChunkWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/TimeChunkWriter.java
@@ -105,11 +105,11 @@ public class TimeChunkWriter {
   }
 
   public TimeChunkWriter(
-          String measurementId,
-          CompressionType compressionType,
-          TSEncoding encodingType,
-          Encoder timeEncoder,
-          int bufCapacity) {
+      String measurementId,
+      CompressionType compressionType,
+      TSEncoding encodingType,
+      Encoder timeEncoder,
+      int bufCapacity) {
     this.measurementId = measurementId;
     this.encodingType = encodingType;
     this.compressionType = compressionType;
@@ -117,7 +117,7 @@ public class TimeChunkWriter {
 
     this.pageSizeThreshold = TSFileDescriptor.getInstance().getConfig().getPageSizeInByte();
     this.maxNumberOfPointsInPage =
-            TSFileDescriptor.getInstance().getConfig().getMaxNumberOfPointsInPage();
+        TSFileDescriptor.getInstance().getConfig().getMaxNumberOfPointsInPage();
     // initial check of memory usage. So that we have enough data to make an initial prediction
     this.valueCountInOnePageForNextCheck = MINIMUM_RECORD_COUNT_FOR_CHECK;
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/TimeChunkWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/TimeChunkWriter.java
@@ -104,6 +104,29 @@ public class TimeChunkWriter {
     this.pageWriter = new TimePageWriter(timeEncoder, ICompressor.getCompressor(compressionType));
   }
 
+  public TimeChunkWriter(
+          String measurementId,
+          CompressionType compressionType,
+          TSEncoding encodingType,
+          Encoder timeEncoder,
+          int bufCapacity) {
+    this.measurementId = measurementId;
+    this.encodingType = encodingType;
+    this.compressionType = compressionType;
+    this.pageBuffer = new PublicBAOS(bufCapacity);
+
+    this.pageSizeThreshold = TSFileDescriptor.getInstance().getConfig().getPageSizeInByte();
+    this.maxNumberOfPointsInPage =
+            TSFileDescriptor.getInstance().getConfig().getMaxNumberOfPointsInPage();
+    // initial check of memory usage. So that we have enough data to make an initial prediction
+    this.valueCountInOnePageForNextCheck = MINIMUM_RECORD_COUNT_FOR_CHECK;
+
+    // init statistics for this chunk and page
+    this.statistics = new TimeStatistics();
+
+    this.pageWriter = new TimePageWriter(timeEncoder, ICompressor.getCompressor(compressionType));
+  }
+
   public void write(long time) {
     pageWriter.write(time);
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/TimeChunkWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/TimeChunkWriter.java
@@ -126,14 +126,14 @@ public class TimeChunkWriter {
     int bufferCount =
         rowCount * TSDataType.TIMESTAMP.getDataTypeSize()
             + PageHeader.estimateMaxPageHeaderSizeWithoutStatistics();
+    bufferCount = (bufferCount + 31) >> 5;
     this.pageBuffer = new PublicBAOS(bufferCount);
     int pageSize =
         Math.min(
             MINIMUM_RECORD_COUNT_FOR_CHECK * TSDataType.TIMESTAMP.getDataTypeSize(),
             Math.min(bufferCount, (int) pageSizeThreshold));
     this.pageWriter =
-        new TimePageWriter(timeEncoder, ICompressor.getCompressor(compressionType), pageSize);
-
+        new TimePageWriter(timeEncoder, ICompressor.getCompressor(compressionType), (pageSize + 31) >> 5);
   }
 
   public void write(long time) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ValueChunkWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ValueChunkWriter.java
@@ -339,19 +339,12 @@ public class ValueChunkWriter {
   public boolean checkPageSizeAndMayOpenANewPage() {
     if (pageWriter.getPointNumber() == maxNumberOfPointsInPage) {
       logger.debug("current line count reaches the upper bound, write page {}", measurementId);
-      logger.warn("currentPage is reach maxNumberOfPointsInPage: {}", maxNumberOfPointsInPage);
       return true;
     } else if (pageWriter.getPointNumber()
         >= valueCountInOnePageForNextCheck) { // need to check memory size
       // not checking the memory used for every value
       long currentPageSize = pageWriter.estimateMaxMemSize();
       if (currentPageSize > pageSizeThreshold) { // memory size exceeds threshold
-        logger.warn(
-            "enough size, write page {}, pageSizeThreshold:{}, currentPageSize:{}, valueCountInOnePage:{}",
-            measurementId,
-            pageSizeThreshold,
-            currentPageSize,
-            pageWriter.getPointNumber());
         // we will write the current page
         logger.debug(
             "enough size, write page {}, pageSizeThreshold:{}, currentPageSize:{}, valueCountInOnePage:{}",

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ValueChunkWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ValueChunkWriter.java
@@ -107,12 +107,12 @@ public class ValueChunkWriter {
   }
 
   public ValueChunkWriter(
-          String measurementId,
-          CompressionType compressionType,
-          TSDataType dataType,
-          TSEncoding encodingType,
-          Encoder valueEncoder,
-          int bufCapacity) {
+      String measurementId,
+      CompressionType compressionType,
+      TSDataType dataType,
+      TSEncoding encodingType,
+      Encoder valueEncoder,
+      int bufCapacity) {
     this.measurementId = measurementId;
     this.encodingType = encodingType;
     this.dataType = dataType;
@@ -120,14 +120,14 @@ public class ValueChunkWriter {
     this.pageBuffer = new PublicBAOS(bufCapacity);
     this.pageSizeThreshold = TSFileDescriptor.getInstance().getConfig().getPageSizeInByte();
     this.maxNumberOfPointsInPage =
-            TSFileDescriptor.getInstance().getConfig().getMaxNumberOfPointsInPage();
+        TSFileDescriptor.getInstance().getConfig().getMaxNumberOfPointsInPage();
     this.valueCountInOnePageForNextCheck = MINIMUM_RECORD_COUNT_FOR_CHECK;
 
     // init statistics for this chunk and page
     this.statistics = Statistics.getStatsByType(dataType);
 
     this.pageWriter =
-            new ValuePageWriter(valueEncoder, ICompressor.getCompressor(compressionType), dataType);
+        new ValuePageWriter(valueEncoder, ICompressor.getCompressor(compressionType), dataType);
   }
 
   public void write(long time, long value, boolean isNull) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ValueChunkWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ValueChunkWriter.java
@@ -106,6 +106,30 @@ public class ValueChunkWriter {
         new ValuePageWriter(valueEncoder, ICompressor.getCompressor(compressionType), dataType);
   }
 
+  public ValueChunkWriter(
+          String measurementId,
+          CompressionType compressionType,
+          TSDataType dataType,
+          TSEncoding encodingType,
+          Encoder valueEncoder,
+          int bufCapacity) {
+    this.measurementId = measurementId;
+    this.encodingType = encodingType;
+    this.dataType = dataType;
+    this.compressionType = compressionType;
+    this.pageBuffer = new PublicBAOS(bufCapacity);
+    this.pageSizeThreshold = TSFileDescriptor.getInstance().getConfig().getPageSizeInByte();
+    this.maxNumberOfPointsInPage =
+            TSFileDescriptor.getInstance().getConfig().getMaxNumberOfPointsInPage();
+    this.valueCountInOnePageForNextCheck = MINIMUM_RECORD_COUNT_FOR_CHECK;
+
+    // init statistics for this chunk and page
+    this.statistics = Statistics.getStatsByType(dataType);
+
+    this.pageWriter =
+            new ValuePageWriter(valueEncoder, ICompressor.getCompressor(compressionType), dataType);
+  }
+
   public void write(long time, long value, boolean isNull) {
     pageWriter.write(time, value, isNull);
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ValueChunkWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ValueChunkWriter.java
@@ -137,8 +137,7 @@ public class ValueChunkWriter {
     this.pageWriter =
         new ValuePageWriter(
             valueEncoder, ICompressor.getCompressor(compressionType), dataType, pageCapacity);
-    // logger.warn("ValueChunkWriter: bufferCount = {}, pageCapacity = {}", bufferCount,
-    // pageCapacity);
+
   }
 
   public void write(long time, long value, boolean isNull) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ValueChunkWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ValueChunkWriter.java
@@ -128,16 +128,16 @@ public class ValueChunkWriter {
     int bufferCount =
         rowCount * dataType.getDataTypeSize()
             + PageHeader.estimateMaxPageHeaderSizeWithoutStatistics();
-    this.pageBuffer = new PublicBAOS(bufferCount);
+    this.pageBuffer = new PublicBAOS((bufferCount + 31) >> 5);
     int pageCapacity =
         Math.min(
             Math.min((int) pageSizeThreshold, bufferCount),
             MINIMUM_RECORD_COUNT_FOR_CHECK * rowCount
                 + PageHeader.estimateMaxPageHeaderSizeWithoutStatistics());
+    pageCapacity = (pageCapacity + 31) >> 5;
     this.pageWriter =
         new ValuePageWriter(
             valueEncoder, ICompressor.getCompressor(compressionType), dataType, pageCapacity);
-
   }
 
   public void write(long time, long value, boolean isNull) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/page/PageWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/page/PageWriter.java
@@ -300,7 +300,11 @@ public class PageWriter {
     return statistics;
   }
 
+  public PublicBAOS getPageBuffer() {
+    return valueOut;
+  }
 
-  public PublicBAOS getPageBuffer() { return valueOut;}
-  public PublicBAOS getTimeOut() { return timeOut; }
+  public PublicBAOS getTimeOut() {
+    return timeOut;
+  }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/page/PageWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/page/PageWriter.java
@@ -76,6 +76,19 @@ public class PageWriter {
     this.compressor = ICompressor.getCompressor(measurementSchema.getCompressor());
   }
 
+  public PageWriter(IMeasurementSchema measurementSchema, int pageSize) {
+    this(measurementSchema.getTimeEncoder(), measurementSchema.getValueEncoder(), pageSize);
+    this.statistics = Statistics.getStatsByType(measurementSchema.getType());
+    this.compressor = ICompressor.getCompressor(measurementSchema.getCompressor());
+  }
+
+  private PageWriter(Encoder timeEncoder, Encoder valueEncoder, int pageSize) {
+    this.timeOut = new PublicBAOS(pageSize);
+    this.valueOut = new PublicBAOS(pageSize);
+    this.timeEncoder = timeEncoder;
+    this.valueEncoder = valueEncoder;
+  }
+
   private PageWriter(Encoder timeEncoder, Encoder valueEncoder) {
     this.timeOut = new PublicBAOS();
     this.valueOut = new PublicBAOS();

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/page/PageWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/page/PageWriter.java
@@ -64,6 +64,12 @@ public class PageWriter {
     this(null, null);
   }
 
+  public PageWriter(int capacity) {
+    this(null, null);
+    this.timeOut = new PublicBAOS(capacity);
+    this.valueOut = new PublicBAOS(capacity);
+  }
+
   public PageWriter(IMeasurementSchema measurementSchema) {
     this(measurementSchema.getTimeEncoder(), measurementSchema.getValueEncoder());
     this.statistics = Statistics.getStatsByType(measurementSchema.getType());
@@ -293,4 +299,8 @@ public class PageWriter {
   public Statistics<? extends Serializable> getStatistics() {
     return statistics;
   }
+
+
+  public PublicBAOS getPageBuffer() { return valueOut;}
+  public PublicBAOS getTimeOut() { return timeOut; }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/page/TimePageWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/page/TimePageWriter.java
@@ -180,4 +180,7 @@ public class TimePageWriter {
   public TimeStatistics getStatistics() {
     return statistics;
   }
+
+  public PublicBAOS getPageBuffer() { return timeOut;}
+
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/page/TimePageWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/page/TimePageWriter.java
@@ -181,6 +181,7 @@ public class TimePageWriter {
     return statistics;
   }
 
-  public PublicBAOS getPageBuffer() { return timeOut;}
-
+  public PublicBAOS getPageBuffer() {
+    return timeOut;
+  }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/page/TimePageWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/page/TimePageWriter.java
@@ -60,6 +60,13 @@ public class TimePageWriter {
     this.compressor = compressor;
   }
 
+  public TimePageWriter(Encoder timeEncoder, ICompressor compressor, int pageSize) {
+    this.timeOut = new PublicBAOS(pageSize);
+    this.timeEncoder = timeEncoder;
+    this.statistics = new TimeStatistics();
+    this.compressor = compressor;
+  }
+
   /** write a time into encoder */
   public void write(long time) {
     timeEncoder.encode(time, timeOut);

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/page/ValuePageWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/page/ValuePageWriter.java
@@ -73,6 +73,17 @@ public class ValuePageWriter {
     this.compressor = compressor;
   }
 
+  public ValuePageWriter(
+      Encoder valueEncoder, ICompressor compressor, TSDataType dataType, int pageSize) {
+    this.valueOut = new PublicBAOS(pageSize);
+    this.bitmap = 0;
+    this.size = 0;
+    this.bitmapOut = new PublicBAOS(pageSize);
+    this.valueEncoder = valueEncoder;
+    this.statistics = Statistics.getStatsByType(dataType);
+    this.compressor = compressor;
+  }
+
   /** write a time value pair into encoder */
   public void write(long time, boolean value, boolean isNull) {
     setBit(isNull);

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/page/ValuePageWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/page/ValuePageWriter.java
@@ -341,5 +341,7 @@ public class ValuePageWriter {
     return size;
   }
 
-  public PublicBAOS getPageBuffer() { return valueOut;}
+  public PublicBAOS getPageBuffer() {
+    return valueOut;
+  }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/page/ValuePageWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/page/ValuePageWriter.java
@@ -78,7 +78,7 @@ public class ValuePageWriter {
     this.valueOut = new PublicBAOS(pageSize);
     this.bitmap = 0;
     this.size = 0;
-    this.bitmapOut = new PublicBAOS(pageSize);
+    this.bitmapOut = new PublicBAOS((pageSize + 7) >> 3);
     this.valueEncoder = valueEncoder;
     this.statistics = Statistics.getStatsByType(dataType);
     this.compressor = compressor;

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/page/ValuePageWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/page/ValuePageWriter.java
@@ -340,4 +340,6 @@ public class ValuePageWriter {
   public int getSize() {
     return size;
   }
+
+  public PublicBAOS getPageBuffer() { return valueOut;}
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/writer/LocalTsFileOutput.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/writer/LocalTsFileOutput.java
@@ -36,7 +36,7 @@ public class LocalTsFileOutput extends OutputStream implements TsFileOutput {
 
   public LocalTsFileOutput(FileOutputStream outputStream) {
     this.outputStream = outputStream;
-    this.bufferedStream = new BufferedOutputStream(outputStream);
+    this.bufferedStream = new BufferedOutputStream(outputStream, DEFAULT_BUFFER_SIZE);
     position = 0;
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/writer/TsFileOutput.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/writer/TsFileOutput.java
@@ -23,6 +23,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
 public interface TsFileOutput {
+
   int DEFAULT_BUFFER_SIZE = 64 * 1024;
   /**
    * Writes <code>b.length</code> bytes from the specified byte array to this output at the current

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/writer/TsFileOutput.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/writer/TsFileOutput.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 public interface TsFileOutput {
 
   int DEFAULT_BUFFER_SIZE = 64 * 1024;
+
   /**
    * Writes <code>b.length</code> bytes from the specified byte array to this output at the current
    * position.

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/writer/TsFileOutput.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/writer/TsFileOutput.java
@@ -23,7 +23,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
 public interface TsFileOutput {
-
+  int DEFAULT_BUFFER_SIZE = 64 * 1024;
   /**
    * Writes <code>b.length</code> bytes from the specified byte array to this output at the current
    * position.


### PR DESCRIPTION
For ChunkWriter, we add some constructor with rowCount params to specific the capacity of bytestream such that we can reduce the bytestream grow times.
Note: these constructors are used just in iotdb currently