### PR TITLE
Separate java and cpp/py UT

### DIFF
--- a/.github/workflows/unit-test-cpp-py.yml
+++ b/.github/workflows/unit-test-cpp-py.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Unit-Test
+name: Unit-Test-Cpp-Py
 
 on:
   push:
@@ -11,6 +11,7 @@ on:
       - rc/*
     paths-ignore:
       - 'docs/**'
+      - 'java/**'
   pull_request:
     branches:
       - develop
@@ -18,6 +19,7 @@ on:
       - rc/*
     paths-ignore:
       - 'docs/**'
+      - 'java/**'
   # Enable manually starting builds, and allow forcing updating of SNAPSHOT dependencies.
   workflow_dispatch:
     inputs:
@@ -38,9 +40,8 @@ jobs:
   unit-test:
     strategy:
       fail-fast: false
-      max-parallel: 20
+      max-parallel: 15
       matrix:
-        java: [ 8, 17, 21 ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
 
@@ -48,12 +49,6 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
-        with:
-          distribution: corretto
-          java-version: ${{ matrix.java }}
 
       # Setup caching of the artifacts in the .m2 directory, so they don't have to
       # all be downloaded again for every build.
@@ -79,14 +74,13 @@ jobs:
               core.setOutput('platform_suffix', ``)
             }
 
-      # Run the actual maven build including all unit- and integration-tests.
+      # Run the actual maven build including all tests.
       - name: Build and test with Maven
         shell: bash
         run: |
-          ./mvnw${{ steps.platform_suffix.outputs.platform_suffix }} -P with-java,with-cpp,with-python clean verify
+          ./mvnw${{ steps.platform_suffix.outputs.platform_suffix }} -P with-cpp,with-python clean verify
 
       - name: Upload whl Artifact
-        if: ${{ matrix.java == '17'}}
         uses: actions/upload-artifact@v4
         with:
           name: tsfile-${{ runner.os }}-whl

--- a/.github/workflows/unit-test-java.yml
+++ b/.github/workflows/unit-test-java.yml
@@ -1,0 +1,90 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Unit-Test-Java
+
+on:
+  push:
+    branches:
+      - develop
+      - iotdb
+      - rc/*
+    paths-ignore:
+      - 'docs/**'
+      - 'cpp/**'
+      - 'python/**'
+  pull_request:
+    branches:
+      - develop
+      - iotdb
+      - rc/*
+    paths-ignore:
+      - 'docs/**'
+      - 'cpp/**'
+      - 'python/**'
+  # Enable manually starting builds, and allow forcing updating of SNAPSHOT dependencies.
+  workflow_dispatch:
+    inputs:
+      forceUpdates:
+        description: "Forces a snapshot update"
+        required: false
+        default: 'false'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+
+jobs:
+  unit-test:
+    strategy:
+      fail-fast: false
+      max-parallel: 15
+      matrix:
+        java: [ 8, 17, 21 ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: ${{ matrix.java }}
+
+      # Setup caching of the artifacts in the .m2 directory, so they don't have to
+      # all be downloaded again for every build.
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2-
+
+      # On Windows systems the 'mvnw' script needs an additional ".cmd" appended.
+      - name: Calculate platform suffix
+        id: platform_suffix
+        uses: actions/github-script@v7.0.1
+        env:
+          OS: ${{ matrix.os }}
+        with:
+          script: |
+            const { OS } = process.env
+            if (OS.includes("windows")) {
+              core.setOutput('platform_suffix', `.cmd`)
+            } else {
+              core.setOutput('platform_suffix', ``)
+            }
+
+      # Run the actual maven build including all tests.
+      - name: Build and test with Maven
+        shell: bash
+        run: |
+          ./mvnw${{ steps.platform_suffix.outputs.platform_suffix }} -P with-java clean verify


### PR DESCRIPTION
After this PR, if only change some cpp code, we don't need to run the Java UT, which will accelerate the CI running. 