### PR TITLE
Correct the retained size calculation for BinaryColumn and BinaryColumnBuilder

### DIFF
--- a/java/common/src/main/java/org/apache/tsfile/block/column/Column.java
+++ b/java/common/src/main/java/org/apache/tsfile/block/column/Column.java
@@ -144,6 +144,13 @@ public interface Column {
   long getRetainedSizeInBytes();
 
   /**
+   * Returns the size of this Column as if it was compacted, ignoring any over-allocations and any
+   * unloaded nested Columns. For example, in dictionary blocks, this only counts each dictionary
+   * entry once, rather than each time a value is referenced.
+   */
+  long getSizeInBytes();
+
+  /**
    * Returns a column starting at the specified position and extends for the specified length. The
    * specified region must be entirely contained within this column.
    *

--- a/java/common/src/main/java/org/apache/tsfile/utils/RamUsageEstimator.java
+++ b/java/common/src/main/java/org/apache/tsfile/utils/RamUsageEstimator.java
@@ -271,6 +271,18 @@ public final class RamUsageEstimator {
         : alignObjectSize(NUM_BYTES_ARRAY_HEADER + (long) Double.BYTES * arr.length);
   }
 
+  public static long sizeOf(Accountable[] arr) {
+    if (arr == null) {
+      return 0;
+    } else {
+      long size = shallowSizeOf(arr);
+      for (Accountable obj : arr) {
+        size += obj != null ? obj.ramBytesUsed() : 0;
+      }
+      return size;
+    }
+  }
+
   /** Returns the size in bytes of the String[] object. */
   public static long sizeOf(String[] arr) {
     long size = shallowSizeOf(arr);

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/header/ChunkGroupHeader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/header/ChunkGroupHeader.java
@@ -53,7 +53,6 @@ public class ChunkGroupHeader {
   }
 
   private int getSerializedSize(IDeviceID deviceID) {
-    // TODO: add an interface in IDeviceID
     int length = deviceID.serializedSize();
     return Byte.BYTES + ReadWriteForEncodingUtils.varIntSize(length) + length;
   }
@@ -73,7 +72,6 @@ public class ChunkGroupHeader {
       }
     }
 
-    // TODO: add an interface in IDeviceID
     final IDeviceID deviceID = deserializeDeviceID(inputStream, versionNumber);
     return new ChunkGroupHeader(deviceID);
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/TsBlockBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/TsBlockBuilder.java
@@ -104,8 +104,6 @@ public class TsBlockBuilder {
     valueColumnBuilders = new ColumnBuilder[types.size()];
 
     for (int i = 0; i < valueColumnBuilders.length; i++) {
-      // TODO use Type interface to encapsulate createColumnBuilder to each concrete type class
-      // instead of switch-case
       switch (types.get(i)) {
         case BOOLEAN:
           valueColumnBuilders[i] =
@@ -176,8 +174,6 @@ public class TsBlockBuilder {
     valueColumnBuilders = new ColumnBuilder[types.size()];
     int initialExpectedEntries = timeColumnBuilder.getPositionCount();
     for (int i = 0; i < valueColumnBuilders.length; i++) {
-      // TODO use Type interface to encapsulate createColumnBuilder to each concrete type class
-      // instead of switch-case
       switch (types.get(i)) {
         case BOOLEAN:
           valueColumnBuilders[i] =

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumn.java
@@ -32,8 +32,8 @@ import java.util.Optional;
 import static org.apache.tsfile.read.common.block.column.ColumnUtil.checkArrayRange;
 import static org.apache.tsfile.read.common.block.column.ColumnUtil.checkReadablePosition;
 import static org.apache.tsfile.read.common.block.column.ColumnUtil.checkValidRegion;
+import static org.apache.tsfile.utils.RamUsageEstimator.sizeOf;
 import static org.apache.tsfile.utils.RamUsageEstimator.sizeOfBooleanArray;
-import static org.apache.tsfile.utils.RamUsageEstimator.sizeOfObjectArray;
 
 public class BinaryColumn implements Column {
 
@@ -75,9 +75,7 @@ public class BinaryColumn implements Column {
     }
     this.valueIsNull = valueIsNull;
 
-    // TODO we need to sum up all the Binary's retainedSize here
-    retainedSizeInBytes =
-        INSTANCE_SIZE + sizeOfBooleanArray(positionCount) + sizeOfObjectArray(positionCount);
+    retainedSizeInBytes = INSTANCE_SIZE + sizeOfBooleanArray(positionCount) + sizeOf(values);
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumn.java
@@ -78,6 +78,34 @@ public class BinaryColumn implements Column {
     retainedSizeInBytes = INSTANCE_SIZE + sizeOfBooleanArray(positionCount) + sizeOf(values);
   }
 
+  // called by getRegion which already knows the underlying retainedSizeInBytes
+  private BinaryColumn(
+      int arrayOffset,
+      int positionCount,
+      boolean[] valueIsNull,
+      Binary[] values,
+      long retainedSizeInBytes) {
+    if (arrayOffset < 0) {
+      throw new IllegalArgumentException("arrayOffset is negative");
+    }
+    this.arrayOffset = arrayOffset;
+    if (positionCount < 0) {
+      throw new IllegalArgumentException("positionCount is negative");
+    }
+    this.positionCount = positionCount;
+
+    if (values.length - arrayOffset < positionCount) {
+      throw new IllegalArgumentException("values length is less than positionCount");
+    }
+    this.values = values;
+
+    if (valueIsNull != null && valueIsNull.length - arrayOffset < positionCount) {
+      throw new IllegalArgumentException("isNull length is less than positionCount");
+    }
+    this.valueIsNull = valueIsNull;
+    this.retainedSizeInBytes = retainedSizeInBytes;
+  }
+
   @Override
   public TSDataType getDataType() {
     return TSDataType.TEXT;
@@ -141,7 +169,8 @@ public class BinaryColumn implements Column {
   @Override
   public Column getRegion(int positionOffset, int length) {
     checkValidRegion(getPositionCount(), positionOffset, length);
-    return new BinaryColumn(positionOffset + arrayOffset, length, valueIsNull, values);
+    return new BinaryColumn(
+        positionOffset + arrayOffset, length, valueIsNull, values, getRetainedSizeInBytes());
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumn.java
@@ -46,6 +46,7 @@ public class BinaryColumn implements Column {
   private final Binary[] values;
 
   private final long retainedSizeInBytes;
+  private final long sizeInBytes;
 
   public BinaryColumn(int initialCapacity) {
     this(0, 0, null, new Binary[initialCapacity]);
@@ -76,6 +77,7 @@ public class BinaryColumn implements Column {
     this.valueIsNull = valueIsNull;
 
     retainedSizeInBytes = INSTANCE_SIZE + sizeOfBooleanArray(positionCount) + sizeOf(values);
+    sizeInBytes = values.length > 0 ? retainedSizeInBytes * positionCount / values.length : 0L;
   }
 
   // called by getRegion which already knows the underlying retainedSizeInBytes
@@ -104,6 +106,7 @@ public class BinaryColumn implements Column {
     }
     this.valueIsNull = valueIsNull;
     this.retainedSizeInBytes = retainedSizeInBytes;
+    this.sizeInBytes = values.length > 0 ? retainedSizeInBytes * positionCount / values.length : 0L;
   }
 
   @Override
@@ -164,6 +167,11 @@ public class BinaryColumn implements Column {
   @Override
   public long getRetainedSizeInBytes() {
     return retainedSizeInBytes;
+  }
+
+  @Override
+  public long getSizeInBytes() {
+    return sizeInBytes;
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumnBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumnBuilder.java
@@ -32,7 +32,6 @@ import java.util.Arrays;
 
 import static java.lang.Math.max;
 import static org.apache.tsfile.read.common.block.column.ColumnUtil.calculateBlockResetSize;
-import static org.apache.tsfile.utils.RamUsageEstimator.shallowSizeOf;
 import static org.apache.tsfile.utils.RamUsageEstimator.sizeOf;
 
 public class BinaryColumnBuilder implements ColumnBuilder {
@@ -129,7 +128,6 @@ public class BinaryColumnBuilder implements ColumnBuilder {
 
   @Override
   public long getRetainedSizeInBytes() {
-    // TODO we need to sum up all the Binary's retainedSize here
     long size = INSTANCE_SIZE + arraysRetainedSizeInBytes;
     if (columnBuilderStatus != null) {
       size += ColumnBuilderStatus.INSTANCE_SIZE;
@@ -139,7 +137,6 @@ public class BinaryColumnBuilder implements ColumnBuilder {
 
   @Override
   public ColumnBuilder newColumnBuilderLike(ColumnBuilderStatus columnBuilderStatus) {
-    // TODO we should take retain size into account here
     return new BinaryColumnBuilder(columnBuilderStatus, calculateBlockResetSize(positionCount));
   }
 
@@ -158,6 +155,6 @@ public class BinaryColumnBuilder implements ColumnBuilder {
   }
 
   private void updateArraysDataSize() {
-    arraysRetainedSizeInBytes = sizeOf(valueIsNull) + shallowSizeOf(values);
+    arraysRetainedSizeInBytes = sizeOf(valueIsNull) + sizeOf(values);
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BooleanColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BooleanColumn.java
@@ -139,6 +139,11 @@ public class BooleanColumn implements Column {
   }
 
   @Override
+  public long getSizeInBytes() {
+    return (long) positionCount * SIZE_IN_BYTES_PER_POSITION;
+  }
+
+  @Override
   public Column getRegion(int positionOffset, int length) {
     checkValidRegion(getPositionCount(), positionOffset, length);
     return new BooleanColumn(positionOffset + arrayOffset, length, valueIsNull, values);

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/DictionaryColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/DictionaryColumn.java
@@ -188,6 +188,11 @@ public final class DictionaryColumn implements Column {
   }
 
   @Override
+  public long getSizeInBytes() {
+    return ids.length > 0 ? getRetainedSizeInBytes() * positionCount / ids.length : 0L;
+  }
+
+  @Override
   public Column getRegion(int positionOffset, int length) {
     checkValidRegion(positionCount, positionOffset, length);
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/DoubleColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/DoubleColumn.java
@@ -140,6 +140,11 @@ public class DoubleColumn implements Column {
   }
 
   @Override
+  public long getSizeInBytes() {
+    return (long) positionCount * SIZE_IN_BYTES_PER_POSITION;
+  }
+
+  @Override
   public Column getRegion(int positionOffset, int length) {
     checkValidRegion(getPositionCount(), positionOffset, length);
     return new DoubleColumn(positionOffset + arrayOffset, length, valueIsNull, values);

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/FloatColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/FloatColumn.java
@@ -155,6 +155,11 @@ public class FloatColumn implements Column {
   }
 
   @Override
+  public long getSizeInBytes() {
+    return (long) positionCount * SIZE_IN_BYTES_PER_POSITION;
+  }
+
+  @Override
   public Column getRegion(int positionOffset, int length) {
     checkValidRegion(getPositionCount(), positionOffset, length);
     return new FloatColumn(positionOffset + arrayOffset, length, valueIsNull, values);

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/IntColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/IntColumn.java
@@ -183,6 +183,11 @@ public class IntColumn implements Column {
   }
 
   @Override
+  public long getSizeInBytes() {
+    return (long) positionCount * SIZE_IN_BYTES_PER_POSITION;
+  }
+
+  @Override
   public Column getRegion(int positionOffset, int length) {
     checkValidRegion(getPositionCount(), positionOffset, length);
     return new IntColumn(positionOffset + arrayOffset, length, valueIsNull, values);

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/LongColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/LongColumn.java
@@ -155,6 +155,11 @@ public class LongColumn implements Column {
   }
 
   @Override
+  public long getSizeInBytes() {
+    return (long) positionCount * SIZE_IN_BYTES_PER_POSITION;
+  }
+
+  @Override
   public Column getRegion(int positionOffset, int length) {
     checkValidRegion(getPositionCount(), positionOffset, length);
     return new LongColumn(positionOffset + arrayOffset, length, valueIsNull, values);

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/NullColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/NullColumn.java
@@ -86,6 +86,11 @@ public class NullColumn implements Column {
   }
 
   @Override
+  public long getSizeInBytes() {
+    return retainedSizeInBytes;
+  }
+
+  @Override
   public Column getRegion(int positionOffset, int length) {
     checkValidRegion(getPositionCount(), positionOffset, length);
     return new NullColumn(length);

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/RunLengthEncodedColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/RunLengthEncodedColumn.java
@@ -194,6 +194,11 @@ public class RunLengthEncodedColumn implements Column {
   }
 
   @Override
+  public long getSizeInBytes() {
+    return value.getSizeInBytes();
+  }
+
+  @Override
   public Column getRegion(int positionOffset, int length) {
     checkValidRegion(positionCount, positionOffset, length);
     return new RunLengthEncodedColumn(value, length);

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TimeColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TimeColumn.java
@@ -100,8 +100,7 @@ public class TimeColumn implements Column {
 
   @Override
   public boolean[] isNull() {
-    // todo
-    return null;
+    throw new UnsupportedOperationException("isNull is not supported for TimeColumn");
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TimeColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TimeColumn.java
@@ -114,6 +114,11 @@ public class TimeColumn implements Column {
   }
 
   @Override
+  public long getSizeInBytes() {
+    return (long) positionCount * SIZE_IN_BYTES_PER_POSITION;
+  }
+
+  @Override
   public Column getRegion(int positionOffset, int length) {
     ColumnUtil.checkValidRegion(getPositionCount(), positionOffset, length);
     return new TimeColumn(positionOffset + arrayOffset, length, values);

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TsBlockSerde.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TsBlockSerde.java
@@ -67,7 +67,6 @@ public class TsBlockSerde {
     }
 
     // Time column.
-    // TODO: a TimeColumn will be deserialized as a LongColumn
     Column timeColumn =
         ColumnEncoderFactory.get(columnEncodings.get(0))
             .readColumn(byteBuffer, TSDataType.INT64, positionCount);

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TsBlockSerde.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TsBlockSerde.java
@@ -90,12 +90,12 @@ public class TsBlockSerde {
    * @return Serialized tsblock.
    */
   public ByteBuffer serialize(TsBlock tsBlock) throws IOException {
-    if (tsBlock.getRetainedSizeInBytes() > Integer.MAX_VALUE) {
+    if (tsBlock.getSizeInBytes() > Integer.MAX_VALUE) {
       throw new IllegalStateException(
-          "TsBlock should not be that large: " + tsBlock.getRetainedSizeInBytes());
+          "TsBlock should not be that large: " + tsBlock.getSizeInBytes());
     }
     ByteArrayOutputStream byteArrayOutputStream =
-        new ByteArrayOutputStream((int) tsBlock.getRetainedSizeInBytes());
+        new ByteArrayOutputStream((int) tsBlock.getSizeInBytes());
     DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
 
     // Value column count.


### PR DESCRIPTION
1. Correct the retained size calculation for BinaryColumn and BinaryColumnBuilder
2. remove some useless todo
3. throw new UnsupportedOperationException for isNull method in TimeColumn

Do the performance test, build 1 billion binary using TsBlockBuilder, we only see  1-second performance impact(macOS M2 pro, OpenJDK-21).
Before：
6779
6420
6394
6387
6527

After：
7589
7524
8063
7592
7696

You can replay that test, using the following codes
```
public static void main(String[] args) {
  TsBlockBuilder builder = new TsBlockBuilder(Collections.singletonList(TSDataType.BLOB));
  TimeColumnBuilder timeColumnBuilder = builder.getTimeColumnBuilder();
  ColumnBuilder columnBuilder = builder.getColumnBuilder(0);
  long startTime = System.nanoTime();
  for (int i = 0; i < 1_000_000_000; i++) {
    timeColumnBuilder.writeLong(i);
    Binary binary = new Binary(BytesUtils.intToBytes(i));
    columnBuilder.writeBinary(binary);
    builder.declarePosition();
    if (builder.isFull()) {
      builder.build();
      builder.reset();
      timeColumnBuilder = builder.getTimeColumnBuilder();
      columnBuilder = builder.getColumnBuilder(0);
    }
  }
  if (!builder.isEmpty()) {
    builder.build();
    builder.reset();
  }
  System.out.println("cost: " + (System.nanoTime() - startTime) / 1_000_000);
}
```