### PR TITLE
Fix code scanning alert no. 5: Unsigned difference expression compared to zero

### DIFF
--- a/cpp/src/reader/bloom_filter.cc
+++ b/cpp/src/reader/bloom_filter.cc
@@ -140,7 +140,7 @@ int BitSet::from_bytes(uint8_t *filter_data, uint32_t filter_data_bytes_len) {
         *(words_ + word_idx) = cur_word;
     }
 
-    if (filter_data_bytes_len - word_idx * 8 > 0) {
+    if (filter_data_bytes_len > word_idx * 8) {
         uint64_t cur_word = 0;
         uint8_t *cur_word_start_byte = filter_data + (word_idx * 8);
         for (uint32_t r = 0; r < filter_data_bytes_len - word_idx * 8; r++) {


### PR DESCRIPTION
Fixes [https://github.com/apache/tsfile/security/code-scanning/5](https://github.com/apache/tsfile/security/code-scanning/5)

To fix the problem, we need to ensure that the comparison correctly reflects the intended logic without relying on the properties of unsigned integers. Since the intention seems to be to check if there are remaining bytes to process, we can replace the relational comparison with an equality check. This avoids the potential pitfalls of unsigned arithmetic.

- Change the comparison `filter_data_bytes_len - word_idx * 8 > 0` to `filter_data_bytes_len > word_idx * 8`.
- This change ensures that we are directly comparing the two unsigned values without performing a subtraction that could lead to confusion or errors.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
