### PR TITLE
Potential fix for code scanning alert no. 17: Multiplication result converted to larger type

### DIFF
--- a/cpp/test/reader/table_view/tsfile_reader_table_test.cc
+++ b/cpp/test/reader/table_view/tsfile_reader_table_test.cc
@@ -188,7 +188,7 @@ class TsFileTableReaderTest : public ::testing::Test {
             ASSERT_EQ(table_result_set->get_value<int64_t>(1), row_num % points_per_device);
             row_num++;
         }
-        ASSERT_EQ(row_num, std::min<int64_t>(points_per_device * device_num, end_time + 1));
+        ASSERT_EQ(row_num, std::min<int64_t>(static_cast<int64_t>(points_per_device) * device_num, end_time + 1));
         reader.destroy_query_data_set(table_result_set);
         delete[] literal;
         ASSERT_EQ(reader.close(), common::E_OK);


### PR DESCRIPTION
Potential fix for [https://github.com/apache/tsfile/security/code-scanning/17](https://github.com/apache/tsfile/security/code-scanning/17)

To fix the issue, we need to ensure that the multiplication is performed using a larger integer type (e.g., `int64_t`) to prevent overflow. This can be achieved by explicitly casting one of the operands to `int64_t` before the multiplication. This ensures that the multiplication is performed in 64-bit arithmetic, avoiding overflow.

The specific change will be made on line 191, where the multiplication `points_per_device * device_num` occurs. We will cast `points_per_device` to `int64_t` before the multiplication. This change does not alter the logic or functionality of the code but ensures that the multiplication is safe.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
