### PR TITLE
remove get escape code and change the function in filteroperator

### DIFF
--- a/java/tsfile/src/main/codegen/templates/FilterOperatorsTemplate.ftl
+++ b/java/tsfile/src/main/codegen/templates/FilterOperatorsTemplate.ftl
@@ -51,8 +51,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.apache.tsfile.common.regexp.LikePattern.getEscapeCharacter;
-
   /*
 * This class is generated using freemarker and the ${.template_name} template.
 */
@@ -1294,7 +1292,7 @@ public final class ${className} {
           LikePattern.compile(
               ReadWriteIOUtils.readString(buffer),
               ReadWriteIOUtils.readBool(buffer)
-                  ? getEscapeCharacter(Optional.of(ReadWriteIOUtils.readString(buffer)))
+                  ? Optional.of(ReadWriteIOUtils.readString(buffer).charAt(0))
                   : Optional.empty());
     }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/common/regexp/LikePattern.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/regexp/LikePattern.java
@@ -74,25 +74,11 @@ public class LikePattern {
 
   @Override
   public String toString() {
-    // 既要有pattern，又考虑escape
     return "LikePattern{"
         + "pattern='"
         + pattern
         + '\''
         + (escape.map(character -> ", escape=" + character).orElse(""))
         + '}';
-  }
-
-  public static Optional<Character> getEscapeCharacter(Optional<String> escape) {
-    if (escape.isPresent()) {
-      String escapeString = escape.get();
-      if (escapeString.length() == 1) {
-        return Optional.of(escapeString.charAt(0));
-      } else {
-        throw new IllegalArgumentException("Escape string must be a single character");
-      }
-    } else {
-      return Optional.empty();
-    }
   }
 }


### PR DESCRIPTION
Syntax checking should not be placed in the storage layer. The syntax that can be transferred to the storage layer should be checked for correctness and can be used directly. Therefore, the getEscapeCharacter function is migrated to iotdb.Also ,fix some code smell problem in this pr