### PR TITLE
Correct the retained size calculation for BinaryColumn and BinaryColumnBuilder

### DIFF
--- a/java/common/src/main/java/org/apache/tsfile/utils/RamUsageEstimator.java
+++ b/java/common/src/main/java/org/apache/tsfile/utils/RamUsageEstimator.java
@@ -271,6 +271,18 @@ public final class RamUsageEstimator {
         : alignObjectSize(NUM_BYTES_ARRAY_HEADER + (long) Double.BYTES * arr.length);
   }
 
+  public static long sizeOf(Accountable[] arr) {
+    if (arr == null) {
+      return 0;
+    } else {
+      long size = shallowSizeOf(arr);
+      for (Accountable obj : arr) {
+        size += obj.ramBytesUsed();
+      }
+      return size;
+    }
+  }
+
   /** Returns the size in bytes of the String[] object. */
   public static long sizeOf(String[] arr) {
     long size = shallowSizeOf(arr);

--- a/java/common/src/main/java/org/apache/tsfile/utils/RamUsageEstimator.java
+++ b/java/common/src/main/java/org/apache/tsfile/utils/RamUsageEstimator.java
@@ -277,7 +277,7 @@ public final class RamUsageEstimator {
     } else {
       long size = shallowSizeOf(arr);
       for (Accountable obj : arr) {
-        size += obj.ramBytesUsed();
+        size += obj != null ? obj.ramBytesUsed() : 0;
       }
       return size;
     }

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/header/ChunkGroupHeader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/header/ChunkGroupHeader.java
@@ -53,7 +53,6 @@ public class ChunkGroupHeader {
   }
 
   private int getSerializedSize(IDeviceID deviceID) {
-    // TODO: add an interface in IDeviceID
     int length = deviceID.serializedSize();
     return Byte.BYTES + ReadWriteForEncodingUtils.varIntSize(length) + length;
   }
@@ -73,7 +72,6 @@ public class ChunkGroupHeader {
       }
     }
 
