### PR TITLE
Fix code scanning alert no. 7: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/encrypt/EncryptUtils.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encrypt/EncryptUtils.java
@@ -94,7 +94,7 @@ public class EncryptUtils {
 
   public static String getNormalKeyStr() {
     try {
-      MessageDigest md = MessageDigest.getInstance("MD5");
+      MessageDigest md = MessageDigest.getInstance("SHA-256");
       md.update("IoTDB is the best".getBytes());
       md.update(TSFileDescriptor.getInstance().getConfig().getEncryptKey().getBytes());
       byte[] data_key = md.digest();


### PR DESCRIPTION
Fixes [https://github.com/apache/tsfile/security/code-scanning/7](https://github.com/apache/tsfile/security/code-scanning/7)

To fix the problem, we should replace the use of the MD5 algorithm with a stronger, modern cryptographic hash function such as SHA-256. This change will enhance the security of the cryptographic operations performed by the code.

- Replace `MessageDigest.getInstance("MD5")` with `MessageDigest.getInstance("SHA-256")`.
- Ensure that the rest of the code correctly handles the output size of SHA-256, which is 256 bits (32 bytes), compared to MD5's 128 bits (16 bytes).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
