### PR TITLE
fix duplicate column name

### DIFF
--- a/cpp/src/common/schema.h
+++ b/cpp/src/common/schema.h
@@ -199,18 +199,22 @@ class TableSchema {
                 const std::vector<common::ColumnSchema> &column_schemas)
         : table_name_(table_name) {
         to_lowercase_inplace(table_name_);
-        for (const common::ColumnSchema &column_schema : column_schemas) {
+        for (int i = 0; i < column_schemas.size(); ++i) {
+            auto &column_schema = column_schemas[i];
+            auto measurement_name = to_lower(column_schema.column_name_);
             column_schemas_.emplace_back(std::make_shared<MeasurementSchema>(
-                column_schema.get_column_name(),
-                column_schema.get_data_type()));
+                measurement_name,
+                column_schema.get_data_type(),
+                column_schema.get_encoding(),
+                column_schema.get_compression()));
             column_categories_.emplace_back(
                 column_schema.get_column_category());
-        }
-        int idx = 0;
-        for (const auto &measurement_schema : column_schemas_) {
-            to_lowercase_inplace(measurement_schema->measurement_name_);
             column_pos_index_.insert(
-                std::make_pair(measurement_schema->measurement_name_, idx++));
+                std::make_pair(measurement_name, i));
+        }
+        if (column_categories_.size() != column_pos_index_.size()) {
+            throw std::invalid_argument("Each column name in the table "
+                                        "should be unique(case insensitive).");
         }
     }
 
@@ -219,17 +223,19 @@ class TableSchema {
                 const std::vector<common::ColumnCategory> &column_categories)
         : table_name_(table_name), column_categories_(column_categories) {
         to_lowercase_inplace(table_name_);
-        for (const auto column_schema : column_schemas) {
+        for (int i = 0; i < column_schemas.size(); ++i) {
+            auto &column_schema = column_schemas[i];
             if (column_schema != nullptr) {
                 column_schemas_.emplace_back(
                     std::shared_ptr<MeasurementSchema>(column_schema));
+                auto measurement_name = to_lower(column_schema->measurement_name_);
+                column_pos_index_.insert(
+                    std::make_pair(measurement_name, i));
             }
         }
-        int idx = 0;
-        for (const auto &measurement_schema : column_schemas_) {
-            to_lowercase_inplace(measurement_schema->measurement_name_);
-            column_pos_index_.insert(
-                std::make_pair(measurement_schema->measurement_name_, idx++));
+        if (column_categories_.size() != column_pos_index_.size()) {
+            throw std::invalid_argument("Each column name in the table "
+                                        "should be unique(case insensitive).");
         }
     }
 

--- a/cpp/test/writer/table_view/tsfile_writer_table_test.cc
+++ b/cpp/test/writer/table_view/tsfile_writer_table_test.cc
@@ -32,7 +32,7 @@ using namespace storage;
 using namespace common;
 
 class TsFileWriterTableTest : public ::testing::Test {
-   protected:
+protected:
     void SetUp() override {
         libtsfile_init();
         file_name_ = std::string("tsfile_writer_table_test_") +
@@ -49,7 +49,7 @@ class TsFileWriterTableTest : public ::testing::Test {
     std::string file_name_;
     WriteFile write_file_;
 
-   public:
+public:
     static std::string generate_random_string(int length) {
         std::random_device rd;
         std::mt19937 gen(rd());
@@ -137,6 +137,15 @@ TEST_F(TsFileWriterTableTest, WriteTableTest) {
     ASSERT_EQ(tsfile_table_writer_->flush(), common::E_OK);
     ASSERT_EQ(tsfile_table_writer_->close(), common::E_OK);
     delete table_schema;
+}
+
+TEST_F(TsFileWriterTableTest, TableSchemaDupColNameTest) {
+    ColumnSchema column_schema("id", STRING, ColumnCategory::TAG);
+    std::vector<ColumnSchema> column_schemas = {column_schema, column_schema};
+    EXPECT_THROW(
+        TableSchema table("table", column_schemas),
+        std::invalid_argument
+        );
 }
 
 TEST_F(TsFileWriterTableTest, WriteTableTestMultiFlush) {
@@ -292,7 +301,7 @@ TEST_F(TsFileWriterTableTest, WriteAndReadSimple) {
         cur_line++;
         int64_t timestamp = table_result_set->get_value<int64_t>("time");
         ASSERT_EQ(table_result_set->get_value<common::String*>("device")
-                      ->to_std_string(),
+                  ->to_std_string(),
                   "device" + to_string(timestamp));
         ASSERT_EQ(table_result_set->get_value<double>("value"),
                   timestamp * 1.1);


### PR DESCRIPTION
Duplicate column names in table model are prohibited (case-sensitive)