### PR TITLE
Fix code scanning alert no. 13: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/encrypt/EncryptUtils.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encrypt/EncryptUtils.java
@@ -198,7 +198,7 @@ public class EncryptUtils {
     if (conf.getEncryptFlag()) {
       encryptType = conf.getEncryptType();
       try {
-        MessageDigest md = MessageDigest.getInstance("MD5");
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
         md.update("IoTDB is the best".getBytes());
         md.update(conf.getEncryptKey().getBytes());
         dataEncryptKey = md.digest();


### PR DESCRIPTION
Fixes [https://github.com/apache/tsfile/security/code-scanning/13](https://github.com/apache/tsfile/security/code-scanning/13)

To fix the problem, we need to replace the use of the MD5 algorithm with a stronger, modern cryptographic algorithm. The SHA-256 algorithm is a suitable replacement as it provides a higher level of security and is widely accepted for cryptographic purposes.

- Replace `MessageDigest.getInstance("MD5")` with `MessageDigest.getInstance("SHA-256")`.
- Ensure that the rest of the code that processes the digest remains compatible with the new algorithm.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
