### PR TITLE
If no subSensor, typeMatch should always return true

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/AbstractAlignedTimeSeriesMetadata.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/AbstractAlignedTimeSeriesMetadata.java
@@ -172,6 +172,9 @@ public abstract class AbstractAlignedTimeSeriesMetadata implements ITimeSeriesMe
 
   @Override
   public boolean typeMatch(List<TSDataType> dataTypes) {
+    if (dataTypes.isEmpty()) {
+      return true;
+    }
     if (valueTimeseriesMetadataList != null) {
       int notMatchCount = 0;
       for (int i = 0, size = dataTypes.size(); i < size; i++) {


### PR DESCRIPTION
If no subSensor, typeMatch should always return true