### PR TITLE
Add processing when a deviceId contains null

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/exception/IllegalDeviceIDException.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/exception/IllegalDeviceIDException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tsfile.exception;
+
+public class IllegalDeviceIDException extends RuntimeException {
+
+  public IllegalDeviceIDException(String message) {
+    super(message);
+  }
+}

--- a/java/tsfile/src/test/java/org/apache/tsfile/file/metadata/IDeviceIDTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/file/metadata/IDeviceIDTest.java
@@ -115,6 +115,9 @@ public class IDeviceIDTest {
     assertThrows(
         IllegalDeviceIDException.class,
         () -> Factory.DEFAULT_FACTORY.create(new String[] {null, null, null, null}));
+    assertThrows(
+        IllegalDeviceIDException.class,
+        () -> Factory.DEFAULT_FACTORY.create(new String[] {}));
   }
 
   @Test


### PR DESCRIPTION
When constructing an IDeviceID with String[]:
(1) If all segments are null (or length == 0), throw an IllegalDeviceID exception;
(2) If the segments contain tailing nulls, remove them;
(3) If the segments have only one segment after (2), add a tailing null to it.