### PR TITLE
Publish build scans to develocity.apache.org

### DIFF
--- a/.github/workflows/unit-test-cpp-py.yml
+++ b/.github/workflows/unit-test-cpp-py.yml
@@ -34,7 +34,7 @@ concurrency:
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   unit-test:

--- a/.github/workflows/unit-test-java.yml
+++ b/.github/workflows/unit-test-java.yml
@@ -36,7 +36,7 @@ concurrency:
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   unit-test:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/.mvn/.gradle-enterprise/gradle-enterprise-workspace-id
+/.mvn/.gradle-enterprise/
+/.mvn/.develocity/
 /.mvn/wrapper/maven-wrapper.jar
 **/target/**
 /java/tsfile/test.tsfile

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -19,20 +19,22 @@
     under the License.
 
 -->
-<gradleEnterprise xmlns="https://www.gradle.com/gradle-enterprise-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.gradle.com/gradle-enterprise-maven https://www.gradle.com/schema/gradle-enterprise-maven.xsd">
+<develocity xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+    <projectId>tsfile</projectId>
     <server>
-        <url>https://ge.apache.org</url>
+        <url>https://develocity.apache.org</url>
         <allowUntrusted>false</allowUntrusted>
     </server>
     <buildScan>
         <capture>
-            <goalInputFiles>true</goalInputFiles>
+            <fileFingerprints>true</fileFingerprints>
             <buildLogging>true</buildLogging>
             <testLogging>true</testLogging>
         </capture>
         <backgroundBuildScanUpload>#{isFalse(env['GITHUB_ACTIONS'])}</backgroundBuildScanUpload>
-        <publish>ALWAYS</publish>
-        <publishIfAuthenticated>true</publishIfAuthenticated>
+        <publishing>
+            <onlyIf><![CDATA[authenticated]]></onlyIf>
+        </publishing>
         <obfuscation>
             <ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
         </obfuscation>
@@ -45,4 +47,4 @@
             <enabled>false</enabled>
         </remote>
     </buildCache>
-</gradleEnterprise>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -22,12 +22,12 @@
 <extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
     <extension>
         <groupId>com.gradle</groupId>
-        <artifactId>gradle-enterprise-maven-extension</artifactId>
-        <version>1.20.1</version>
+        <artifactId>develocity-maven-extension</artifactId>
+        <version>1.23.1</version>
     </extension>
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>common-custom-user-data-maven-extension</artifactId>
-        <version>2</version>
+        <version>2.0.1</version>
     </extension>
 </extensions>


### PR DESCRIPTION
This PR migrates the TsFile project to publish Build Scans to the the new Develocity instance at develocity.apache.org.

Additionally, this PR migrates from the legacy Gradle Enterprise extension to the renamed Develocity extension and sets a projectId for use by Develocity.