### PR TITLE
fix compile on clang 17.

### DIFF
--- a/cpp/third_party/zlib-1.2.13/zutil.c
+++ b/cpp/third_party/zlib-1.2.13/zutil.c
@@ -5,10 +5,11 @@
 
 /* @(#) $Id$ */
 
-#include "zutil.h"
 #ifndef Z_SOLO
 #  include "gzguts.h"
 #endif
+#include "zutil.h"
+
 
 z_const char * const z_errmsg[10] = {
     (z_const char *)"need dictionary",     /* Z_NEED_DICT       2  */


### PR DESCRIPTION
In this pr:
1. Fix compile error with clang 17 when compiling zlib.

The issue arises because the fopen function provided by Clang is overridden in zlib's header files, leading to subsequent compilation errors. After adjusting the inclusion order of these headers, the project compiles successfully.