### PR TITLE
Fix code scanning alert no. 11: Multiplication result converted to larger type

### DIFF
--- a/cpp/third_party/zlib-1.2.13/zutil.c
+++ b/cpp/third_party/zlib-1.2.13/zutil.c
@@ -310,7 +310,7 @@ voidpf ZLIB_INTERNAL zcalloc(opaque, items, size)
     unsigned size;
 {
     (void)opaque;
-    return sizeof(uInt) > 2 ? (voidpf)malloc(items * size) :
+    return sizeof(uInt) > 2 ? (voidpf)malloc((size_t)items * size) :
                               (voidpf)calloc(items, size);
 }
 


### PR DESCRIPTION
Fixes [https://github.com/apache/tsfile/security/code-scanning/11](https://github.com/apache/tsfile/security/code-scanning/11)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be achieved by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done using the `size_t` type, which is typically larger than `unsigned int` and can hold larger values.

The specific change involves casting `items` to `size_t` before multiplying it by `size` on line 313. This ensures that the multiplication is performed using the `size_t` type, preventing overflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
