### PR TITLE
fix: Fix the bug in parse date to int when year out of range

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/utils/DateUtils.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/utils/DateUtils.java
@@ -48,7 +48,7 @@ public class DateUtils {
       throw new DateTimeParseException(
           "Invalid date format. Please use YYYY-MM-DD format.", dateExpression, 0);
     }
-    if (date.getYear() < 1000) {
+    if (date.getYear() < 1000 || date.getYear() > 9999) {
       throw new DateTimeParseException("Year must be between 1000 and 9999.", dateExpression, 0);
     }
     return date.getYear() * 10000 + date.getMonthValue() * 100 + date.getDayOfMonth();
@@ -58,7 +58,7 @@ public class DateUtils {
     if (localDate == null) {
       throw new DateTimeParseException("Date expression is null or empty.", "", 0);
     }
-    if (localDate.getYear() < 1000) {
+    if (localDate.getYear() < 1000 || localDate.getYear() > 9999) {
       throw new DateTimeParseException(
           "Year must be between 1000 and 9999.", localDate.format(DATE_FORMATTER), 0);
     }


### PR DESCRIPTION
This pull request includes updates to the `DateUtils` class to enhance date validation logic. The changes ensure that the year in the date expression falls within a valid range.

Validation improvements:

* [`java/tsfile/src/main/java/org/apache/tsfile/utils/DateUtils.java`](diffhunk://#diff-30d849eff6235c344df0d6b2fd3db364b502477d2de5b225d64102edb12f0dfaL51-R51): Updated the `parseDateExpressionToInt(String dateExpression)` method to throw an exception if the year is greater than 9999.
* [`java/tsfile/src/main/java/org/apache/tsfile/utils/DateUtils.java`](diffhunk://#diff-30d849eff6235c344df0d6b2fd3db364b502477d2de5b225d64102edb12f0dfaL61-R61): Updated the `parseDateExpressionToInt(LocalDate localDate)` method to throw an exception if the year is greater than 9999.