### PR TITLE
Remove redundant conversion in TableResultSet

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumn.java
@@ -146,7 +146,7 @@ public class BinaryColumn implements Column {
 
   @Override
   public boolean isNull(int position) {
-    return valueIsNull != null && valueIsNull[position + arrayOffset];
+    return values[position] == null || valueIsNull != null && valueIsNull[position + arrayOffset];
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumn.java
@@ -146,7 +146,8 @@ public class BinaryColumn implements Column {
 
   @Override
   public boolean isNull(int position) {
-    return values[position + arrayOffset] == null || valueIsNull != null && valueIsNull[position + arrayOffset];
+    return values[position + arrayOffset] == null
+        || valueIsNull != null && valueIsNull[position + arrayOffset];
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumn.java
@@ -146,7 +146,7 @@ public class BinaryColumn implements Column {
 
   @Override
   public boolean isNull(int position) {
-    return values[position] == null || valueIsNull != null && valueIsNull[position + arrayOffset];
+    return values[position + arrayOffset] == null || valueIsNull != null && valueIsNull[position + arrayOffset];
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/query/dataset/TableResultSet.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/query/dataset/TableResultSet.java
@@ -20,58 +20,102 @@
 package org.apache.tsfile.read.query.dataset;
 
 import org.apache.tsfile.enums.TSDataType;
-import org.apache.tsfile.read.TimeValuePair;
-import org.apache.tsfile.read.common.Field;
-import org.apache.tsfile.read.common.RowRecord;
 import org.apache.tsfile.read.common.block.TsBlock;
-import org.apache.tsfile.read.reader.IPointReader;
 import org.apache.tsfile.read.reader.block.TsBlockReader;
+import org.apache.tsfile.utils.DateUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.List;
 
 public class TableResultSet extends AbstractResultSet {
   private static final Logger LOG = LoggerFactory.getLogger(TableResultSet.class);
 
-  private TsBlockReader tsBlockReader;
-  private IPointReader tsBlockPointReader;
-  private List<String> columnNameList;
-  private List<TSDataType> dataTypeList;
+  private final TsBlockReader tsBlockReader;
+  private TsBlock currentTsBlock;
+  private int currentTsBlockIndex;
 
   public TableResultSet(
       TsBlockReader tsBlockReader, List<String> columnNameList, List<TSDataType> dataTypeList) {
     super(columnNameList, dataTypeList);
     this.tsBlockReader = tsBlockReader;
-    this.columnNameList = columnNameList;
-    this.dataTypeList = dataTypeList;
   }
 
   @Override
   public boolean next() throws IOException {
-    while ((tsBlockPointReader == null || !tsBlockPointReader.hasNextTimeValuePair())
+    while ((currentTsBlock == null || currentTsBlockIndex >= currentTsBlock.getPositionCount() - 1)
         && tsBlockReader.hasNext()) {
-      TsBlock currentTsBlock = tsBlockReader.next();
-      tsBlockPointReader = currentTsBlock.getTsBlockAlignedRowIterator();
+      currentTsBlock = tsBlockReader.next();
+      currentTsBlockIndex = -1;
     }
-    if (tsBlockPointReader == null || !tsBlockPointReader.hasNextTimeValuePair()) {
-      return false;
-    }
-    TimeValuePair currentTimeValuePair = tsBlockPointReader.nextTimeValuePair();
-    currentRow = convertTimeValuePairToRowRecord(currentTimeValuePair);
-    return true;
+    currentTsBlockIndex++;
+    return currentTsBlock != null && currentTsBlockIndex < currentTsBlock.getPositionCount();
   }
 
-  private RowRecord convertTimeValuePairToRowRecord(TimeValuePair timeValuePair) {
-    RowRecord rowRecord = new RowRecord(timeValuePair.getValues().length);
-    rowRecord.setTimestamp(timeValuePair.getTimestamp());
-    for (int i = 0; i < timeValuePair.getValues().length; i++) {
-      Object value = timeValuePair.getValues()[i];
-      rowRecord.addField(Field.getField(value, dataTypeList.get(i)));
-    }
-    return rowRecord;
+  @Override
+  public int getInt(int columnIndex) {
+    // -2 because the columnIndex starts from 1 and the first column is fixed as the time column
+    return currentTsBlock.getValueColumns()[columnIndex - 2].getInt(currentTsBlockIndex);
+  }
+
+  @Override
+  public long getLong(int columnIndex) {
+    return columnIndex == 1
+        ? currentTsBlock.getTimeByIndex(currentTsBlockIndex)
+        // -2 because the columnIndex starts from 1 and the first column is fixed as the time column
+        : currentTsBlock.getValueColumns()[columnIndex - 2].getLong(currentTsBlockIndex);
+  }
+
+  @Override
+  public double getDouble(int columnIndex) {
+    // -2 because the columnIndex starts from 1 and the first column is fixed as the time column
+    return currentTsBlock.getValueColumns()[columnIndex - 2].getDouble(currentTsBlockIndex);
+  }
+
+  @Override
+  public float getFloat(int columnIndex) {
+    // -2 because the columnIndex starts from 1 and the first column is fixed as the time column
+    return currentTsBlock.getValueColumns()[columnIndex - 2].getFloat(currentTsBlockIndex);
+  }
+
+  @Override
+  public boolean getBoolean(int columnIndex) {
+    // -2 because the columnIndex starts from 1 and the first column is fixed as the time column
+    return currentTsBlock.getValueColumns()[columnIndex - 2].getBoolean(currentTsBlockIndex);
+  }
+
+  @Override
+  public LocalDate getDate(int columnIndex) {
+    // -2 because the columnIndex starts from 1 and the first column is fixed as the time column
+    return DateUtils.parseIntToLocalDate(
+        currentTsBlock.getValueColumns()[columnIndex - 2].getInt(currentTsBlockIndex));
+  }
+
+  @Override
+  public byte[] getBinary(int columnIndex) {
+    // -2 because the columnIndex starts from 1 and the first column is fixed as the time column
+    return currentTsBlock
+        .getValueColumns()[columnIndex - 2]
+        .getBinary(currentTsBlockIndex)
+        .getValues();
+  }
+
+  @Override
+  public String getString(int columnIndex) {
+    // -2 because the columnIndex starts from 1 and the first column is fixed as the time column
+    return currentTsBlock
+        .getValueColumns()[columnIndex - 2]
+        .getBinary(currentTsBlockIndex)
+        .toString();
+  }
+
+  @Override
+  public boolean isNull(int columnIndex) {
+    // -2 because the columnIndex starts from 1 and the first column is fixed as the time column
+    return currentTsBlock.getValueColumns()[columnIndex - 2].isNull(currentTsBlockIndex);
   }
 
   @Override


### PR DESCRIPTION
Time consumption of reading a TsFile of 120MB with all floats:
5.3s -> 3.5s