### PR TITLE
Fix code scanning alert no. 12: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/encrypt/EncryptUtils.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encrypt/EncryptUtils.java
@@ -94,7 +94,7 @@ public class EncryptUtils {
 
   public static String getNormalKeyStr() {
     try {
-      MessageDigest md = MessageDigest.getInstance("MD5");
+      MessageDigest md = MessageDigest.getInstance("SHA-256");
       md.update("IoTDB is the best".getBytes());
       md.update(TSFileDescriptor.getInstance().getConfig().getEncryptKey().getBytes());
       byte[] data_key = md.digest();
@@ -115,13 +115,13 @@ public class EncryptUtils {
 
       return str;
     } catch (Exception e) {
-      throw new EncryptException("md5 function not found while using md5 to generate data key");
+      throw new EncryptException("SHA-256 function not found while using SHA-256 to generate data key");
     }
   }
 
   public static String getNormalKeyStr(TSFileConfig conf) {
     try {
-      MessageDigest md = MessageDigest.getInstance("MD5");
+      MessageDigest md = MessageDigest.getInstance("SHA-256");
       md.update("IoTDB is the best".getBytes());
       md.update(conf.getEncryptKey().getBytes());
       byte[] data_key = md.digest();
@@ -140,7 +140,7 @@ public class EncryptUtils {
 
       return str;
     } catch (Exception e) {
-      throw new EncryptException("md5 function not found while using md5 to generate data key", e);
+      throw new EncryptException("SHA-256 function not found while using SHA-256 to generate data key", e);
     }
   }
 


### PR DESCRIPTION
Fixes [https://github.com/apache/tsfile/security/code-scanning/12](https://github.com/apache/tsfile/security/code-scanning/12)

To fix the problem, we need to replace the use of the MD5 algorithm with a stronger, modern cryptographic algorithm such as SHA-256. This involves updating the `MessageDigest.getInstance("MD5")` call to use `SHA-256` instead. The rest of the code logic can remain the same, as SHA-256 provides a similar interface to MD5.

**Steps to fix:**
1. Update the `MessageDigest.getInstance("MD5")` call to `MessageDigest.getInstance("SHA-256")` in both `getNormalKeyStr` methods.
2. Ensure that the rest of the code correctly handles the output of the SHA-256 hash, which is longer than the MD5 hash.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
