### PR TITLE
Fix losing first page and missing time column in result set metadata

### DIFF
--- a/cpp/examples/c_examples/demo_read.c
+++ b/cpp/examples/c_examples/demo_read.c
@@ -56,7 +56,7 @@ ERRNO read_tsfile() {
         Timestamp timestamp =
             tsfile_result_set_get_value_by_index_int64_t(ret, 1);
         printf("%ld ", timestamp);
-        for (int i = 1; i < column_num; i++) {
+        for (int i = 1; i <= column_num; i++) {
             if (tsfile_result_set_is_null_by_index(ret, i)) {
                 printf(" null ");
             } else {

--- a/cpp/examples/c_examples/demo_write.c
+++ b/cpp/examples/c_examples/demo_write.c
@@ -36,19 +36,19 @@ ERRNO write_tsfile() {
     table_schema.column_schemas =
         (ColumnSchema*)malloc(sizeof(ColumnSchema) * 3);
     table_schema.column_schemas[0] =
-        ColumnSchema{.column_name = strdup("id1"),
+        (ColumnSchema){.column_name = strdup("id1"),
                      .data_type = TS_DATATYPE_STRING,
                      .compression = TS_COMPRESSION_UNCOMPRESSED,
                      .encoding = TS_ENCODING_PLAIN,
                      .column_category = TAG};
     table_schema.column_schemas[1] =
-        ColumnSchema{.column_name = strdup("id2"),
+        (ColumnSchema){.column_name = strdup("id2"),
                      .data_type = TS_DATATYPE_STRING,
                      .compression = TS_COMPRESSION_UNCOMPRESSED,
                      .encoding = TS_ENCODING_PLAIN,
                      .column_category = TAG};
     table_schema.column_schemas[2] =
-        ColumnSchema{.column_name = strdup("s1"),
+        (ColumnSchema){.column_name = strdup("s1"),
                      .data_type = TS_DATATYPE_INT32,
                      .compression = TS_COMPRESSION_UNCOMPRESSED,
                      .encoding = TS_ENCODING_PLAIN,

--- a/cpp/examples/cpp_examples/demo_read.cpp
+++ b/cpp/examples/cpp_examples/demo_read.cpp
@@ -51,7 +51,7 @@ int demo_read() {
     // Metadata in query handler.
     auto metadata = ret->get_metadata();
     int column_num = metadata->get_column_count();
-    for (int i = 0; i < column_num; i++) {
+    for (int i = 1; i <= column_num; i++) {
         std::cout << "column name: " << metadata->get_column_name(i)
                   << std::endl;
         std::cout << "column type: " << metadata->get_column_type(i)
@@ -63,7 +63,7 @@ int demo_read() {
     while ((code = ret->next(has_next)) == common::E_OK && has_next) {
         // Timestamp at column 1 and column index begin from 1.
         Timestamp timestamp = ret->get_value<Timestamp>(1);
-        for (int i = 0; i < column_num; i++) {
+        for (int i = 1; i <= column_num; i++) {
             if (ret->is_null(i)) {
                 std::cout << "null" << std::endl;
             } else {
@@ -98,4 +98,5 @@ int demo_read() {
 
     // Close reader.
     reader.close();
+    return 0;
 }

--- a/cpp/src/common/tablet.cc
+++ b/cpp/src/common/tablet.cc
@@ -275,7 +275,7 @@ template<>
 int Tablet::add_value(uint32_t row_index,
                                const std::string &measurement_name,
                                const char *val) {
-    add_value(row_index, measurement_name, String(val));
+    return add_value(row_index, measurement_name, String(val));
 }
 
 template int Tablet::add_value(uint32_t row_index, uint32_t schema_index,

--- a/cpp/src/cwrapper/tsfile_cwrapper.cc
+++ b/cpp/src/cwrapper/tsfile_cwrapper.cc
@@ -422,27 +422,27 @@ ResultSetMetaData tsfile_result_set_get_metadata(ResultSet result_set) {
         malloc(meta_data.column_num * sizeof(TSDataType)));
     for (int i = 0; i < meta_data.column_num; i++) {
         meta_data.column_names[i] =
-            strdup(result_set_metadata->get_column_name(i).c_str());
+            strdup(result_set_metadata->get_column_name(i + 1).c_str());
         meta_data.data_types[i] =
-            static_cast<TSDataType>(result_set_metadata->get_column_type(i));
+            static_cast<TSDataType>(result_set_metadata->get_column_type(i + 1));
     }
     return meta_data;
 }
 
 char *tsfile_result_set_metadata_get_column_name(ResultSetMetaData result_set,
                                                  uint32_t column_index) {
-    if (column_index >= result_set.column_num) {
+    if (column_index > result_set.column_num) {
         return nullptr;
     }
-    return result_set.column_names[column_index];
+    return result_set.column_names[column_index - 1];
 }
 
 TSDataType tsfile_result_set_metadata_get_data_type(
     ResultSetMetaData result_set, uint32_t column_index) {
-    if (column_index >= result_set.column_num) {
+    if (column_index > result_set.column_num) {
         return TS_DATATYPE_INVALID;
     }
-    return result_set.data_types[column_index];
+    return result_set.data_types[column_index - 1];
 }
 
 int tsfile_result_set_metadata_get_column_num(ResultSetMetaData result_set) {

--- a/cpp/src/reader/result_set.h
+++ b/cpp/src/reader/result_set.h
@@ -29,15 +29,21 @@ namespace storage {
 class ResultSetMetadata {
    public:
     ResultSetMetadata(const std::vector<std::string>& column_names,
-                      const std::vector<common::TSDataType>& column_types)
-        : column_names_(column_names), column_types_(column_types) {}
+                      const std::vector<common::TSDataType>& column_types) {
+        this->column_names_.emplace_back("time");
+        this->column_types_.emplace_back(common::INT64);
+        for (size_t i = 0; i < column_names.size(); ++i) {
+            this->column_names_.emplace_back(column_names[i]);
+            this->column_types_.emplace_back(column_types[i]);
+        }
+    }
     common::TSDataType get_column_type(uint32_t column_index) {
-        ASSERT(column_index >= 0 && column_index < column_types_.size());
-        return column_types_[column_index];
+        ASSERT(column_index >= 1 && column_index <= column_types_.size());
+        return column_types_[column_index - 1];
     }
     std::string get_column_name(uint32_t column_index) {
-        ASSERT(column_index >= 0 && column_index < column_names_.size());
-        return column_names_[column_index];
+        ASSERT(column_index >= 1 && column_index <= column_names_.size());
+        return column_names_[column_index - 1];
     }
     uint32_t get_column_count() { return column_names_.size(); }
 

--- a/cpp/src/reader/table_result_set.cc
+++ b/cpp/src/reader/table_result_set.cc
@@ -72,12 +72,13 @@ bool TableResultSet::is_null(const std::string& column_name) {
     if (iter == index_lookup_.end()) {
         return true;
     } else {
-        return is_null(iter->second);
+        return is_null(iter->second + 1);
     }
 }
 
 bool TableResultSet::is_null(uint32_t column_index) {
-    return row_record_->get_field(column_index) == nullptr;
+    ASSERT(1 <= column_index && column_index <= row_record_->get_col_num());
+    return row_record_->get_field(column_index - 1) == nullptr;
 }
 
 RowRecord* TableResultSet::get_row_record() {

--- a/cpp/src/writer/chunk_writer.cc
+++ b/cpp/src/writer/chunk_writer.cc
@@ -127,9 +127,9 @@ void ChunkWriter::save_first_page_data(PageWriter &first_page_writer) {
     first_page_statistic_->deep_copy_from(first_page_writer.get_statistic());
 }
 
-int ChunkWriter::write_first_page_data(ByteStream &pages_data) {
+int ChunkWriter::write_first_page_data(ByteStream &pages_data, bool with_statistic) {
     int ret = E_OK;
-    if (RET_FAIL(first_page_statistic_->serialize_to(pages_data))) {
+    if (with_statistic && RET_FAIL(first_page_statistic_->serialize_to(pages_data))) {
     } else if (RET_FAIL(
                    pages_data.write_buf(first_page_data_.compressed_buf_,
                                         first_page_data_.compressed_size_))) {
@@ -142,6 +142,13 @@ int ChunkWriter::end_encode_chunk() {
     if (page_writer_.get_statistic()->count_ > 0) {
         ret = seal_cur_page(/*end_chunk*/ true);
         if (E_OK == ret) {
+            chunk_header_.data_size_ = chunk_data_.total_size();
+            chunk_header_.num_of_pages_ = num_of_pages_;
+        }
+    } else if (first_page_statistic_ != nullptr) {
+        ret = write_first_page_data(chunk_data_, false);
+        if (E_OK == ret) {
+            free_first_writer_data();
             chunk_header_.data_size_ = chunk_data_.total_size();
             chunk_header_.num_of_pages_ = num_of_pages_;
         }

--- a/cpp/src/writer/chunk_writer.h
+++ b/cpp/src/writer/chunk_writer.h
@@ -119,12 +119,14 @@ class ChunkWriter {
     FORCE_INLINE void free_first_writer_data() {
         // free memory
         first_page_data_.destroy();
-        StatisticFactory::free(first_page_statistic_);
-        first_page_statistic_ = nullptr;
+        if (first_page_statistic_ != nullptr) {
+            StatisticFactory::free(first_page_statistic_);
+            first_page_statistic_ = nullptr;
+        }
     }
     int seal_cur_page(bool end_chunk);
     void save_first_page_data(PageWriter &first_page_writer);
-    int write_first_page_data(common::ByteStream &pages_data);
+    int write_first_page_data(common::ByteStream &pages_data, bool with_statistic = true);
 
    private:
     common::TSDataType data_type_;

--- a/cpp/src/writer/time_chunk_writer.h
+++ b/cpp/src/writer/time_chunk_writer.h
@@ -84,12 +84,14 @@ class TimeChunkWriter {
     FORCE_INLINE void free_first_writer_data() {
         // free memory
         first_page_data_.destroy();
-        StatisticFactory::free(first_page_statistic_);
-        first_page_statistic_ = nullptr;
+        if (first_page_statistic_ != nullptr) {
+          StatisticFactory::free(first_page_statistic_);
+          first_page_statistic_ = nullptr;
+        }
     }
     int seal_cur_page(bool end_chunk);
     void save_first_page_data(TimePageWriter &first_time_page_writer);
-    int write_first_page_data(common::ByteStream &pages_data);
+    int write_first_page_data(common::ByteStream &pages_data, bool with_statistic = true);
 
    private:
     TimePageWriter time_page_writer_;

--- a/cpp/src/writer/value_chunk_writer.cc
+++ b/cpp/src/writer/value_chunk_writer.cc
@@ -132,9 +132,9 @@ void ValueChunkWriter::save_first_page_data(
     first_page_statistic_->deep_copy_from(first_page_writer.get_statistic());
 }
 
-int ValueChunkWriter::write_first_page_data(ByteStream &pages_data) {
+int ValueChunkWriter::write_first_page_data(ByteStream &pages_data, bool with_statistic) {
     int ret = E_OK;
-    if (RET_FAIL(first_page_statistic_->serialize_to(pages_data))) {
+    if (with_statistic && RET_FAIL(first_page_statistic_->serialize_to(pages_data))) {
     } else if (RET_FAIL(
                    pages_data.write_buf(first_page_data_.compressed_buf_,
                                         first_page_data_.compressed_size_))) {
@@ -147,6 +147,13 @@ int ValueChunkWriter::end_encode_chunk() {
     if (value_page_writer_.get_statistic()->count_ > 0) {
         ret = seal_cur_page(/*end_chunk*/ true);
         if (E_OK == ret) {
+            chunk_header_.data_size_ = chunk_data_.total_size();
+            chunk_header_.num_of_pages_ = num_of_pages_;
+        }
+    } else if (first_page_statistic_ != nullptr) {
+        ret = write_first_page_data(chunk_data_, false);
+        if (E_OK == ret) {
+            free_first_writer_data();
             chunk_header_.data_size_ = chunk_data_.total_size();
             chunk_header_.num_of_pages_ = num_of_pages_;
         }

--- a/cpp/src/writer/value_chunk_writer.h
+++ b/cpp/src/writer/value_chunk_writer.h
@@ -105,12 +105,14 @@ class ValueChunkWriter {
     }
     FORCE_INLINE void free_first_writer_data() {
         first_page_data_.destroy();
-        StatisticFactory::free(first_page_statistic_);
-        first_page_statistic_ = nullptr;
+        if (first_page_statistic_ != nullptr) {
+            StatisticFactory::free(first_page_statistic_);
+            first_page_statistic_ = nullptr;
+        }
     }
     int seal_cur_page(bool end_chunk);
     void save_first_page_data(ValuePageWriter &first_page_writer);
-    int write_first_page_data(common::ByteStream &pages_data);
+    int write_first_page_data(common::ByteStream &pages_data, bool with_statistic = true);
 
    private:
     common::TSDataType data_type_;

--- a/cpp/test/reader/table_view/tsfile_reader_table_test.cc
+++ b/cpp/test/reader/table_view/tsfile_reader_table_test.cc
@@ -97,13 +97,13 @@ class TsFileTableReaderTest : public ::testing::Test {
     }
 
     static storage::Tablet gen_tablet(TableSchema* table_schema, int offset,
-                                      int device_num) {
+                                      int device_num,
+                                      int num_timestamp_per_device = 10) {
         storage::Tablet tablet(table_schema->get_table_name(),
                                table_schema->get_measurement_names(),
                                table_schema->get_data_types(),
                                table_schema->get_column_categories());
 
-        int num_timestamp_per_device = 10;
         char* literal = new char[std::strlen("device_id") + 1];
         std::strcpy(literal, "device_id");
         String literal_str(literal, std::strlen("device_id"));
@@ -133,65 +133,72 @@ class TsFileTableReaderTest : public ::testing::Test {
         delete[] literal;
         return tablet;
     }
+
+    void test_table_model_query(uint32_t points_per_device = 10) {
+        auto table_schema = gen_table_schema(0);
+        auto tsfile_table_writer_ =
+            std::make_shared<TsFileTableWriter>(&write_file_, table_schema);
+        auto tablet = gen_tablet(table_schema, 0, 1, points_per_device);
+        ASSERT_EQ(tsfile_table_writer_->write_table(tablet), common::E_OK);
+        ASSERT_EQ(tsfile_table_writer_->flush(), common::E_OK);
+        ASSERT_EQ(tsfile_table_writer_->close(), common::E_OK);
+        storage::TsFileReader reader;
+        int ret = reader.open(file_name_);
+        ASSERT_EQ(ret, common::E_OK);
+
+        ResultSet* tmp_result_set = nullptr;
+        ret = reader.query(table_schema->get_table_name(),
+                           table_schema->get_measurement_names(), 0,
+                           1000000000000, tmp_result_set);
+        auto* table_result_set = (TableResultSet*)tmp_result_set;
+        char* literal = new char[std::strlen("device_id") + 1];
+        std::strcpy(literal, "device_id");
+        String literal_str(literal, std::strlen("device_id"));
+        bool has_next = false;
+        int64_t timestamp = 0;
+        while (IS_SUCC(table_result_set->next(has_next)) && has_next) {
+            auto column_schemas = table_schema->get_measurement_schemas();
+            for (const auto& column_schema : column_schemas) {
+                switch (column_schema->data_type_) {
+                    case TSDataType::INT64:
+                        ASSERT_EQ(table_result_set->get_value<int64_t>(
+                                      column_schema->measurement_name_),
+                                  0);
+                        break;
+                    case TSDataType::STRING:
+                        ASSERT_EQ(table_result_set
+                                      ->get_value<common::String*>(
+                                          column_schema->measurement_name_)
+                                      ->compare(literal_str),
+                                  0);
+                        break;
+                    default:
+                        break;
+                }
+            }
+            for (int i = 2; i <= 6; i++) {
+                ASSERT_EQ(
+                    table_result_set->get_value<common::String*>(i)->compare(
+                        literal_str),
+                    0);
+            }
+            for (int i = 7; i <= 11; i++) {
+                ASSERT_EQ(table_result_set->get_value<int64_t>(i), 0);
+            }
+            ASSERT_EQ(table_result_set->get_value<int64_t>(1), timestamp);
+            timestamp++;
+        }
+        ASSERT_EQ(timestamp, points_per_device);
+        reader.destroy_query_data_set(table_result_set);
+        delete[] literal;
+        ASSERT_EQ(reader.close(), common::E_OK);
+    }
 };
 
-TEST_F(TsFileTableReaderTest, TableModelQuery) {
-    auto table_schema = gen_table_schema(0);
-    auto tsfile_table_writer_ =
-        std::make_shared<TsFileTableWriter>(&write_file_, table_schema);
-    auto tablet = gen_tablet(table_schema, 0, 1);
-    ASSERT_EQ(tsfile_table_writer_->write_table(tablet), common::E_OK);
-    ASSERT_EQ(tsfile_table_writer_->flush(), common::E_OK);
-    ASSERT_EQ(tsfile_table_writer_->close(), common::E_OK);
-    storage::TsFileReader reader;
-    int ret = reader.open(file_name_);
-    ASSERT_EQ(ret, common::E_OK);
+TEST_F(TsFileTableReaderTest, TableModelQuery) { test_table_model_query(); }
 
-    ResultSet* tmp_result_set = nullptr;
-    ret = reader.query(table_schema->get_table_name(),
-                       table_schema->get_measurement_names(), 0, 1000000000000,
-                       tmp_result_set);
-    auto* table_result_set = (TableResultSet*)tmp_result_set;
-    char* literal = new char[std::strlen("device_id") + 1];
-    std::strcpy(literal, "device_id");
-    String literal_str(literal, std::strlen("device_id"));
-    bool has_next = false;
-    int64_t timestamp = 0;
-    while (IS_SUCC(table_result_set->next(has_next)) && has_next) {
-        auto column_schemas = table_schema->get_measurement_schemas();
-        for (const auto& column_schema : column_schemas) {
-            switch (column_schema->data_type_) {
-                case TSDataType::INT64:
-                    ASSERT_EQ(table_result_set->get_value<int64_t>(
-                                  column_schema->measurement_name_),
-                              0);
-                    break;
-                case TSDataType::STRING:
-                    ASSERT_EQ(table_result_set
-                                  ->get_value<common::String*>(
-                                      column_schema->measurement_name_)
-                                  ->compare(literal_str),
-                              0);
-                    break;
-                default:
-                    break;
-            }
-        }
-        for (int i = 2; i <= 6; i++) {
-            ASSERT_EQ(table_result_set->get_value<common::String*>(i)->compare(
-                          literal_str),
-                      0);
-        }
-        for (int i = 7; i <= 11; i++) {
-            ASSERT_EQ(table_result_set->get_value<int64_t>(i), 0);
-        }
-        ASSERT_EQ(table_result_set->get_value<int64_t>(1), timestamp);
-        timestamp++;
-    }
-    ASSERT_EQ(timestamp, 10);
-    reader.destroy_query_data_set(table_result_set);
-    delete[] literal;
-    ASSERT_EQ(reader.close(), common::E_OK);
+TEST_F(TsFileTableReaderTest, TableModelQueryOnePage) {
+    test_table_model_query(g_config_value_.page_writer_max_point_num_);
 }
 
 TEST_F(TsFileTableReaderTest, TableModelResultMetadata) {
@@ -216,7 +223,8 @@ TEST_F(TsFileTableReaderTest, TableModelResultMetadata) {
     ASSERT_EQ(result_set_metadata->get_column_name(1), "time");
     ASSERT_EQ(result_set_metadata->get_column_type(1), INT64);
     for (int i = 2; i <= 6; i++) {
-        ASSERT_EQ(result_set_metadata->get_column_name(i), "id" + to_string(i-2));
+        ASSERT_EQ(result_set_metadata->get_column_name(i),
+                  "id" + to_string(i - 2));
         ASSERT_EQ(result_set_metadata->get_column_type(i), TSDataType::STRING);
     }
     for (int i = 7; i <= 11; i++) {

--- a/cpp/test/reader/table_view/tsfile_reader_table_test.cc
+++ b/cpp/test/reader/table_view/tsfile_reader_table_test.cc
@@ -212,14 +212,16 @@ TEST_F(TsFileTableReaderTest, TableModelResultMetadata) {
                        tmp_result_set);
     auto* table_result_set = (TableResultSet*)tmp_result_set;
     auto result_set_metadata = table_result_set->get_metadata();
-    ASSERT_EQ(result_set_metadata->get_column_count(), 10);
-    for (int i = 0; i < 5; i++) {
-        ASSERT_EQ(result_set_metadata->get_column_name(i), "id" + to_string(i));
+    ASSERT_EQ(result_set_metadata->get_column_count(), 11);
+    ASSERT_EQ(result_set_metadata->get_column_name(1), "time");
+    ASSERT_EQ(result_set_metadata->get_column_type(1), INT64);
+    for (int i = 2; i <= 6; i++) {
+        ASSERT_EQ(result_set_metadata->get_column_name(i), "id" + to_string(i-2));
         ASSERT_EQ(result_set_metadata->get_column_type(i), TSDataType::STRING);
     }
-    for (int i = 5; i < 10; i++) {
+    for (int i = 7; i <= 11; i++) {
         ASSERT_EQ(result_set_metadata->get_column_name(i),
-                  "s" + to_string(i - 5));
+                  "s" + to_string(i - 7));
         ASSERT_EQ(result_set_metadata->get_column_type(i), TSDataType::INT64);
     }
     reader.destroy_query_data_set(table_result_set);

--- a/cpp/test/reader/tsfile_reader_test.cc
+++ b/cpp/test/reader/tsfile_reader_test.cc
@@ -143,8 +143,10 @@ TEST_F(TsFileReaderTest, ResultSetMetadata) {
     auto* qds = (QDSWithoutTimeGenerator*)tmp_qds;
 
     std::shared_ptr<ResultSetMetadata> result_set_metadata = qds->get_metadata();
-    ASSERT_EQ(result_set_metadata->get_column_type(0), data_type);
-    ASSERT_EQ(result_set_metadata->get_column_name(0),
+    ASSERT_EQ(result_set_metadata->get_column_type(1), INT64);
+    ASSERT_EQ(result_set_metadata->get_column_name(1), "time");
+    ASSERT_EQ(result_set_metadata->get_column_type(2), data_type);
+    ASSERT_EQ(result_set_metadata->get_column_name(2),
               device_path + "." + measurement_name);
     reader.destroy_query_data_set(qds);
     reader.close();


### PR DESCRIPTION
1. If no data is written after the first page is sealed, the first page will be lost.
2. The time column is missing in the ResultSetMetadata.