-    // TODO: add an interface in IDeviceID
     final IDeviceID deviceID = deserializeDeviceID(inputStream, versionNumber);
     return new ChunkGroupHeader(deviceID);
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/TsBlockBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/TsBlockBuilder.java
@@ -104,8 +104,6 @@ public class TsBlockBuilder {
     valueColumnBuilders = new ColumnBuilder[types.size()];
 
     for (int i = 0; i < valueColumnBuilders.length; i++) {
-      // TODO use Type interface to encapsulate createColumnBuilder to each concrete type class
-      // instead of switch-case
       switch (types.get(i)) {
         case BOOLEAN:
           valueColumnBuilders[i] =
@@ -176,8 +174,6 @@ public class TsBlockBuilder {
     valueColumnBuilders = new ColumnBuilder[types.size()];
     int initialExpectedEntries = timeColumnBuilder.getPositionCount();
     for (int i = 0; i < valueColumnBuilders.length; i++) {
-      // TODO use Type interface to encapsulate createColumnBuilder to each concrete type class
-      // instead of switch-case
       switch (types.get(i)) {
         case BOOLEAN:
           valueColumnBuilders[i] =

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumn.java
@@ -32,8 +32,8 @@ import java.util.Optional;
 import static org.apache.tsfile.read.common.block.column.ColumnUtil.checkArrayRange;
 import static org.apache.tsfile.read.common.block.column.ColumnUtil.checkReadablePosition;
 import static org.apache.tsfile.read.common.block.column.ColumnUtil.checkValidRegion;
+import static org.apache.tsfile.utils.RamUsageEstimator.sizeOf;
 import static org.apache.tsfile.utils.RamUsageEstimator.sizeOfBooleanArray;
-import static org.apache.tsfile.utils.RamUsageEstimator.sizeOfObjectArray;
 
 public class BinaryColumn implements Column {
 
@@ -75,9 +75,7 @@ public class BinaryColumn implements Column {
     }
     this.valueIsNull = valueIsNull;
 
-    // TODO we need to sum up all the Binary's retainedSize here
-    retainedSizeInBytes =
-        INSTANCE_SIZE + sizeOfBooleanArray(positionCount) + sizeOfObjectArray(positionCount);
+    retainedSizeInBytes = INSTANCE_SIZE + sizeOfBooleanArray(positionCount) + sizeOf(values);
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumnBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumnBuilder.java
@@ -32,7 +32,6 @@ import java.util.Arrays;
 
 import static java.lang.Math.max;
 import static org.apache.tsfile.read.common.block.column.ColumnUtil.calculateBlockResetSize;
-import static org.apache.tsfile.utils.RamUsageEstimator.shallowSizeOf;
 import static org.apache.tsfile.utils.RamUsageEstimator.sizeOf;
 
 public class BinaryColumnBuilder implements ColumnBuilder {
@@ -129,7 +128,6 @@ public class BinaryColumnBuilder implements ColumnBuilder {
 
   @Override
   public long getRetainedSizeInBytes() {
-    // TODO we need to sum up all the Binary's retainedSize here
     long size = INSTANCE_SIZE + arraysRetainedSizeInBytes;
     if (columnBuilderStatus != null) {
       size += ColumnBuilderStatus.INSTANCE_SIZE;
@@ -139,7 +137,6 @@ public class BinaryColumnBuilder implements ColumnBuilder {
 
   @Override
   public ColumnBuilder newColumnBuilderLike(ColumnBuilderStatus columnBuilderStatus) {
-    // TODO we should take retain size into account here
     return new BinaryColumnBuilder(columnBuilderStatus, calculateBlockResetSize(positionCount));
   }
 
@@ -158,6 +155,6 @@ public class BinaryColumnBuilder implements ColumnBuilder {
   }
 
   private void updateArraysDataSize() {
-    arraysRetainedSizeInBytes = sizeOf(valueIsNull) + shallowSizeOf(values);
+    arraysRetainedSizeInBytes = sizeOf(valueIsNull) + sizeOf(values);
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TimeColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TimeColumn.java
@@ -100,8 +100,7 @@ public class TimeColumn implements Column {
 
   @Override
   public boolean[] isNull() {
-    // todo
-    return null;
+    throw new UnsupportedOperationException("isNull is not supported for TimeColumn");
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TsBlockSerde.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TsBlockSerde.java
@@ -67,7 +67,6 @@ public class TsBlockSerde {
     }
 
     // Time column.
-    // TODO: a TimeColumn will be deserialized as a LongColumn
     Column timeColumn =
         ColumnEncoderFactory.get(columnEncodings.get(0))
             .readColumn(byteBuffer, TSDataType.INT64, positionCount);


### PR DESCRIPTION
1. Correct the retained size calculation for BinaryColumn and BinaryColumnBuilder
2. remove some useless todo
3. throw new UnsupportedOperationException for isNull method in TimeColumn

Do the performance test, build 1 billion binary using TsBlockBuilder, we only see  1-second performance impact(macOS M2 pro, OpenJDK-21).
Before：
6779
6420
6394
6387
6527

After：
7589
7524
8063
7592
7696

You can replay that test, using the following codes
```
public static void main(String[] args) {
  TsBlockBuilder builder = new TsBlockBuilder(Collections.singletonList(TSDataType.BLOB));
  TimeColumnBuilder timeColumnBuilder = builder.getTimeColumnBuilder();
  ColumnBuilder columnBuilder = builder.getColumnBuilder(0);
  long startTime = System.nanoTime();
  for (int i = 0; i < 1_000_000_000; i++) {
    timeColumnBuilder.writeLong(i);
    Binary binary = new Binary(BytesUtils.intToBytes(i));
    columnBuilder.writeBinary(binary);
    builder.declarePosition();
    if (builder.isFull()) {
      builder.build();
      builder.reset();
      timeColumnBuilder = builder.getTimeColumnBuilder();
      columnBuilder = builder.getColumnBuilder(0);
    }
  }
  if (!builder.isEmpty()) {
    builder.build();
    builder.reset();
  }
  System.out.println("cost: " + (System.nanoTime() - startTime) / 1_000_000);
}
```