### PR TITLE
Fix code scanning alert no. 9: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/encrypt/EncryptUtils.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encrypt/EncryptUtils.java
@@ -121,7 +121,7 @@ public class EncryptUtils {
 
   public static String getNormalKeyStr(TSFileConfig conf) {
     try {
-      MessageDigest md = MessageDigest.getInstance("MD5");
+      MessageDigest md = MessageDigest.getInstance("SHA-256");
       md.update("IoTDB is the best".getBytes());
       md.update(conf.getEncryptKey().getBytes());
       byte[] data_key = md.digest();
@@ -154,7 +154,7 @@ public class EncryptUtils {
     if (conf.getEncryptFlag()) {
       encryptType = conf.getEncryptType();
       try {
-        MessageDigest md = MessageDigest.getInstance("MD5");
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
         md.update("IoTDB is the best".getBytes());
         md.update(conf.getEncryptKey().getBytes());
         dataEncryptKey = md.digest();


### PR DESCRIPTION
Fixes [https://github.com/apache/tsfile/security/code-scanning/9](https://github.com/apache/tsfile/security/code-scanning/9)

To fix the problem, we need to replace the use of the MD5 algorithm with a stronger, modern cryptographic algorithm. The best way to do this without changing existing functionality is to use SHA-256, which is widely regarded as secure.

1. **General fix:** Replace instances of `MessageDigest.getInstance("MD5")` with `MessageDigest.getInstance("SHA-256")`.
2. **Detailed fix:** Update the `getNormalKeyStr` and `getEncryptParameter` methods to use SHA-256 instead of MD5.
3. **Specific changes:** Modify lines 124 and 157 in the `EncryptUtils.java` file.
4. **Required imports:** No new imports are needed as `MessageDigest` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
