### PR TITLE
Fix allSatisfy bug in InFilter

### DIFF
--- a/java/tsfile/src/main/codegen/templates/FilterOperatorsTemplate.ftl
+++ b/java/tsfile/src/main/codegen/templates/FilterOperatorsTemplate.ftl
@@ -1035,6 +1035,11 @@ public final class ${className} {
         return true;
       }
 
+      // has null value, just return false
+      if (metadata.hasNullValue(measurementIndex)) {
+        return false;
+      }
+
       // All values are same
       if (statistics.isPresent()) {
         Statistics<? extends Serializable> stat = statistics.get();


### PR DESCRIPTION
if a block has null value, allSatisfy should return false for InFilter