### PR TITLE
Add switch to disable native lz4

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/common/conf/TSFileConfig.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/conf/TSFileConfig.java
@@ -236,6 +236,8 @@ public class TSFileConfig implements Serializable {
 
   private String objectStorageTsFileOutput = "org.apache.iotdb.os.fileSystem.OSTsFileOutput";
 
+  private boolean lz4UseJni = true;
+
   /** customizedProperties, this should be empty by default. */
   private Properties customizedProperties = new Properties();
 
@@ -689,5 +691,13 @@ public class TSFileConfig implements Serializable {
 
   public void setObjectStorageTsFileOutput(String objectStorageTsFileOutput) {
     this.objectStorageTsFileOutput = objectStorageTsFileOutput;
+  }
+
+  public boolean isLz4UseJni() {
+    return lz4UseJni;
+  }
+
+  public void setLz4UseJni(boolean lz4UseJni) {
+    this.lz4UseJni = lz4UseJni;
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/common/conf/TSFileDescriptor.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/conf/TSFileDescriptor.java
@@ -85,6 +85,7 @@ public class TSFileDescriptor {
     writer.setString(conf::setEncryptFlag, "encrypt_flag");
     writer.setString(conf::setEncryptType, "encrypt_type");
     writer.setString(conf::setEncryptKeyFromPath, "encrypt_key_path");
+    writer.setBoolean(conf::setLz4UseJni, "lz4_use_jni");
   }
 
   private static class PropertiesOverWriter {
@@ -108,6 +109,10 @@ public class TSFileDescriptor {
 
     public void setString(Consumer<String> setter, String propertyKey) {
       set(setter, propertyKey, Function.identity());
+    }
+
+    public void setBoolean(Consumer<Boolean> setter, String propertyKey) {
+      set(setter, propertyKey, Boolean::parseBoolean);
     }
 
     private <T> void set(

--- a/java/tsfile/src/main/java/org/apache/tsfile/compress/ICompressor.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/compress/ICompressor.java
@@ -19,6 +19,7 @@
 
 package org.apache.tsfile.compress;
 
+import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.exception.compress.CompressionTypeNotSupportedException;
 import org.apache.tsfile.exception.compress.GZIPCompressOverflowException;
 import org.apache.tsfile.file.metadata.enums.CompressionType;
@@ -201,7 +202,10 @@ public interface ICompressor extends Serializable {
      * This instance should be cached to avoid performance problem. See:
      * https://github.com/lz4/lz4-java/issues/152 and https://github.com/apache/spark/pull/24905
      */
-    private static final LZ4Factory factory = LZ4Factory.fastestInstance();
+    private static final LZ4Factory factory =
+        TSFileDescriptor.getInstance().getConfig().isLz4UseJni()
+            ? LZ4Factory.fastestInstance()
+            : LZ4Factory.safeInstance();
 
     private static final net.jpountz.lz4.LZ4Compressor compressor = factory.fastCompressor();
 


### PR DESCRIPTION
By default, we use the native (JNI) LZ4 implementation, which is expected to be faster than the Java implementation.
However, the JNI mechanism has a drawback: native calls will hold the GCLock, which prevents GCs.
Consequently, if there are many parallel compression tasks, a typical scenario in IoTDB, GCs will be constantly blocked by native calls and can only run effectively for a short time.
OOM occurs when the CPU is not powerful enough to collect enough garbage during the limited GC time.

In this PR, the new configuration item "lz4_use_jni" allows the user to choose to adjust the LZ4 implementation.
When it is true (by default), TsFile will use the native implementation. Otherwise, it falls back to the Java implementation.
Although some performance loss is expected due to the less efficient Java implementation, reducing the chance of OOM when the GC pressure is high will reduce the need to hold GCLock. 