### PR TITLE
Use spotless to format CPP code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,226 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: NextLine
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+PPIndentWidth:   -1
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: pb
+    BasedOnStyle:    google
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Auto
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Generate code coverage reports
         run: |
           sudo apt-get install lcov
-          ./mvnw -B -P with-java,with-cpp,with-code-coverage clean verify
+          ./mvnw -B -P with-java,with-cpp,with-code-coverage clean verify -Dspotless.skip=true
           lcov --capture --directory cpp/target/build/test --output-file cpp/target/build/test/coverage.info
           lcov --remove cpp/target/build/test/coverage.info '*/tsfile/cpp/test/*' --output-file cpp/target/build/test/coverage_filtered.info
           genhtml cpp/target/build/test/coverage_filtered.info --output-directory cpp/target/build/test/coverage_report

--- a/.github/workflows/unit-test-cpp.yml
+++ b/.github/workflows/unit-test-cpp.yml
@@ -108,7 +108,7 @@ jobs:
         shell: bash
         run: |
           if [[ "$RUNNER_OS" == "Linux" ]]; then
-            sudo apt-get install -y clang-format-10
+            sudo apt-get install -y clang-format-18
           elif [[ "$RUNNER_OS" == "Windows" ]]; then
             choco install llvm --version 20.1.7 
           else

--- a/.github/workflows/unit-test-cpp.yml
+++ b/.github/workflows/unit-test-cpp.yml
@@ -108,11 +108,13 @@ jobs:
         shell: bash
         run: |
           if [[ "$RUNNER_OS" == "Linux" ]]; then
-            sudo update-alternatives --set clang-format /usr/lib/llvm-17/bin/clang-format
+            sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-17 100
+            sudo update-alternatives --set clang-format /usr/bin/clang-format-17
           elif [[ "$RUNNER_OS" == "Windows" ]]; then
-            choco install llvm --version 17.0.6
+            choco install llvm --version 17.0.6 --force
           else
             brew install llvm@17
+            ln -sf $(brew --prefix llvm@17)/bin/clang-format /opt/homebrew/bin/clang-format
           fi
 
       # Run the actual maven build including all tests.

--- a/.github/workflows/unit-test-cpp.yml
+++ b/.github/workflows/unit-test-cpp.yml
@@ -105,7 +105,6 @@ jobs:
             }
 
       - name: Install clang-format
-        id: platform_suffix
         run: |
           if [[ "$RUNNER_OS" == "Linux" ]]; then
             apt install clang-format-10

--- a/.github/workflows/unit-test-cpp.yml
+++ b/.github/workflows/unit-test-cpp.yml
@@ -106,19 +106,14 @@ jobs:
 
       - name: Install clang-format
         id: platform_suffix
-        uses: actions/github-script@v7.0.1
-        env:
-          OS: ${{ matrix.os }}
-        with:
-          script: |
-            const { OS } = process.env
-            if (OS.includes("windows")) {
-              choco install llvm --version 20.1.7 
-            } else (OS.includes("mac")) {
-              brew install clang-format
-            } else {
-              apt install clang-format-10
-            }
+        run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            apt install clang-format-10
+          elif [[ "$RUNNER_OS" == "Windows" ]]; then
+            choco install llvm --version 20.1.7 
+          else
+            brew install clang-format
+          fi
 
       # Run the actual maven build including all tests.
       - name: Build and test with Maven

--- a/.github/workflows/unit-test-cpp.yml
+++ b/.github/workflows/unit-test-cpp.yml
@@ -104,6 +104,22 @@ jobs:
               core.setOutput('platform_suffix', ``)
             }
 
+      - name: Install clang-format
+        id: platform_suffix
+        uses: actions/github-script@v7.0.1
+        env:
+          OS: ${{ matrix.os }}
+        with:
+          script: |
+            const { OS } = process.env
+            if (OS.includes("windows")) {
+              choco install llvm --version 20.1.7 
+            } else (OS.includes("mac")) {
+              brew install clang-format
+            } else {
+              apt install clang-format-10
+            }
+
       # Run the actual maven build including all tests.
       - name: Build and test with Maven
         shell: bash

--- a/.github/workflows/unit-test-cpp.yml
+++ b/.github/workflows/unit-test-cpp.yml
@@ -105,9 +105,10 @@ jobs:
             }
 
       - name: Install clang-format
+        shell: bash
         run: |
           if [[ "$RUNNER_OS" == "Linux" ]]; then
-            apt install clang-format-10
+            sudo apt-get install -y clang-format-10
           elif [[ "$RUNNER_OS" == "Windows" ]]; then
             choco install llvm --version 20.1.7 
           else

--- a/.github/workflows/unit-test-cpp.yml
+++ b/.github/workflows/unit-test-cpp.yml
@@ -108,11 +108,11 @@ jobs:
         shell: bash
         run: |
           if [[ "$RUNNER_OS" == "Linux" ]]; then
-            sudo apt-get install -y clang-format-18
+            sudo update-alternatives --set clang-format /usr/lib/llvm-17/bin/clang-format
           elif [[ "$RUNNER_OS" == "Windows" ]]; then
-            choco install llvm --version 20.1.7 
+            choco install llvm --version 17.0.6
           else
-            brew install clang-format
+            brew install llvm@17
           fi
 
       # Run the actual maven build including all tests.

--- a/.github/workflows/unit-test-python.yml
+++ b/.github/workflows/unit-test-python.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Build and test with Maven
         shell: bash
         run: |
-          ./mvnw${{ steps.platform_suffix.outputs.platform_suffix }} -P with-python -Denable.asan=OFF -Dbuild.type=Release clean verify
+          ./mvnw${{ steps.platform_suffix.outputs.platform_suffix }} -P with-python -Denable.asan=OFF -Dbuild.type=Release clean verify -spotless.skip=true
 
       - name: Upload whl Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/unit-test-python.yml
+++ b/.github/workflows/unit-test-python.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Build and test with Maven
         shell: bash
         run: |
-          ./mvnw${{ steps.platform_suffix.outputs.platform_suffix }} -P with-python -Denable.asan=OFF -Dbuild.type=Release clean verify -spotless.skip=true
+          ./mvnw${{ steps.platform_suffix.outputs.platform_suffix }} -P with-python -Denable.asan=OFF -Dbuild.type=Release clean verify -Dspotless.skip=true
 
       - name: Upload whl Artifact
         uses: actions/upload-artifact@v4

--- a/cpp/examples/c_examples/demo_read.c
+++ b/cpp/examples/c_examples/demo_read.c
@@ -25,7 +25,6 @@
 
 // This example shows you how to read tsfile.
 ERRNO read_tsfile() {
-
     ERRNO code = 0;
     char* table_name = "table1";
 
@@ -46,7 +45,8 @@ ERRNO read_tsfile() {
     int column_num = tsfile_result_set_metadata_get_column_num(metadata);
 
     for (int i = 1; i <= column_num; i++) {
-        printf("column:%s, datatype:%d\n", tsfile_result_set_metadata_get_column_name(metadata, i),
+        printf("column:%s, datatype:%d\n",
+               tsfile_result_set_metadata_get_column_name(metadata, i),
                tsfile_result_set_metadata_get_data_type(metadata, i));
     }
 
@@ -62,8 +62,9 @@ ERRNO read_tsfile() {
             } else {
                 switch (tsfile_result_set_metadata_get_data_type(metadata, i)) {
                     case TS_DATATYPE_BOOLEAN:
-                        printf("%d\n", tsfile_result_set_get_value_by_index_bool(
-                                         ret, i));
+                        printf(
+                            "%d\n",
+                            tsfile_result_set_get_value_by_index_bool(ret, i));
                         break;
                     case TS_DATATYPE_INT32:
                         printf("%d\n",
@@ -76,8 +77,9 @@ ERRNO read_tsfile() {
                                                                             i));
                         break;
                     case TS_DATATYPE_FLOAT:
-                        printf("%f\n", tsfile_result_set_get_value_by_index_float(
-                                         ret, i));
+                        printf(
+                            "%f\n",
+                            tsfile_result_set_get_value_by_index_float(ret, i));
                         break;
                     case TS_DATATYPE_DOUBLE:
                         printf("%lf\n",

--- a/cpp/examples/c_examples/demo_write.c
+++ b/cpp/examples/c_examples/demo_write.c
@@ -17,9 +17,9 @@
  * under the License.
  */
 
-#include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "c_examples.h"
@@ -37,16 +37,16 @@ ERRNO write_tsfile() {
         (ColumnSchema*)malloc(sizeof(ColumnSchema) * 3);
     table_schema.column_schemas[0] =
         (ColumnSchema){.column_name = strdup("id1"),
-                     .data_type = TS_DATATYPE_STRING,
-                     .column_category = TAG};
+                       .data_type = TS_DATATYPE_STRING,
+                       .column_category = TAG};
     table_schema.column_schemas[1] =
         (ColumnSchema){.column_name = strdup("id2"),
-                     .data_type = TS_DATATYPE_STRING,
-                     .column_category = TAG};
+                       .data_type = TS_DATATYPE_STRING,
+                       .column_category = TAG};
     table_schema.column_schemas[2] =
         (ColumnSchema){.column_name = strdup("s1"),
-                     .data_type = TS_DATATYPE_INT32,
-                     .column_category = FIELD};
+                       .data_type = TS_DATATYPE_INT32,
+                       .column_category = FIELD};
 
     remove("test_c.tsfile");
     // Create a file with specify path to write tsfile.

--- a/cpp/pom.xml
+++ b/cpp/pom.xml
@@ -148,6 +148,45 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.version}</version>
+                <configuration>
+                    <cpp>
+                        <includes>
+                            <!-- You have to set the target manually -->
+                            <include>bench_mark/**/*.h</include>
+                            <include>bench_mark/**/*.cc</include>
+                            <include>examples/**/*.h</include>
+                            <include>examples/**/*.c</include>
+                            <include>examples/**/*.cc</include>
+                            <include>src/**/*.h</include>
+                            <include>src/**/*.c</include>
+                            <include>src/**/*.cc</include>
+                            <include>test/**/*.h</include>
+                            <include>test/**/*.c</include>
+                            <include>test/**/*.cc</include>
+                        </includes>
+                        <clangFormat>
+                            <!-- optional: if clang-format isn't in your path -->
+                            <version>${clang.format.version}</version>
+                            <style>file</style>
+                            <!-- optional: can be LLVM, Google, Chromium, Mozilla, WebKit -->
+                        </clangFormat>
+                    </cpp>
+                    <lineEndings>UNIX</lineEndings>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>spotless-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/cpp/pom.xml
+++ b/cpp/pom.xml
@@ -176,6 +176,7 @@
                         </clangFormat>
                     </cpp>
                     <lineEndings>UNIX</lineEndings>
+                    <skip>${spotless.skip}</skip>
                 </configuration>
                 <executions>
                     <execution>

--- a/cpp/pom.xml
+++ b/cpp/pom.xml
@@ -148,46 +148,6 @@
                     </dependency>
                 </dependencies>
             </plugin>
-            <plugin>
-                <groupId>com.diffplug.spotless</groupId>
-                <artifactId>spotless-maven-plugin</artifactId>
-                <version>${spotless.version}</version>
-                <configuration>
-                    <cpp>
-                        <includes>
-                            <!-- You have to set the target manually -->
-                            <include>bench_mark/**/*.h</include>
-                            <include>bench_mark/**/*.cc</include>
-                            <include>examples/**/*.h</include>
-                            <include>examples/**/*.c</include>
-                            <include>examples/**/*.cc</include>
-                            <include>src/**/*.h</include>
-                            <include>src/**/*.c</include>
-                            <include>src/**/*.cc</include>
-                            <include>test/**/*.h</include>
-                            <include>test/**/*.c</include>
-                            <include>test/**/*.cc</include>
-                        </includes>
-                        <clangFormat>
-                            <!-- optional: if clang-format isn't in your path -->
-                            <version>${clang.format.version}</version>
-                            <style>file</style>
-                            <!-- optional: can be LLVM, Google, Chromium, Mozilla, WebKit -->
-                        </clangFormat>
-                    </cpp>
-                    <lineEndings>UNIX</lineEndings>
-                    <skip>${spotless.skip}</skip>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>spotless-check</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <phase>validate</phase>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -262,6 +222,57 @@
             <properties>
                 <coverage.enabled>ON</coverage.enabled>
             </properties>
+        </profile>
+        <profile>
+            <id>.java-9-and-above</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.diffplug.spotless</groupId>
+                        <artifactId>spotless-maven-plugin</artifactId>
+                        <version>${spotless.version}</version>
+                        <configuration>
+                            <cpp>
+                                <includes>
+                                    <!-- You have to set the target manually -->
+                                    <include>bench_mark/**/*.h</include>
+                                    <include>bench_mark/**/*.cc</include>
+                                    <include>examples/**/*.h</include>
+                                    <include>examples/**/*.c</include>
+                                    <include>examples/**/*.cc</include>
+                                    <include>src/**/*.h</include>
+                                    <include>src/**/*.c</include>
+                                    <include>src/**/*.cc</include>
+                                    <include>test/**/*.h</include>
+                                    <include>test/**/*.c</include>
+                                    <include>test/**/*.cc</include>
+                                </includes>
+                                <clangFormat>
+                                    <!--pathToExe>/path/to/buf</pathToExe-->
+                                    <!-- optional: if clang-format isn't in your path -->
+                                    <version>${clang.format.version}</version>
+                                    <style>file</style>
+                                    <!-- optional: can be LLVM, Google, Chromium, Mozilla, WebKit -->
+                                </clangFormat>
+                            </cpp>
+                            <lineEndings>UNIX</lineEndings>
+                            <skip>${spotless.skip}</skip>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>spotless-check</id>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                                <phase>validate</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/cpp/src/common/constant/tsfile_constant.h
+++ b/cpp/src/common/constant/tsfile_constant.h
@@ -19,33 +19,33 @@
 
 #ifndef COMMON_CONSTANT_TSFILE_CONSTANT_H_
 #define COMMON_CONSTANT_TSFILE_CONSTANT_H_
-#include <string>
 #include <regex>
+#include <string>
 
-namespace storage
-{
-    static const std::string TSFILE_SUFFIX = ".tsfile";
-    static const std::string TSFILE_HOME = "TSFILE_HOME";
-    static const std::string TSFILE_CONF = "TSFILE_CONF";
-    static const std::string PATH_ROOT = "root";
-    static const std::string TMP_SUFFIX = "tmp";
-    static const std::string PATH_SEPARATOR = ".";
-    static const char PATH_SEPARATOR_CHAR = '.';
-    static const std::string PATH_SEPARATER_NO_REGEX = "\\.";
-    static const char DOUBLE_QUOTE = '"';
-    static const char BACK_QUOTE = '`';
-    static const std::string BACK_QUOTE_STRING = "`";
-    static const std::string DOUBLE_BACK_QUOTE_STRING = "``";
- 
-    static const unsigned char TIME_COLUMN_MASK = 0x80;
-    static const unsigned char VALUE_COLUMN_MASK = 0x40;
+namespace storage {
+static const std::string TSFILE_SUFFIX = ".tsfile";
+static const std::string TSFILE_HOME = "TSFILE_HOME";
+static const std::string TSFILE_CONF = "TSFILE_CONF";
+static const std::string PATH_ROOT = "root";
+static const std::string TMP_SUFFIX = "tmp";
+static const std::string PATH_SEPARATOR = ".";
+static const char PATH_SEPARATOR_CHAR = '.';
+static const std::string PATH_SEPARATER_NO_REGEX = "\\.";
+static const char DOUBLE_QUOTE = '"';
+static const char BACK_QUOTE = '`';
+static const std::string BACK_QUOTE_STRING = "`";
+static const std::string DOUBLE_BACK_QUOTE_STRING = "``";
 
-    static const std::string TIME_COLUMN_ID = "";
-    static const int NO_STR_TO_READ = -1;
- 
-    static const std::regex IDENTIFIER_PATTERN("([a-zA-Z0-9_\\u2E80-\\u9FFF]+)");
-    static const std::regex NODE_NAME_PATTERN("(\\*{0,2}[a-zA-Z0-9_\\u2E80-\\u9FFF]+\\*{0,2})");
-    static const int DEFAULT_SEGMENT_NUM_FOR_TABLE_NAME = 3;
-} // namespace storage
+static const unsigned char TIME_COLUMN_MASK = 0x80;
+static const unsigned char VALUE_COLUMN_MASK = 0x40;
+
+static const std::string TIME_COLUMN_ID = "";
+static const int NO_STR_TO_READ = -1;
+
+static const std::regex IDENTIFIER_PATTERN("([a-zA-Z0-9_\\u2E80-\\u9FFF]+)");
+static const std::regex NODE_NAME_PATTERN(
+    "(\\*{0,2}[a-zA-Z0-9_\\u2E80-\\u9FFF]+\\*{0,2})");
+static const int DEFAULT_SEGMENT_NUM_FOR_TABLE_NAME = 3;
+}  // namespace storage
 
 #endif

--- a/cpp/src/common/container/hash_table.h
+++ b/cpp/src/common/container/hash_table.h
@@ -744,15 +744,17 @@ class HashTable {
                 if ((*table_[i])[j].get_valid()) {
                     printf("----(%ld)segment id is %ld, bucket id is %ld----\n",
                            bucket_num++, i, j);
-                    std::cout << "|      " << "key is "
-                              << (*table_[i])[j].get_key() << ", value is "
-                              << (*table_[i])[j].get_value() << ", rehashid is "
+                    std::cout << "|      "
+                              << "key is " << (*table_[i])[j].get_key()
+                              << ", value is " << (*table_[i])[j].get_value()
+                              << ", rehashid is "
                               << (int)(*table_[i])[j].get_rehashid()
                               << std::endl;
                     HashNode<KeyType, ValueType>* entry =
                         ((*table_[i])[j]).get_next();
                     while (entry != nullptr) {
-                        std::cout << "|      " << "key is " << entry->get_key()
+                        std::cout << "|      "
+                                  << "key is " << entry->get_key()
                                   << ", value is " << entry->get_value()
                                   << ", rehashid is "
                                   << (int)entry->get_rehashid() << std::endl;

--- a/cpp/src/common/row_record.h
+++ b/cpp/src/common/row_record.h
@@ -53,8 +53,8 @@ struct Field {
                is_type(common::NULL_TYPE);
     }
 
-    void set_value(common::TSDataType type, void* val, size_t len,
-                                common::PageArena &pa) {
+    void set_value(common::TSDataType type, void *val, size_t len,
+                   common::PageArena &pa) {
         if (val == nullptr) {
             type_ = common::NULL_TYPE;
             return;
@@ -83,7 +83,8 @@ struct Field {
             }
             case common::STRING: {
                 value_.strval_ = new common::String();
-                value_.strval_->dup_from(std::string(static_cast<char*>(val), len), pa);
+                value_.strval_->dup_from(
+                    std::string(static_cast<char *>(val), len), pa);
                 break;
             }
             // case common::TEXT: {

--- a/cpp/src/common/tsblock/tsblock.cc
+++ b/cpp/src/common/tsblock/tsblock.cc
@@ -246,7 +246,8 @@ std::string RowIterator::debug_string() {
         if (is_null) {
             out << "NULL";
         } else {
-            ColumnSchema &col_schema = tsblock_->tuple_desc_->get_column_schema(i);
+            ColumnSchema &col_schema =
+                tsblock_->tuple_desc_->get_column_schema(i);
             switch (col_schema.data_type_) {
                 case common::BOOLEAN: {
                     out << *static_cast<bool *>(value);

--- a/cpp/src/common/tsfile_common.h
+++ b/cpp/src/common/tsfile_common.h
@@ -1004,7 +1004,7 @@ struct MetaIndexNode {
             if (IS_NULL(entry_buf)) {
                 return common::E_OOM;
             }
-            auto* entry_ptr = new(entry_buf) DeviceMetaIndexEntry();
+            auto *entry_ptr = new (entry_buf) DeviceMetaIndexEntry();
             auto entry = std::shared_ptr<DeviceMetaIndexEntry>(
                 entry_ptr, DeviceMetaIndexEntry::self_deleter);
             if (RET_FAIL(entry->deserialize_from(in, pa_))) {

--- a/cpp/src/compress/gzip_compressor.cc
+++ b/cpp/src/compress/gzip_compressor.cc
@@ -19,271 +19,248 @@
 
 #include "gzip_compressor.h"
 
-using  namespace common;
+using namespace common;
 
+namespace storage {
 
+GzipCompressor::GzipCompressor() : compressed_buf() { zstream_valid_ = false; }
 
-namespace storage
-{
+GzipCompressor::~GzipCompressor() { end_zstream(); }
 
-GzipCompressor::GzipCompressor() : compressed_buf()
-{
-  zstream_valid_ = false;
+int GzipCompressor::reset() {
+    int ret = E_OK;
+    if (RET_FAIL(end_zstream())) {
+    } else if (RET_FAIL(init_zstream())) {
+    }
+    return ret;
 }
 
-GzipCompressor::~GzipCompressor()
-{
-  end_zstream();
-}
+int GzipCompressor::init_zstream() {
+    if (zstream_valid_) {
+        return E_OK;
+    }
+    compress_stream_.zalloc = (alloc_func)0;  // Z_NULL
+    compress_stream_.zfree = (free_func)0;
+    compress_stream_.opaque = (voidpf)0;
+    compress_stream_.next_in = 0;
+    compress_stream_.avail_in = 0;
+    compress_stream_.next_out = 0;
+    compress_stream_.avail_out = 0;
 
-int GzipCompressor::reset()
-{
-  int ret = E_OK;
-  if (RET_FAIL(end_zstream())) {
-  } else if (RET_FAIL(init_zstream())) {
-  }
-  return ret;
-}
+    memset(compressed_buf, 0, DEFLATE_BUFFER_SIZE);
 
-int GzipCompressor::init_zstream()
-{
-  if (zstream_valid_) {
+    if (deflateInit2(&compress_stream_, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 31,
+                     8, Z_DEFAULT_STRATEGY) != Z_OK) {
+        // log_err("gzip deflateInit2 failed");
+        return E_COMPRESS_ERR;
+    }
+    zstream_valid_ = true;
     return E_OK;
-  }
-  compress_stream_.zalloc = (alloc_func)0;  // Z_NULL
-  compress_stream_.zfree = (free_func)0;
-  compress_stream_.opaque = (voidpf)0;
-  compress_stream_.next_in = 0;
-  compress_stream_.avail_in = 0;
-  compress_stream_.next_out = 0;
-  compress_stream_.avail_out = 0;
-
-  memset(compressed_buf, 0, DEFLATE_BUFFER_SIZE);
-
-  if (deflateInit2(&compress_stream_,
-                   Z_DEFAULT_COMPRESSION,
-                   Z_DEFLATED,
-                   31,
-                   8,
-                   Z_DEFAULT_STRATEGY) != Z_OK) {
-    //log_err("gzip deflateInit2 failed");
-    return E_COMPRESS_ERR;
-  }
-  zstream_valid_ = true;
-  return E_OK;
 }
 
-int GzipCompressor::end_zstream()
-{
-  if (!zstream_valid_) {
+int GzipCompressor::end_zstream() {
+    if (!zstream_valid_) {
+        return E_OK;
+    }
+    if (deflateEnd(&compress_stream_) != Z_OK) {
+        // log_err("deflateEnd failed");
+        return E_COMPRESS_ERR;
+    }
+    zstream_valid_ = false;
     return E_OK;
-  }
-  if(deflateEnd(&compress_stream_) != Z_OK) {
-    //log_err("deflateEnd failed");
-    return E_COMPRESS_ERR;
-  }
-  zstream_valid_ = false;
-  return E_OK;
 }
 
 int GzipCompressor::compress_into_bytestream(char *uncompressed_buf,
                                              uint32_t uncompressed_buf_len,
-                                             ByteStream &out)
-{
-  int ret = Z_OK;
+                                             ByteStream &out) {
+    int ret = Z_OK;
 
-  compress_stream_.next_in = (Bytef *)uncompressed_buf;
-  compress_stream_.avail_in = uncompressed_buf_len;
-  compress_stream_.next_out = (Bytef *)compressed_buf;
-  compress_stream_.avail_out = DEFLATE_BUFFER_SIZE;
+    compress_stream_.next_in = (Bytef *)uncompressed_buf;
+    compress_stream_.avail_in = uncompressed_buf_len;
+    compress_stream_.next_out = (Bytef *)compressed_buf;
+    compress_stream_.avail_out = DEFLATE_BUFFER_SIZE;
 
-  if (uncompressed_buf == nullptr || uncompressed_buf_len == 0) {  // no more
-    if (compress_stream_.next_out) {
-      while (ret != Z_STREAM_END) {
-        ret = deflate(&compress_stream_, Z_FINISH);
-        if(ret != Z_OK && ret != Z_STREAM_END) {
-          //log_err("deflate failed");
-          return E_COMPRESS_ERR;
+    if (uncompressed_buf == nullptr || uncompressed_buf_len == 0) {  // no more
+        if (compress_stream_.next_out) {
+            while (ret != Z_STREAM_END) {
+                ret = deflate(&compress_stream_, Z_FINISH);
+                if (ret != Z_OK && ret != Z_STREAM_END) {
+                    // log_err("deflate failed");
+                    return E_COMPRESS_ERR;
+                }
+                out.write_buf(compressed_buf,
+                              DEFLATE_BUFFER_SIZE - compress_stream_.avail_out);
+                compress_stream_.next_out = (Bytef *)compressed_buf;
+                compress_stream_.avail_out = DEFLATE_BUFFER_SIZE;
+            }
         }
-        out.write_buf(compressed_buf, DEFLATE_BUFFER_SIZE -
-        compress_stream_.avail_out); compress_stream_.next_out = (Bytef
-        *)compressed_buf; compress_stream_.avail_out = DEFLATE_BUFFER_SIZE;
-      }
+        return E_OK;
     }
+
+    for (;;) {
+        ret = deflate(&compress_stream_, Z_NO_FLUSH);
+        if (ret != Z_OK) {
+            // log_err("deflate failed");
+            return E_COMPRESS_ERR;
+        }
+
+        if (compress_stream_.avail_in == 0) {  // current input data are all
+            out.write_buf(compressed_buf,
+                          DEFLATE_BUFFER_SIZE - compress_stream_.avail_out);
+            compress_stream_.next_out = (Bytef *)compressed_buf;
+            compress_stream_.avail_out = DEFLATE_BUFFER_SIZE;
+            break;
+        } else if (compress_stream_.avail_out ==
+                   0) {  // no more space for output
+            out.write_buf(compressed_buf, DEFLATE_BUFFER_SIZE);
+            compress_stream_.next_out = (Bytef *)compressed_buf;
+            compress_stream_.avail_out = DEFLATE_BUFFER_SIZE;
+        }
+    }
+
     return E_OK;
-  }
-
-  for (;;) {
-    ret = deflate(&compress_stream_, Z_NO_FLUSH);
-    if (ret != Z_OK) {
-      //log_err("deflate failed");
-      return E_COMPRESS_ERR;
-    }
-
-    if (compress_stream_.avail_in == 0) {  // current input data are all
-      out.write_buf(compressed_buf, DEFLATE_BUFFER_SIZE -
-      compress_stream_.avail_out); compress_stream_.next_out = (Bytef
-      *)compressed_buf; compress_stream_.avail_out = DEFLATE_BUFFER_SIZE;
-      break;
-    }
-    else if (compress_stream_.avail_out == 0) {  // no more space for output
-      out.write_buf(compressed_buf, DEFLATE_BUFFER_SIZE);
-      compress_stream_.next_out = (Bytef *)compressed_buf;
-      compress_stream_.avail_out = DEFLATE_BUFFER_SIZE;
-    }
-  }
-
-  return E_OK;
 }
 
 int GzipCompressor::compress(char *uncompressed_buf,
                              uint32_t uncompressed_buf_len,
                              char *&compressed_buf,
-                             uint32_t &compressed_buf_len)
-{
-  int ret = E_OK;
-  ByteStream out(DEFLATE_BUFFER_SIZE, MOD_COMPRESSOR_OBJ);
-  if (RET_FAIL(compress_into_bytestream(uncompressed_buf,
-  uncompressed_buf_len, out))) {
+                             uint32_t &compressed_buf_len) {
+    int ret = E_OK;
+    ByteStream out(DEFLATE_BUFFER_SIZE, MOD_COMPRESSOR_OBJ);
+    if (RET_FAIL(compress_into_bytestream(uncompressed_buf,
+                                          uncompressed_buf_len, out))) {
+        return ret;
+    }
+    if (RET_FAIL(compress_into_bytestream(nullptr, 0, out))) {
+        return ret;
+    }
+    compressed_buf = get_bytes_from_bytestream(out);
+    compressed_buf_len = out.total_size();
+    out.destroy();
     return ret;
-  }
-  if (RET_FAIL(compress_into_bytestream(nullptr, 0, out))) {
+}
+
+GzipDeCompressor::GzipDeCompressor() : decompressed_buf() {
+    zstream_valid_ = false;
+}
+
+GzipDeCompressor::~GzipDeCompressor() { end_zstream(); }
+
+int GzipDeCompressor::init_zstream() {
+    if (zstream_valid_) {
+        return E_OK;
+    }
+    decompress_stream_.zalloc = (alloc_func)0;  // Z_NULL
+    decompress_stream_.zfree = (free_func)0;
+    decompress_stream_.opaque = (voidpf)0;
+    decompress_stream_.next_in = 0;
+    decompress_stream_.avail_in = 0;
+    decompress_stream_.next_out = 0;
+    decompress_stream_.avail_out = 0;
+
+    memset(decompressed_buf, 0, INFLATE_BUFFER_SIZE);
+
+    if (inflateInit2(&decompress_stream_, 31) != Z_OK) {
+        // log_err("inflateInit2 failed");
+        return E_COMPRESS_ERR;
+    }
+    zstream_valid_ = true;
+    return E_OK;
+}
+
+int GzipDeCompressor::end_zstream() {
+    if (!zstream_valid_) {
+        return E_OK;
+    }
+    if (inflateEnd(&decompress_stream_) != Z_OK) {
+        // log_err("inflateEnd failed");
+        return E_COMPRESS_ERR;
+    }
+    zstream_valid_ = false;
+    return E_OK;
+}
+
+int GzipDeCompressor::reset() {
+    int ret = E_OK;
+    if (RET_FAIL(end_zstream())) {
+    } else if (RET_FAIL(init_zstream())) {
+    }
     return ret;
-  }
-  compressed_buf = get_bytes_from_bytestream(out);
-  compressed_buf_len = out.total_size();
-  out.destroy();
-  return ret;
-}
-
-GzipDeCompressor::GzipDeCompressor() : decompressed_buf()
-{
-  zstream_valid_ = false;
-}
-
-GzipDeCompressor::~GzipDeCompressor()
-{
-  end_zstream();
-}
-
-int GzipDeCompressor::init_zstream()
-{
-  if (zstream_valid_) {
-    return E_OK;
-  }
-  decompress_stream_.zalloc = (alloc_func)0;  // Z_NULL
-  decompress_stream_.zfree = (free_func)0;
-  decompress_stream_.opaque = (voidpf)0;
-  decompress_stream_.next_in = 0;
-  decompress_stream_.avail_in = 0;
-  decompress_stream_.next_out = 0;
-  decompress_stream_.avail_out = 0;
-
-  memset(decompressed_buf, 0, INFLATE_BUFFER_SIZE);
-
-  if (inflateInit2(&decompress_stream_, 31) != Z_OK) {
-    //log_err("inflateInit2 failed");
-    return E_COMPRESS_ERR;
-  }
-  zstream_valid_ = true;
-  return E_OK;
-}
-
-int GzipDeCompressor::end_zstream()
-{
-  if (!zstream_valid_) {
-    return E_OK;
-  }
-  if(inflateEnd(&decompress_stream_) != Z_OK) {
-    //log_err("inflateEnd failed");
-    return E_COMPRESS_ERR;
-  }
-  zstream_valid_ = false;
-  return E_OK;
-}
-
-int GzipDeCompressor::reset()
-{
-  int ret = E_OK;
-  if (RET_FAIL(end_zstream())) {
-  } else if (RET_FAIL(init_zstream())) {
-  }
-  return ret;
 }
 
 int GzipDeCompressor::decompress_into_bytestream(char *compressed_buf,
                                                  uint32_t compressed_buf_len,
-                                                 ByteStream &out)
-{
-  int ret = Z_OK;
+                                                 ByteStream &out) {
+    int ret = Z_OK;
 
-  decompress_stream_.next_in = (Bytef *)compressed_buf;
-  decompress_stream_.avail_in = compressed_buf_len;
-  decompress_stream_.next_out = (Bytef *)decompressed_buf;
-  decompress_stream_.avail_out = INFLATE_BUFFER_SIZE;
+    decompress_stream_.next_in = (Bytef *)compressed_buf;
+    decompress_stream_.avail_in = compressed_buf_len;
+    decompress_stream_.next_out = (Bytef *)decompressed_buf;
+    decompress_stream_.avail_out = INFLATE_BUFFER_SIZE;
 
-  if (compressed_buf == nullptr || compressed_buf_len == 0) {
-    if (decompress_stream_.next_out) {
-      while (ret != Z_STREAM_END) {
-        ret = inflate(&decompress_stream_, Z_FINISH);
-        if(ret != Z_OK && ret != Z_STREAM_END) {
-          //log_err("inflate failed");
-          return E_COMPRESS_ERR;
+    if (compressed_buf == nullptr || compressed_buf_len == 0) {
+        if (decompress_stream_.next_out) {
+            while (ret != Z_STREAM_END) {
+                ret = inflate(&decompress_stream_, Z_FINISH);
+                if (ret != Z_OK && ret != Z_STREAM_END) {
+                    // log_err("inflate failed");
+                    return E_COMPRESS_ERR;
+                }
+                out.write_buf(
+                    decompressed_buf,
+                    INFLATE_BUFFER_SIZE - decompress_stream_.avail_out);
+                decompress_stream_.next_out = (Bytef *)decompressed_buf;
+                decompress_stream_.avail_out = INFLATE_BUFFER_SIZE;
+            }
         }
-        out.write_buf(decompressed_buf, INFLATE_BUFFER_SIZE -
-        decompress_stream_.avail_out); decompress_stream_.next_out = (Bytef
-        *)decompressed_buf; decompress_stream_.avail_out =
-        INFLATE_BUFFER_SIZE;
-      }
+        return E_OK;
     }
+
+    for (;;) {
+        ret = inflate(&decompress_stream_, Z_NO_FLUSH);
+        if (ret == Z_STREAM_END) {
+            out.write_buf(decompressed_buf,
+                          INFLATE_BUFFER_SIZE - decompress_stream_.avail_out);
+            break;
+        }
+        if (ret != Z_OK) {
+            // log_err("inflate failed");
+            return E_COMPRESS_ERR;
+        }
+        if (decompress_stream_.avail_in == 0) {
+            out.write_buf(decompressed_buf,
+                          INFLATE_BUFFER_SIZE - decompress_stream_.avail_out);
+            decompress_stream_.next_out = (Bytef *)decompressed_buf;
+            decompress_stream_.avail_out = INFLATE_BUFFER_SIZE;
+            break;
+        } else if (decompress_stream_.avail_out == 0) {
+            out.write_buf(decompressed_buf, INFLATE_BUFFER_SIZE);
+            decompress_stream_.next_out = (Bytef *)decompressed_buf;
+            decompress_stream_.avail_out = INFLATE_BUFFER_SIZE;
+        }
+    }
+
     return E_OK;
-  }
-
-  for (;;) {
-    ret = inflate(&decompress_stream_, Z_NO_FLUSH);
-    if (ret == Z_STREAM_END) {
-      out.write_buf(decompressed_buf, INFLATE_BUFFER_SIZE -
-      decompress_stream_.avail_out); break;
-    }
-    if (ret != Z_OK) {
-      //log_err("inflate failed");
-      return E_COMPRESS_ERR;
-    }
-    if (decompress_stream_.avail_in == 0) {
-      out.write_buf(decompressed_buf, INFLATE_BUFFER_SIZE -
-      decompress_stream_.avail_out); decompress_stream_.next_out = (Bytef
-      *)decompressed_buf; decompress_stream_.avail_out = INFLATE_BUFFER_SIZE;
-      break;
-    }
-    else if (decompress_stream_.avail_out == 0) {
-      out.write_buf(decompressed_buf, INFLATE_BUFFER_SIZE);
-      decompress_stream_.next_out = (Bytef *)decompressed_buf;
-      decompress_stream_.avail_out = INFLATE_BUFFER_SIZE;
-    }
-  }
-
-  return E_OK;
 }
 
 int GzipDeCompressor::uncompress(char *compressed_buf,
                                  uint32_t compressed_buf_len,
                                  char *&uncompressed_buf,
-                                 uint32_t &uncompressed_buf_len)
-{
-  int ret = E_OK;
-  ByteStream out(INFLATE_BUFFER_SIZE, MOD_COMPRESSOR_OBJ);
-  if(RET_FAIL(decompress_into_bytestream(compressed_buf, compressed_buf_len,
-  out))) {
+                                 uint32_t &uncompressed_buf_len) {
+    int ret = E_OK;
+    ByteStream out(INFLATE_BUFFER_SIZE, MOD_COMPRESSOR_OBJ);
+    if (RET_FAIL(decompress_into_bytestream(compressed_buf, compressed_buf_len,
+                                            out))) {
+        return ret;
+    }
+    if (RET_FAIL(decompress_into_bytestream(nullptr, 0, out))) {
+        return ret;
+    }
+    uncompressed_buf = get_bytes_from_bytestream(out);
+    uncompressed_buf_len = out.total_size();
+    //   uncompressed_buf[uncompressed_buf_len] = '\0';
+    out.destroy();
     return ret;
-  }
-  if (RET_FAIL(decompress_into_bytestream(nullptr, 0, out))) {
-    return ret;
-  }
-  uncompressed_buf = get_bytes_from_bytestream(out);
-  uncompressed_buf_len = out.total_size();
-//   uncompressed_buf[uncompressed_buf_len] = '\0';
-  out.destroy();
-  return ret;
 }
 
-} // end namespace storage
+}  // end namespace storage

--- a/cpp/src/compress/lz4_compressor.h
+++ b/cpp/src/compress/lz4_compressor.h
@@ -38,8 +38,8 @@ namespace storage {
 
 class LZ4Compressor : public Compressor {
    public:
-    LZ4Compressor() : compressed_buf_(nullptr), uncompressed_buf_(nullptr){};
-    ~LZ4Compressor(){};
+    LZ4Compressor() : compressed_buf_(nullptr), uncompressed_buf_(nullptr) {};
+    ~LZ4Compressor() {};
     // @for_compress
     //  true  - for compressiom
     //  false - for uncompression

--- a/cpp/src/compress/lz4_compressor.h
+++ b/cpp/src/compress/lz4_compressor.h
@@ -38,8 +38,8 @@ namespace storage {
 
 class LZ4Compressor : public Compressor {
    public:
-    LZ4Compressor() : compressed_buf_(nullptr), uncompressed_buf_(nullptr) {};
-    ~LZ4Compressor() {};
+    LZ4Compressor() : compressed_buf_(nullptr), uncompressed_buf_(nullptr){};
+    ~LZ4Compressor(){};
     // @for_compress
     //  true  - for compressiom
     //  false - for uncompression

--- a/cpp/src/compress/lzo_compressor.h
+++ b/cpp/src/compress/lzo_compressor.h
@@ -38,8 +38,8 @@ namespace storage {
 
 class LZOCompressor : public Compressor {
    public:
-    LZOCompressor() : compressed_buf_(nullptr), uncompressed_buf_(nullptr) {};
-    ~LZOCompressor() {};
+    LZOCompressor() : compressed_buf_(nullptr), uncompressed_buf_(nullptr){};
+    ~LZOCompressor(){};
     // @for_compress
     //  true  - for compressiom
     //  false - for uncompression

--- a/cpp/src/compress/lzo_compressor.h
+++ b/cpp/src/compress/lzo_compressor.h
@@ -38,8 +38,8 @@ namespace storage {
 
 class LZOCompressor : public Compressor {
    public:
-    LZOCompressor() : compressed_buf_(nullptr), uncompressed_buf_(nullptr){};
-    ~LZOCompressor(){};
+    LZOCompressor() : compressed_buf_(nullptr), uncompressed_buf_(nullptr) {};
+    ~LZOCompressor() {};
     // @for_compress
     //  true  - for compressiom
     //  false - for uncompression

--- a/cpp/src/compress/snappy_compressor.h
+++ b/cpp/src/compress/snappy_compressor.h
@@ -36,9 +36,8 @@ namespace storage {
 
 class SnappyCompressor : public Compressor {
    public:
-    SnappyCompressor()
-        : compressed_buf_(nullptr), uncompressed_buf_(nullptr) {};
-    ~SnappyCompressor() {};
+    SnappyCompressor() : compressed_buf_(nullptr), uncompressed_buf_(nullptr){};
+    ~SnappyCompressor(){};
     // @for_compress
     //  true  - for compressiom
     //  false - for uncompression

--- a/cpp/src/compress/snappy_compressor.h
+++ b/cpp/src/compress/snappy_compressor.h
@@ -36,8 +36,9 @@ namespace storage {
 
 class SnappyCompressor : public Compressor {
    public:
-    SnappyCompressor() : compressed_buf_(nullptr), uncompressed_buf_(nullptr){};
-    ~SnappyCompressor(){};
+    SnappyCompressor()
+        : compressed_buf_(nullptr), uncompressed_buf_(nullptr) {};
+    ~SnappyCompressor() {};
     // @for_compress
     //  true  - for compressiom
     //  false - for uncompression

--- a/cpp/src/cwrapper/tsfile_cwrapper.cc
+++ b/cpp/src/cwrapper/tsfile_cwrapper.cc
@@ -328,8 +328,7 @@ char *tsfile_result_set_get_value_by_name_string(ResultSet result_set,
                                                  const char *column_name) {
     auto *r = static_cast<storage::TableResultSet *>(result_set);
     std::string column_name_(column_name);
-    common::String *ret =
-        r->get_value<common::String *>(column_name_);
+    common::String *ret = r->get_value<common::String *>(column_name_);
     // Caller should free return's char* 's space.
     char *dup = (char *)malloc(ret->len_ + 1);
     if (dup) {

--- a/cpp/src/cwrapper/tsfile_cwrapper_expression.cc
+++ b/cpp/src/cwrapper/tsfile_cwrapper_expression.cc
@@ -67,8 +67,8 @@
 //                                 float float_value) {
 //     Expression exp;
 //     CONSTRUCT_EXP_INTERNAL(exp, column_name);
-//     memcpy(&exp.const_condition.value_condition, &float_value, sizeof(float));
-//     exp.const_condition.type = TSDataType::TS_DATATYPE_FLOAT;
+//     memcpy(&exp.const_condition.value_condition, &float_value,
+//     sizeof(float)); exp.const_condition.type = TSDataType::TS_DATATYPE_FLOAT;
 //     return exp;
 // }
 // Expression create_column_filter(const char* column_name, OperatorType oper,
@@ -83,9 +83,9 @@
 //                                 const char* char_value) {
 //     Expression exp;
 //     CONSTRUCT_EXP_INTERNAL(exp, column_name);
-//     exp.const_condition.value_condition = reinterpret_cast<int64_t>(char_value);
-//     exp.const_condition.type = TSDataType::TS_DATATYPE_TEXT;
-//     return exp;
+//     exp.const_condition.value_condition =
+//     reinterpret_cast<int64_t>(char_value); exp.const_condition.type =
+//     TSDataType::TS_DATATYPE_TEXT; return exp;
 // }
 //
 // TimeFilterExpression* create_andquery_timefilter() {
@@ -95,7 +95,8 @@
 //
 // TimeFilterExpression* create_time_filter(const char* table_name,
 //                                          const char* column_name,
-//                                          OperatorType oper, int64_t timestamp) {
+//                                          OperatorType oper, int64_t
+//                                          timestamp) {
 //     std::string table_name_str(table_name);
 //     std::string column_name_str(column_name);
 //     storage::Path path(table_name_str, column_name_str);
@@ -163,7 +164,8 @@
 //     }
 // }
 //
-// Expression create_global_time_expression(OperatorType oper, int64_t timestamp) {
+// Expression create_global_time_expression(OperatorType oper, int64_t
+// timestamp) {
 //     Expression exp;
 //     exp.operate_type = oper;
 //     exp.expression_type = GLOBALTIME;

--- a/cpp/src/encoding/intpacker.h
+++ b/cpp/src/encoding/intpacker.h
@@ -34,8 +34,10 @@ class IntPacker {
     IntPacker(int width_) { this->width_ = width_; }
     ~IntPacker() { destroy(); }
 
-    void destroy() { /* do nothing for IntPacker */ }
-    void reset() { /* do thing for IntPacker */ }
+    void destroy() { /* do nothing for IntPacker */
+    }
+    void reset() { /* do thing for IntPacker */
+    }
 
     void pack_8values(int64_t values[], int offset, unsigned char buf[]) {
         int buf_idx = 0;

--- a/cpp/src/encoding/plain_decoder.h
+++ b/cpp/src/encoding/plain_decoder.h
@@ -26,7 +26,8 @@ namespace storage {
 
 class PlainDecoder : public Decoder {
    public:
-    FORCE_INLINE void reset() { /* do nothing */ }
+    FORCE_INLINE void reset() { /* do nothing */
+    }
     FORCE_INLINE bool has_remaining() { return false; }
     FORCE_INLINE int read_boolean(bool &ret_bool, common::ByteStream &in) {
         return common::SerializationUtil::read_ui8((uint8_t &)ret_bool, in);

--- a/cpp/src/encoding/plain_encoder.h
+++ b/cpp/src/encoding/plain_encoder.h
@@ -28,8 +28,10 @@ class PlainEncoder : public Encoder {
    public:
     PlainEncoder() {}
     ~PlainEncoder() { destroy(); }
-    void destroy() { /* do nothing for PlainEncoder */ }
-    void reset() { /* do thing for PlainEncoder */ }
+    void destroy() { /* do nothing for PlainEncoder */
+    }
+    void reset() { /* do thing for PlainEncoder */
+    }
 
     FORCE_INLINE int encode(bool value, common::ByteStream &out_stream) {
         return common::SerializationUtil::write_i8(value ? 1 : 0, out_stream);

--- a/cpp/src/file/tsfile_io_reader.cc
+++ b/cpp/src/file/tsfile_io_reader.cc
@@ -25,365 +25,366 @@ using namespace common;
 
 namespace storage {
 int TsFileIOReader::init(const std::string &file_path) {
-  int ret = E_OK;
-  read_file_ = new ReadFile;
-  read_file_created_ = true;
-  if (RET_FAIL(read_file_->open(file_path))) {
-  }
-  return ret;
+    int ret = E_OK;
+    read_file_ = new ReadFile;
+    read_file_created_ = true;
+    if (RET_FAIL(read_file_->open(file_path))) {
+    }
+    return ret;
 }
 
 int TsFileIOReader::init(ReadFile *read_file) {
-  if (IS_NULL(read_file)) {
-    ASSERT(false);
-    return E_INVALID_ARG;
-  }
-  read_file_created_ = false;
-  read_file_ = read_file;
-  return E_OK;
+    if (IS_NULL(read_file)) {
+        ASSERT(false);
+        return E_INVALID_ARG;
+    }
+    read_file_created_ = false;
+    read_file_ = read_file;
+    return E_OK;
 }
 
 void TsFileIOReader::reset() {
-  if (read_file_ != nullptr) {
-    if (read_file_created_) {
-      read_file_->destroy();
-      delete read_file_;
+    if (read_file_ != nullptr) {
+        if (read_file_created_) {
+            read_file_->destroy();
+            delete read_file_;
+        }
+        read_file_ = nullptr;
+        tsfile_meta_page_arena_.destroy();
+        tsfile_meta_ready_ = false;
     }
-    read_file_ = nullptr;
-    tsfile_meta_page_arena_.destroy();
-    tsfile_meta_ready_ = false;
-  }
 }
 
 int TsFileIOReader::alloc_ssi(std::shared_ptr<IDeviceID> device_id,
                               const std::string &measurement_name,
                               TsFileSeriesScanIterator *&ssi,
                               common::PageArena &pa, Filter *time_filter) {
-  int ret = E_OK;
-  if (RET_FAIL(load_tsfile_meta_if_necessary())) {
-  } else {
-    ssi = new TsFileSeriesScanIterator;
-    ssi->init(device_id, measurement_name, read_file_, time_filter, pa);
-    if (RET_FAIL(load_timeseries_index_for_ssi(device_id,
-                                               measurement_name, ssi))) {
-    } else if (time_filter != nullptr &&
-        !filter_stasify(ssi->itimeseries_index_, time_filter)) {
-      ret = E_NO_MORE_DATA;
-    } else if (RET_FAIL(ssi->init_chunk_reader())) {
+    int ret = E_OK;
+    if (RET_FAIL(load_tsfile_meta_if_necessary())) {
+    } else {
+        ssi = new TsFileSeriesScanIterator;
+        ssi->init(device_id, measurement_name, read_file_, time_filter, pa);
+        if (RET_FAIL(load_timeseries_index_for_ssi(device_id, measurement_name,
+                                                   ssi))) {
+        } else if (time_filter != nullptr &&
+                   !filter_stasify(ssi->itimeseries_index_, time_filter)) {
+            ret = E_NO_MORE_DATA;
+        } else if (RET_FAIL(ssi->init_chunk_reader())) {
+        }
+        if (ret != E_OK) {
+            ssi->destroy();
+            delete ssi;
+            ssi = nullptr;
+        }
     }
-    if (ret != E_OK) {
-      ssi->destroy();
-      delete ssi;
-      ssi = nullptr;
-    }
-  }
-  return ret;
+    return ret;
 }
 
 void TsFileIOReader::revert_ssi(TsFileSeriesScanIterator *ssi) {
-  if (ssi != nullptr) {
-    ssi->destroy();
-    delete ssi;
-  }
+    if (ssi != nullptr) {
+        ssi->destroy();
+        delete ssi;
+    }
 }
 
 int TsFileIOReader::get_device_timeseries_meta_without_chunk_meta(
     std::shared_ptr<IDeviceID> device_id,
-    std::vector<ITimeseriesIndex *> &timeseries_indexs,
-    PageArena &pa) {
-  int ret = E_OK;
-  load_tsfile_meta_if_necessary();
-  std::shared_ptr<IMetaIndexEntry> meta_index_entry;
-  int64_t end_offset;
-  std::vector<std::pair<std::shared_ptr<IMetaIndexEntry>, int64_t> >
-      meta_index_entry_list;
-  if (RET_FAIL(
-      load_device_index_entry(std::make_shared<DeviceIDComparable>(device_id),
-                              meta_index_entry, end_offset))) {
-  } else if (RET_FAIL(load_all_measurement_index_entry(
-      meta_index_entry->get_offset(), end_offset, pa,
-      meta_index_entry_list))) {
-  } else if (RET_FAIL(do_load_all_timeseries_index(meta_index_entry_list, pa,
-                                                   timeseries_indexs))) {
-  }
-  return ret;
+    std::vector<ITimeseriesIndex *> &timeseries_indexs, PageArena &pa) {
+    int ret = E_OK;
+    load_tsfile_meta_if_necessary();
+    std::shared_ptr<IMetaIndexEntry> meta_index_entry;
+    int64_t end_offset;
+    std::vector<std::pair<std::shared_ptr<IMetaIndexEntry>, int64_t> >
+        meta_index_entry_list;
+    if (RET_FAIL(load_device_index_entry(
+            std::make_shared<DeviceIDComparable>(device_id), meta_index_entry,
+            end_offset))) {
+    } else if (RET_FAIL(load_all_measurement_index_entry(
+                   meta_index_entry->get_offset(), end_offset, pa,
+                   meta_index_entry_list))) {
+    } else if (RET_FAIL(do_load_all_timeseries_index(meta_index_entry_list, pa,
+                                                     timeseries_indexs))) {
+    }
+    return ret;
 }
 
 bool TsFileIOReader::filter_stasify(ITimeseriesIndex *ts_index,
                                     Filter *time_filter) {
-  ASSERT(ts_index->get_statistic() != nullptr);
-  return time_filter->satisfy(ts_index->get_statistic());
+    ASSERT(ts_index->get_statistic() != nullptr);
+    return time_filter->satisfy(ts_index->get_statistic());
 }
 
 int TsFileIOReader::load_tsfile_meta_if_necessary() {
-  int ret = E_OK;
-  if (!tsfile_meta_ready_) {
-    if (RET_FAIL(load_tsfile_meta())) {
-      // log_err("load_tsfile_meta error, ret=%d", ret);
-      return ret;
-    } else {
-      tsfile_meta_ready_ = true;
+    int ret = E_OK;
+    if (!tsfile_meta_ready_) {
+        if (RET_FAIL(load_tsfile_meta())) {
+            // log_err("load_tsfile_meta error, ret=%d", ret);
+            return ret;
+        } else {
+            tsfile_meta_ready_ = true;
+        }
     }
-  }
-  return ret;
+    return ret;
 }
 
 int TsFileIOReader::load_tsfile_meta() {
-  const int32_t TSFILE_READ_IO_SIZE = 1024; // TODO make it configurable
-  const int32_t TAIL_MAGIC_AND_META_SIZE_SIZE =
-      10;                  // magic(6B) + meta_size(4B)
-  ASSERT(file_size() > 0); // > 13
+    const int32_t TSFILE_READ_IO_SIZE = 1024;  // TODO make it configurable
+    const int32_t TAIL_MAGIC_AND_META_SIZE_SIZE =
+        10;                   // magic(6B) + meta_size(4B)
+    ASSERT(file_size() > 0);  // > 13
 
-  int ret = E_OK;
-  uint32_t tsfile_meta_size = 0;
-  int32_t read_offset = 0;
-  int32_t ret_read_len = 0;
+    int ret = E_OK;
+    uint32_t tsfile_meta_size = 0;
+    int32_t read_offset = 0;
+    int32_t ret_read_len = 0;
 
-  // Step 1: reader the tsfile_meta_size
-  // 1.1 prepare reader buffer
-  int32_t alloc_size = UTIL_MIN(TSFILE_READ_IO_SIZE, file_size());
-  char *read_buf = (char *) mem_alloc(alloc_size, MOD_TSFILE_READER);
-  if (IS_NULL(read_buf)) {
-    return E_OOM;
-  }
-  // 1.2 reader data from file
-  read_offset = file_size() - alloc_size;
-  ret_read_len = 0;
-  if (RET_FAIL(read_file_->read(read_offset, read_buf, alloc_size,
-                                ret_read_len))) {
-  } else if (ret_read_len != alloc_size) {
-    ret = E_FILE_READ_ERR;
-    // log_err("do not reader enough data from tsfile, want-size=%d,
-    // reader-size=%d, file=%s", alloc_size, ret_read_len,
-    // get_file_path().c_str());
-  }
-  // 1.3 deserialize tsfile_meta_size
-  if (IS_SUCC(ret)) {
-    // deserialize tsfile_meta_size
-    char *size_buf = read_buf + alloc_size - TAIL_MAGIC_AND_META_SIZE_SIZE;
-    tsfile_meta_size = SerializationUtil::read_ui32(size_buf);
-    ASSERT(tsfile_meta_size > 0 && tsfile_meta_size <= (1ll << 20));
-  }
-
-  // Step 2: reader TsFileMeta
-  if (IS_SUCC(ret)) {
-    // 2.1 prepare enough buffer (use the previous buffer if can).
-    char *tsfile_meta_buf = nullptr;
-    if (tsfile_meta_size + TAIL_MAGIC_AND_META_SIZE_SIZE >
-        (uint32_t) alloc_size) {
-      // prepare buffer to re-reader from start of tsfile_meta
-      char *old_read_buf = read_buf;
-      read_buf = (char *) mem_realloc(read_buf, tsfile_meta_size);
-      if (IS_NULL(read_buf)) {
-        read_buf = old_read_buf;
-        ret = E_OOM;
-      } else if (RET_FAIL(read_file_->read(
-          file_size() - tsfile_meta_size -
-              TAIL_MAGIC_AND_META_SIZE_SIZE,
-          read_buf, tsfile_meta_size, ret_read_len))) {
-      } else if (tsfile_meta_size != (uint32_t) ret_read_len) {
+    // Step 1: reader the tsfile_meta_size
+    // 1.1 prepare reader buffer
+    int32_t alloc_size = UTIL_MIN(TSFILE_READ_IO_SIZE, file_size());
+    char *read_buf = (char *)mem_alloc(alloc_size, MOD_TSFILE_READER);
+    if (IS_NULL(read_buf)) {
+        return E_OOM;
+    }
+    // 1.2 reader data from file
+    read_offset = file_size() - alloc_size;
+    ret_read_len = 0;
+    if (RET_FAIL(read_file_->read(read_offset, read_buf, alloc_size,
+                                  ret_read_len))) {
+    } else if (ret_read_len != alloc_size) {
         ret = E_FILE_READ_ERR;
         // log_err("do not reader enough data from tsfile, want-size=%d,
-        // reader-size=%d, file=%s", tsfile_meta_size, ret_read_len,
+        // reader-size=%d, file=%s", alloc_size, ret_read_len,
         // get_file_path().c_str());
-      } else {
-        tsfile_meta_buf = read_buf;
-      }
-    } else {
-      // the previous buffer has contained the TsFileMeta data
-      tsfile_meta_buf = read_buf + alloc_size - tsfile_meta_size -
-          TAIL_MAGIC_AND_META_SIZE_SIZE;
-      // DEBUG_hex_dump_buf("tsfile_meta_buf=", tsfile_meta_buf,
-      // tsfile_meta_size);
     }
+    // 1.3 deserialize tsfile_meta_size
     if (IS_SUCC(ret)) {
-      ByteStream tsfile_meta_bs;
-      tsfile_meta_bs.wrap_from(tsfile_meta_buf, tsfile_meta_size);
-      if (RET_FAIL(tsfile_meta_.deserialize_from(tsfile_meta_bs))) {
-      }
-#if DEBUG_SE
-      std::cout << "load tsfile_meta, ret=" << ret
-                << ", tsfile_meta_=" << tsfile_meta_ << std::endl;
-#endif
+        // deserialize tsfile_meta_size
+        char *size_buf = read_buf + alloc_size - TAIL_MAGIC_AND_META_SIZE_SIZE;
+        tsfile_meta_size = SerializationUtil::read_ui32(size_buf);
+        ASSERT(tsfile_meta_size > 0 && tsfile_meta_size <= (1ll << 20));
     }
-  }
-  mem_free(read_buf);
-  return ret;
+
+    // Step 2: reader TsFileMeta
+    if (IS_SUCC(ret)) {
+        // 2.1 prepare enough buffer (use the previous buffer if can).
+        char *tsfile_meta_buf = nullptr;
+        if (tsfile_meta_size + TAIL_MAGIC_AND_META_SIZE_SIZE >
+            (uint32_t)alloc_size) {
+            // prepare buffer to re-reader from start of tsfile_meta
+            char *old_read_buf = read_buf;
+            read_buf = (char *)mem_realloc(read_buf, tsfile_meta_size);
+            if (IS_NULL(read_buf)) {
+                read_buf = old_read_buf;
+                ret = E_OOM;
+            } else if (RET_FAIL(read_file_->read(
+                           file_size() - tsfile_meta_size -
+                               TAIL_MAGIC_AND_META_SIZE_SIZE,
+                           read_buf, tsfile_meta_size, ret_read_len))) {
+            } else if (tsfile_meta_size != (uint32_t)ret_read_len) {
+                ret = E_FILE_READ_ERR;
+                // log_err("do not reader enough data from tsfile, want-size=%d,
+                // reader-size=%d, file=%s", tsfile_meta_size, ret_read_len,
+                // get_file_path().c_str());
+            } else {
+                tsfile_meta_buf = read_buf;
+            }
+        } else {
+            // the previous buffer has contained the TsFileMeta data
+            tsfile_meta_buf = read_buf + alloc_size - tsfile_meta_size -
+                              TAIL_MAGIC_AND_META_SIZE_SIZE;
+            // DEBUG_hex_dump_buf("tsfile_meta_buf=", tsfile_meta_buf,
+            // tsfile_meta_size);
+        }
+        if (IS_SUCC(ret)) {
+            ByteStream tsfile_meta_bs;
+            tsfile_meta_bs.wrap_from(tsfile_meta_buf, tsfile_meta_size);
+            if (RET_FAIL(tsfile_meta_.deserialize_from(tsfile_meta_bs))) {
+            }
+#if DEBUG_SE
+            std::cout << "load tsfile_meta, ret=" << ret
+                      << ", tsfile_meta_=" << tsfile_meta_ << std::endl;
+#endif
+        }
+    }
+    mem_free(read_buf);
+    return ret;
 }
 
 int TsFileIOReader::load_timeseries_index_for_ssi(
     std::shared_ptr<IDeviceID> device_id, const std::string &measurement_name,
     TsFileSeriesScanIterator *&ssi) {
-  int ret = E_OK;
-  std::shared_ptr<IMetaIndexEntry> device_index_entry;
-  int64_t device_ie_end_offset = 0;
-  std::shared_ptr<IMetaIndexEntry> measurement_index_entry;
-  int64_t measurement_ie_end_offset = 0;
-  // bool is_aligned = false;
-  if (RET_FAIL(load_device_index_entry(
-      std::make_shared<DeviceIDComparable>(device_id), device_index_entry,
-      device_ie_end_offset))) {
-      return ret;
-  }
-  auto& pa = ssi->timeseries_index_pa_;
+    int ret = E_OK;
+    std::shared_ptr<IMetaIndexEntry> device_index_entry;
+    int64_t device_ie_end_offset = 0;
+    std::shared_ptr<IMetaIndexEntry> measurement_index_entry;
+    int64_t measurement_ie_end_offset = 0;
+    // bool is_aligned = false;
+    if (RET_FAIL(load_device_index_entry(
+            std::make_shared<DeviceIDComparable>(device_id), device_index_entry,
+            device_ie_end_offset))) {
+        return ret;
+    }
+    auto &pa = ssi->timeseries_index_pa_;
 
-  int start_offset = device_index_entry->get_offset(), end_offset =
-          device_ie_end_offset;
-  ASSERT(start_offset < end_offset);
-  const int32_t read_size = end_offset - start_offset;
-  int32_t ret_read_len = 0;
-  char* data_buf = (char*)pa.alloc(read_size);
-  void* m_idx_node_buf = pa.alloc(sizeof(MetaIndexNode));
-  if (IS_NULL(data_buf) || IS_NULL(m_idx_node_buf)) {
-      return E_OOM;
-  }
-  auto* top_node_ptr = new(m_idx_node_buf) MetaIndexNode(&pa);
-  auto top_node = std::shared_ptr<MetaIndexNode>(
-      top_node_ptr, MetaIndexNode::self_deleter);
+    int start_offset = device_index_entry->get_offset(),
+        end_offset = device_ie_end_offset;
+    ASSERT(start_offset < end_offset);
+    const int32_t read_size = end_offset - start_offset;
+    int32_t ret_read_len = 0;
+    char *data_buf = (char *)pa.alloc(read_size);
+    void *m_idx_node_buf = pa.alloc(sizeof(MetaIndexNode));
+    if (IS_NULL(data_buf) || IS_NULL(m_idx_node_buf)) {
+        return E_OOM;
+    }
+    auto *top_node_ptr = new (m_idx_node_buf) MetaIndexNode(&pa);
+    auto top_node = std::shared_ptr<MetaIndexNode>(top_node_ptr,
+                                                   MetaIndexNode::self_deleter);
 
-  if (RET_FAIL(read_file_->read(start_offset, data_buf, read_size,
-      ret_read_len))) {
-      return ret;
-  } else if (RET_FAIL(top_node->deserialize_from(data_buf, read_size))) {
-      return ret;
-  }
+    if (RET_FAIL(read_file_->read(start_offset, data_buf, read_size,
+                                  ret_read_len))) {
+        return ret;
+    } else if (RET_FAIL(top_node->deserialize_from(data_buf, read_size))) {
+        return ret;
+    }
 
-  bool is_aligned = is_aligned_device(top_node);
-  TimeseriesIndex* timeseries_index = nullptr;
-  if (is_aligned) {
-      if (RET_FAIL(get_time_column_metadata(top_node, timeseries_index, pa))) {
-          return ret;
-      }
-  }
+    bool is_aligned = is_aligned_device(top_node);
+    TimeseriesIndex *timeseries_index = nullptr;
+    if (is_aligned) {
+        if (RET_FAIL(
+                get_time_column_metadata(top_node, timeseries_index, pa))) {
+            return ret;
+        }
+    }
 
-  if (RET_FAIL(load_measurement_index_entry(
-      measurement_name, top_node, measurement_index_entry,
-      measurement_ie_end_offset))) {
-      return ret;
-  } else if (RET_FAIL(do_load_timeseries_index(
-      measurement_name, measurement_index_entry->get_offset(),
-      measurement_ie_end_offset, ssi->timeseries_index_pa_,
-      ssi->itimeseries_index_, is_aligned))) {
-      return ret;
-  }
-  if (is_aligned) {
-      auto* aligned_timeseries_index = dynamic_cast<
-          AlignedTimeseriesIndex*>(ssi->itimeseries_index_);
-      if (aligned_timeseries_index) {
-          aligned_timeseries_index->time_ts_idx_ = timeseries_index;
-      }
-  }
-
+    if (RET_FAIL(load_measurement_index_entry(measurement_name, top_node,
+                                              measurement_index_entry,
+                                              measurement_ie_end_offset))) {
+        return ret;
+    } else if (RET_FAIL(do_load_timeseries_index(
+                   measurement_name, measurement_index_entry->get_offset(),
+                   measurement_ie_end_offset, ssi->timeseries_index_pa_,
+                   ssi->itimeseries_index_, is_aligned))) {
+        return ret;
+    }
+    if (is_aligned) {
+        auto *aligned_timeseries_index =
+            dynamic_cast<AlignedTimeseriesIndex *>(ssi->itimeseries_index_);
+        if (aligned_timeseries_index) {
+            aligned_timeseries_index->time_ts_idx_ = timeseries_index;
+        }
+    }
 
 #if DEBUG_SE
     if (measurement_index_entry.name_.len_) {
         std::cout << "load timeseries index: "
-                  << *((TimeseriesIndex *)ssi->itimeseries_index_)
-                  << std::endl;
+                  << *((TimeseriesIndex *)ssi->itimeseries_index_) << std::endl;
     } else {
         std::cout << "load aligned timeseries index: "
                   << *((AlignedTimeseriesIndex *)ssi->itimeseries_index_)
                   << std::endl;
     }
 #endif
-  return ret;
+    return ret;
 }
 
 int TsFileIOReader::load_device_index_entry(
     std::shared_ptr<IComparable> device_name,
     std::shared_ptr<IMetaIndexEntry> &device_index_entry, int64_t &end_offset) {
-  int ret = E_OK;
-  std::shared_ptr<DeviceIDComparable> device_id_comparable =
-      std::dynamic_pointer_cast<DeviceIDComparable>(device_name);
-  if (device_id_comparable == nullptr) {
-    return E_INVALID_DATA_POINT;
-  }
-  auto index_node = tsfile_meta_.table_metadata_index_node_map_[device_id_comparable->device_id_->get_table_name()];
-  assert(tsfile_meta_.table_metadata_index_node_map_.find(device_id_comparable->device_id_->get_table_name()) !=
-        tsfile_meta_.table_metadata_index_node_map_.end());
-  assert(index_node != nullptr);
-  if (index_node->node_type_ == LEAF_DEVICE) {
-    // FIXME
-    ret = index_node->binary_search_children(
-        device_name, true, device_index_entry, end_offset);
-  } else {
-    ret = search_from_internal_node(device_name, true, index_node,
-                                    device_index_entry, end_offset);
-  }
-  if (ret == E_NOT_EXIST) {
-    ret = E_DEVICE_NOT_EXIST;
-  }
+    int ret = E_OK;
+    std::shared_ptr<DeviceIDComparable> device_id_comparable =
+        std::dynamic_pointer_cast<DeviceIDComparable>(device_name);
+    if (device_id_comparable == nullptr) {
+        return E_INVALID_DATA_POINT;
+    }
+    auto index_node = tsfile_meta_.table_metadata_index_node_map_
+                          [device_id_comparable->device_id_->get_table_name()];
+    assert(tsfile_meta_.table_metadata_index_node_map_.find(
+               device_id_comparable->device_id_->get_table_name()) !=
+           tsfile_meta_.table_metadata_index_node_map_.end());
+    assert(index_node != nullptr);
+    if (index_node->node_type_ == LEAF_DEVICE) {
+        // FIXME
+        ret = index_node->binary_search_children(
+            device_name, true, device_index_entry, end_offset);
+    } else {
+        ret = search_from_internal_node(device_name, true, index_node,
+                                        device_index_entry, end_offset);
+    }
+    if (ret == E_NOT_EXIST) {
+        ret = E_DEVICE_NOT_EXIST;
+    }
 #if DEBUG_SE
-  std::cout << "load_device_index_entry, device_index_entry={"
-            << device_index_entry << "}, end_offset=" << end_offset
-            << std::endl;
+    std::cout << "load_device_index_entry, device_index_entry={"
+              << device_index_entry << "}, end_offset=" << end_offset
+              << std::endl;
 #endif
-  return ret;
+    return ret;
 }
 
 int TsFileIOReader::load_measurement_index_entry(
-    const std::string &measurement_name_str, std::shared_ptr<MetaIndexNode> top_node,
-        std::shared_ptr<IMetaIndexEntry> &ret_measurement_index_entry,
+    const std::string &measurement_name_str,
+    std::shared_ptr<MetaIndexNode> top_node,
+    std::shared_ptr<IMetaIndexEntry> &ret_measurement_index_entry,
     int64_t &ret_end_offset) {
-  int ret = E_OK;
-  // search from top_node in top-down way
-  auto measurement_name =
-      std::make_shared<StringComparable>(measurement_name_str);
-  if (top_node->node_type_ == LEAF_MEASUREMENT) {
-      ret = top_node->binary_search_children(
-          measurement_name, /*exact*/ false, ret_measurement_index_entry,
-          ret_end_offset);
-  } else {
-      ret = search_from_internal_node(measurement_name, false, top_node,
-                                      ret_measurement_index_entry,
-                                      ret_end_offset);
-  }
-  if (ret == E_NOT_EXIST) {
-    ret = E_MEASUREMENT_NOT_EXIST;
-  }
-  return ret;
+    int ret = E_OK;
+    // search from top_node in top-down way
+    auto measurement_name =
+        std::make_shared<StringComparable>(measurement_name_str);
+    if (top_node->node_type_ == LEAF_MEASUREMENT) {
+        ret = top_node->binary_search_children(
+            measurement_name, /*exact*/ false, ret_measurement_index_entry,
+            ret_end_offset);
+    } else {
+        ret = search_from_internal_node(measurement_name, false, top_node,
+                                        ret_measurement_index_entry,
+                                        ret_end_offset);
+    }
+    if (ret == E_NOT_EXIST) {
+        ret = E_MEASUREMENT_NOT_EXIST;
+    }
+    return ret;
 }
 
 int TsFileIOReader::load_all_measurement_index_entry(
     int64_t start_offset, int64_t end_offset, common::PageArena &pa,
     std::vector<std::pair<std::shared_ptr<IMetaIndexEntry>, int64_t> >
-    &ret_measurement_index_entry) {
+        &ret_measurement_index_entry) {
 #if DEBUG_SE
-  std::cout << "load_measurement_index_entry: measurement_name_str= "
-            << ", start_offset=" << start_offset
-            << ", end_offset=" << end_offset << std::endl;
+    std::cout << "load_measurement_index_entry: measurement_name_str= "
+              << ", start_offset=" << start_offset
+              << ", end_offset=" << end_offset << std::endl;
 #endif
-  ASSERT(start_offset < end_offset);
-  int ret = E_OK;
-  // 1. load top measuremnt_index_node
-  const int32_t read_size = (int32_t) (end_offset - start_offset);
-  int32_t ret_read_len = 0;
-  char *data_buf = (char *) pa.alloc(read_size);
-  void *m_idx_node_buf = pa.alloc(sizeof(MetaIndexNode));
-  if (IS_NULL(data_buf) || IS_NULL(m_idx_node_buf)) {
-    return E_OOM;
-  }
-  auto *top_node_ptr = new(m_idx_node_buf) MetaIndexNode(&pa);
-  auto top_node = std::shared_ptr<MetaIndexNode>(
-      top_node_ptr, MetaIndexNode::self_deleter);
-  if (RET_FAIL(read_file_->read(start_offset, data_buf, read_size,
-                                ret_read_len))) {
-  } else if (RET_FAIL(top_node->deserialize_from(data_buf, read_size))) {
-  }
+    ASSERT(start_offset < end_offset);
+    int ret = E_OK;
+    // 1. load top measuremnt_index_node
+    const int32_t read_size = (int32_t)(end_offset - start_offset);
+    int32_t ret_read_len = 0;
+    char *data_buf = (char *)pa.alloc(read_size);
+    void *m_idx_node_buf = pa.alloc(sizeof(MetaIndexNode));
+    if (IS_NULL(data_buf) || IS_NULL(m_idx_node_buf)) {
+        return E_OOM;
+    }
+    auto *top_node_ptr = new (m_idx_node_buf) MetaIndexNode(&pa);
+    auto top_node = std::shared_ptr<MetaIndexNode>(top_node_ptr,
+                                                   MetaIndexNode::self_deleter);
+    if (RET_FAIL(read_file_->read(start_offset, data_buf, read_size,
+                                  ret_read_len))) {
+    } else if (RET_FAIL(top_node->deserialize_from(data_buf, read_size))) {
+    }
 #if DEBUG_SE
-  std::cout
-      << "load_measurement_index_entry deserialize MetaIndexNode, top_node="
-      << *top_node << " at file pos " << start_offset << " to " << end_offset
-      << std::endl;
+    std::cout
+        << "load_measurement_index_entry deserialize MetaIndexNode, top_node="
+        << *top_node << " at file pos " << start_offset << " to " << end_offset
+        << std::endl;
 #endif
-  // 2. search from top_node in top-down way
-  if (IS_SUCC(ret)) {
-    get_all_leaf(top_node, ret_measurement_index_entry);
-  }
-  if (ret == E_NOT_EXIST) {
-    ret = E_MEASUREMENT_NOT_EXIST;
-  }
-  return ret;
+    // 2. search from top_node in top-down way
+    if (IS_SUCC(ret)) {
+        get_all_leaf(top_node, ret_measurement_index_entry);
+    }
+    if (ret == E_NOT_EXIST) {
+        ret = E_MEASUREMENT_NOT_EXIST;
+    }
+    return ret;
 }
 
 int TsFileIOReader::read_device_meta_index(int32_t start_offset,
@@ -412,69 +413,69 @@ int TsFileIOReader::read_device_meta_index(int32_t start_offset,
     return ret;
 }
 
-int TsFileIOReader::get_timeseries_indexes(std::shared_ptr<IDeviceID> device_id,
-                             const std::unordered_set<std::string> &measurement_names,
-                             std::vector<ITimeseriesIndex *> &timeseries_indexs,
-                             common::PageArena &pa) {
-  int ret = E_OK;
-  std::shared_ptr<IMetaIndexEntry> device_index_entry;
-  int64_t device_ie_end_offset = 0;
-  std::shared_ptr<IMetaIndexEntry> measurement_index_entry;
-  int64_t measurement_ie_end_offset = 0;
-  if (RET_FAIL(load_device_index_entry(
-      std::make_shared<DeviceIDComparable>(device_id), device_index_entry,
-      device_ie_end_offset))) {
+int TsFileIOReader::get_timeseries_indexes(
+    std::shared_ptr<IDeviceID> device_id,
+    const std::unordered_set<std::string> &measurement_names,
+    std::vector<ITimeseriesIndex *> &timeseries_indexs, common::PageArena &pa) {
+    int ret = E_OK;
+    std::shared_ptr<IMetaIndexEntry> device_index_entry;
+    int64_t device_ie_end_offset = 0;
+    std::shared_ptr<IMetaIndexEntry> measurement_index_entry;
+    int64_t measurement_ie_end_offset = 0;
+    if (RET_FAIL(load_device_index_entry(
+            std::make_shared<DeviceIDComparable>(device_id), device_index_entry,
+            device_ie_end_offset))) {
+        return ret;
+    }
+
+    int start_offset = device_index_entry->get_offset(),
+        end_offset = device_ie_end_offset;
+    ASSERT(start_offset < end_offset);
+    const int32_t read_size = end_offset - start_offset;
+    int32_t ret_read_len = 0;
+    char *data_buf = (char *)pa.alloc(read_size);
+    void *m_idx_node_buf = pa.alloc(sizeof(MetaIndexNode));
+    if (IS_NULL(data_buf) || IS_NULL(m_idx_node_buf)) {
+        return E_OOM;
+    }
+    auto *top_node_ptr = new (m_idx_node_buf) MetaIndexNode(&pa);
+    auto top_node = std::shared_ptr<MetaIndexNode>(top_node_ptr,
+                                                   MetaIndexNode::self_deleter);
+
+    if (RET_FAIL(read_file_->read(start_offset, data_buf, read_size,
+                                  ret_read_len))) {
+        return ret;
+    } else if (RET_FAIL(top_node->deserialize_from(data_buf, read_size))) {
+        return ret;
+    }
+
+    bool is_aligned = is_aligned_device(top_node);
+    TimeseriesIndex *timeseries_index = nullptr;
+    if (is_aligned) {
+        get_time_column_metadata(top_node, timeseries_index, pa);
+    }
+
+    int64_t idx = 0;
+    for (const auto &measurement_name : measurement_names) {
+        if (RET_FAIL(load_measurement_index_entry(measurement_name, top_node,
+                                                  measurement_index_entry,
+                                                  measurement_ie_end_offset))) {
+        } else if (RET_FAIL(do_load_timeseries_index(
+                       measurement_name, measurement_index_entry->get_offset(),
+                       measurement_ie_end_offset, pa, timeseries_indexs[idx],
+                       is_aligned))) {
+        }
+        if (is_aligned) {
+            AlignedTimeseriesIndex *aligned_timeseries_index =
+                dynamic_cast<AlignedTimeseriesIndex *>(timeseries_indexs[idx]);
+            if (aligned_timeseries_index) {
+                aligned_timeseries_index->time_ts_idx_ = timeseries_index;
+            }
+        }
+
+        idx++;
+    }
     return ret;
-  }
-
-  int start_offset = device_index_entry->get_offset(), end_offset =
-          device_ie_end_offset;
-  ASSERT(start_offset < end_offset);
-  const int32_t read_size = end_offset - start_offset;
-  int32_t ret_read_len = 0;
-  char* data_buf = (char*)pa.alloc(read_size);
-  void* m_idx_node_buf = pa.alloc(sizeof(MetaIndexNode));
-  if (IS_NULL(data_buf) || IS_NULL(m_idx_node_buf)) {
-      return E_OOM;
-  }
-  auto* top_node_ptr = new(m_idx_node_buf) MetaIndexNode(&pa);
-  auto top_node = std::shared_ptr<MetaIndexNode>(
-      top_node_ptr, MetaIndexNode::self_deleter);
-
-  if (RET_FAIL(read_file_->read(start_offset, data_buf, read_size,
-      ret_read_len))) {
-      return ret;
-  } else if (RET_FAIL(top_node->deserialize_from(data_buf, read_size))) {
-      return ret;
-  }
-
-  bool is_aligned = is_aligned_device(top_node);
-  TimeseriesIndex* timeseries_index = nullptr;
-  if (is_aligned) {
-      get_time_column_metadata(top_node, timeseries_index, pa);
-  }
-
-  int64_t idx = 0;
-  for (const auto& measurement_name : measurement_names) {
-      if (RET_FAIL(load_measurement_index_entry(
-          measurement_name, top_node, measurement_index_entry,
-          measurement_ie_end_offset))) {
-      } else if (RET_FAIL(do_load_timeseries_index(
-          measurement_name, measurement_index_entry->get_offset(),
-          measurement_ie_end_offset, pa,
-          timeseries_indexs[idx], is_aligned))) {
-      }
-      if (is_aligned) {
-          AlignedTimeseriesIndex* aligned_timeseries_index = dynamic_cast<
-              AlignedTimeseriesIndex*>(timeseries_indexs[idx]);
-          if (aligned_timeseries_index) {
-              aligned_timeseries_index->time_ts_idx_ = timeseries_index;
-          }
-      }
-
-      idx++;
-  }
-  return ret;
 }
 
 /*
@@ -484,93 +485,96 @@ int TsFileIOReader::get_timeseries_indexes(std::shared_ptr<IDeviceID> device_id,
 int TsFileIOReader::search_from_leaf_node(
     std::shared_ptr<IComparable> target_name,
     std::shared_ptr<MetaIndexNode> index_node,
-    std::shared_ptr<IMetaIndexEntry> &ret_index_entry, int64_t &ret_end_offset) {
-  int ret = E_OK;
-  ret = index_node->binary_search_children(target_name, true, ret_index_entry,
-                                           ret_end_offset);
-  return ret;
+    std::shared_ptr<IMetaIndexEntry> &ret_index_entry,
+    int64_t &ret_end_offset) {
+    int ret = E_OK;
+    ret = index_node->binary_search_children(target_name, true, ret_index_entry,
+                                             ret_end_offset);
+    return ret;
 }
 
 int TsFileIOReader::search_from_internal_node(
     std::shared_ptr<IComparable> target_name, bool is_device,
-    std::shared_ptr<MetaIndexNode> index_node, std::shared_ptr<IMetaIndexEntry> &ret_index_entry,
+    std::shared_ptr<MetaIndexNode> index_node,
+    std::shared_ptr<IMetaIndexEntry> &ret_index_entry,
     int64_t &ret_end_offset) {
-  int ret = E_OK;
-  std::shared_ptr<IMetaIndexEntry> index_entry;
-  int64_t end_offset = 0;
+    int ret = E_OK;
+    std::shared_ptr<IMetaIndexEntry> index_entry;
+    int64_t end_offset = 0;
 
-  ASSERT(index_node->node_type_ == INTERNAL_MEASUREMENT ||
-      index_node->node_type_ == INTERNAL_DEVICE);
-  if (RET_FAIL(index_node->binary_search_children(
-      target_name, /*exact=*/false, index_entry, end_offset))) {
-    return ret;
-  }
-
-  while (IS_SUCC(ret)) {
-    // reader next level index node
-    const int read_size = end_offset - index_entry->get_offset();
-#if DEBUG_SE
-    std::cout << "search_from_internal_node, end_offset=" << end_offset
-              << ", index_entry.offset_=" << index_entry.get_offset()
-              << std::endl;
-#endif
-    ASSERT(read_size > 0 && read_size < (1 << 30));
-    PageArena cur_level_index_node_pa;
-    void *buf = cur_level_index_node_pa.alloc(sizeof(MetaIndexNode));
-    char *data_buf = (char *) cur_level_index_node_pa.alloc(read_size);
-    if (IS_NULL(buf) || IS_NULL(data_buf)) {
-      return E_OOM;
-    }
-    MetaIndexNode *cur_level_index_node =
-        new(buf) MetaIndexNode(&cur_level_index_node_pa);
-    int32_t ret_read_len = 0;
-    if (RET_FAIL(read_file_->read(index_entry->get_offset(), data_buf, read_size,
-                                  ret_read_len))) {
-    } else if (read_size != ret_read_len) {
-      return E_TSFILE_CORRUPTED;
-    }
-    if (!is_device) {
-        ret = cur_level_index_node->deserialize_from(data_buf, read_size);
-    } else {
-        ret = cur_level_index_node->device_deserialize_from(data_buf, read_size);
-    }
-    if (ret != E_OK) {
+    ASSERT(index_node->node_type_ == INTERNAL_MEASUREMENT ||
+           index_node->node_type_ == INTERNAL_DEVICE);
+    if (RET_FAIL(index_node->binary_search_children(
+            target_name, /*exact=*/false, index_entry, end_offset))) {
         return ret;
     }
-    if (cur_level_index_node->node_type_ == LEAF_DEVICE) {
-        ret = cur_level_index_node->binary_search_children(
-            target_name, /*exact=*/true, ret_index_entry,
-            ret_end_offset);
-        cur_level_index_node->destroy();
-        return ret; //// FIXME
-    } else if (cur_level_index_node->node_type_ == LEAF_MEASUREMENT) {
-        ret = cur_level_index_node->binary_search_children(
-            target_name, /*exact=*/false, ret_index_entry,
-            ret_end_offset);
-        cur_level_index_node->destroy();
-        return ret; //// FIXME
-    } else {
-        ret = cur_level_index_node->binary_search_children(
-            target_name, /*exact=*/false, index_entry, end_offset);
-        cur_level_index_node->destroy();
+
+    while (IS_SUCC(ret)) {
+        // reader next level index node
+        const int read_size = end_offset - index_entry->get_offset();
+#if DEBUG_SE
+        std::cout << "search_from_internal_node, end_offset=" << end_offset
+                  << ", index_entry.offset_=" << index_entry.get_offset()
+                  << std::endl;
+#endif
+        ASSERT(read_size > 0 && read_size < (1 << 30));
+        PageArena cur_level_index_node_pa;
+        void *buf = cur_level_index_node_pa.alloc(sizeof(MetaIndexNode));
+        char *data_buf = (char *)cur_level_index_node_pa.alloc(read_size);
+        if (IS_NULL(buf) || IS_NULL(data_buf)) {
+            return E_OOM;
+        }
+        MetaIndexNode *cur_level_index_node =
+            new (buf) MetaIndexNode(&cur_level_index_node_pa);
+        int32_t ret_read_len = 0;
+        if (RET_FAIL(read_file_->read(index_entry->get_offset(), data_buf,
+                                      read_size, ret_read_len))) {
+        } else if (read_size != ret_read_len) {
+            return E_TSFILE_CORRUPTED;
+        }
+        if (!is_device) {
+            ret = cur_level_index_node->deserialize_from(data_buf, read_size);
+        } else {
+            ret = cur_level_index_node->device_deserialize_from(data_buf,
+                                                                read_size);
+        }
+        if (ret != E_OK) {
+            return ret;
+        }
+        if (cur_level_index_node->node_type_ == LEAF_DEVICE) {
+            ret = cur_level_index_node->binary_search_children(
+                target_name, /*exact=*/true, ret_index_entry, ret_end_offset);
+            cur_level_index_node->destroy();
+            return ret;  //// FIXME
+        } else if (cur_level_index_node->node_type_ == LEAF_MEASUREMENT) {
+            ret = cur_level_index_node->binary_search_children(
+                target_name, /*exact=*/false, ret_index_entry, ret_end_offset);
+            cur_level_index_node->destroy();
+            return ret;  //// FIXME
+        } else {
+            ret = cur_level_index_node->binary_search_children(
+                target_name, /*exact=*/false, index_entry, end_offset);
+            cur_level_index_node->destroy();
+        }
     }
-  }
-  return ret;
+    return ret;
 }
 
-bool TsFileIOReader::is_aligned_device(std::shared_ptr<MetaIndexNode> measurement_node) {
+bool TsFileIOReader::is_aligned_device(
+    std::shared_ptr<MetaIndexNode> measurement_node) {
     auto entry = measurement_node->children_[0];
-    return entry->get_name().is_null() || entry->get_name().to_std_string() == "";
+    return entry->get_name().is_null() ||
+           entry->get_name().to_std_string() == "";
 }
 
 int TsFileIOReader::get_time_column_metadata(
     std::shared_ptr<MetaIndexNode> measurement_node,
-    TimeseriesIndex*& ret_timeseries_index, PageArena& pa) {
+    TimeseriesIndex *&ret_timeseries_index, PageArena &pa) {
     int ret = E_OK;
     if (!is_aligned_device(measurement_node)) {
         return ret;
     }
-    char* ti_buf = nullptr;
+    char *ti_buf = nullptr;
     int start_idx = 0, end_idx = 0;
     int ret_read_len = 0;
     if (measurement_node->node_type_ == LEAF_MEASUREMENT) {
@@ -579,18 +583,16 @@ int TsFileIOReader::get_time_column_metadata(
             start_idx = measurement_node->children_[0]->get_offset();
             end_idx = measurement_node->children_[1]->get_offset();
             ti_buf = pa.alloc(end_idx - start_idx);
-            if (RET_FAIL(
-                read_file_->read(start_idx, ti_buf, end_idx - start_idx,
-                    ret_read_len))) {
+            if (RET_FAIL(read_file_->read(start_idx, ti_buf,
+                                          end_idx - start_idx, ret_read_len))) {
                 return ret;
             }
         } else {
             start_idx = measurement_node->children_[0]->get_offset();
             end_idx = measurement_node->end_offset_;
             ti_buf = pa.alloc(end_idx - start_idx);
-            if (RET_FAIL(
-                read_file_->read(start_idx, ti_buf, end_idx - start_idx,
-                    ret_read_len))) {
+            if (RET_FAIL(read_file_->read(start_idx, ti_buf,
+                                          end_idx - start_idx, ret_read_len))) {
                 return ret;
             }
         }
@@ -599,20 +601,21 @@ int TsFileIOReader::get_time_column_metadata(
         if (IS_NULL(buf)) {
             return E_OOM;
         }
-        ret_timeseries_index = new(buf) TimeseriesIndex;
+        ret_timeseries_index = new (buf) TimeseriesIndex;
         ret_timeseries_index->deserialize_from(buffer, &pa);
     } else if (measurement_node->node_type_ == INTERNAL_MEASUREMENT) {
         start_idx = measurement_node->children_[0]->get_offset();
         end_idx = measurement_node->children_[1]->get_offset();
         ti_buf = pa.alloc(end_idx - start_idx);
-        if (RET_FAIL(
-            read_file_->read(start_idx, ti_buf, end_idx - start_idx,
-                ret_read_len))) {
+        if (RET_FAIL(read_file_->read(start_idx, ti_buf, end_idx - start_idx,
+                                      ret_read_len))) {
             return ret;
         }
-        std::shared_ptr<MetaIndexNode> meta_index_node = std::make_shared<MetaIndexNode>(&pa);
+        std::shared_ptr<MetaIndexNode> meta_index_node =
+            std::make_shared<MetaIndexNode>(&pa);
         meta_index_node->deserialize_from(ti_buf, end_idx - start_idx);
-        return get_time_column_metadata(meta_index_node, ret_timeseries_index, pa);
+        return get_time_column_metadata(meta_index_node, ret_timeseries_index,
+                                        pa);
     }
     return ret;
 }
@@ -621,150 +624,153 @@ int TsFileIOReader::do_load_timeseries_index(
     const std::string &measurement_name_str, int64_t start_offset,
     int64_t end_offset, PageArena &in_timeseries_index_pa,
     ITimeseriesIndex *&ret_timeseries_index, bool is_aligned) {
-  ASSERT(end_offset > start_offset);
-  int ret = E_OK;
-  int32_t read_size = (int32_t) (end_offset - start_offset);
-  int32_t ret_read_len = 0;
-  char *ti_buf = (char *) mem_alloc(read_size, MOD_TSFILE_READER);
-  if (IS_NULL(ti_buf)) {
-    return E_OOM;
-  }
-  if (RET_FAIL(
-      read_file_->read(start_offset, ti_buf, read_size, ret_read_len))) {
-  } else {
-    ByteStream bs;
-    bs.wrap_from(ti_buf, read_size);
-    const String target_measurement_name(
-        (char *) measurement_name_str.c_str(),
-        strlen(measurement_name_str.c_str()));
-    bool found = false;
-#if DEBUG_SE
-    std::cout << "do_load_timeseries_index, reader file at " << start_offset
-              << " to " << end_offset << std::endl;
-#endif
-    while (IS_SUCC(ret)) {
-      TimeseriesIndex cur_timeseries_index;
-      PageArena cur_timeseries_index_pa;
-      cur_timeseries_index_pa.init(512, MOD_TSFILE_READER); // TODO 512
-      if (RET_FAIL(cur_timeseries_index.deserialize_from(
-          bs, &cur_timeseries_index_pa))) {
-      } else if (is_aligned && cur_timeseries_index.get_measurement_name().equal_to(
-            target_measurement_name)) {
-          void *buf = in_timeseries_index_pa.alloc(
-              sizeof(AlignedTimeseriesIndex));
-          if (IS_NULL(buf)) {
-              return E_OOM;
-          }
-          AlignedTimeseriesIndex * aligned_ts_idx = new(buf) AlignedTimeseriesIndex;
-          buf = in_timeseries_index_pa.alloc(sizeof(TimeseriesIndex));
-          if (IS_NULL(buf)) {
-              return E_OOM;
-          }
-          aligned_ts_idx->value_ts_idx_ = new(buf) TimeseriesIndex;
-          aligned_ts_idx->value_ts_idx_->clone_from(
-              cur_timeseries_index, &in_timeseries_index_pa);
-          ret_timeseries_index = aligned_ts_idx;
-          found = true;
-          break;
-      } else if (!is_aligned && cur_timeseries_index.get_measurement_name().equal_to(
-              target_measurement_name)) {
-        void *buf =
-            in_timeseries_index_pa.alloc(sizeof(TimeseriesIndex));
-        auto ts_idx = new(buf) TimeseriesIndex;
-        ts_idx->clone_from(cur_timeseries_index,
-                           &in_timeseries_index_pa);
-        ret_timeseries_index = ts_idx;
-        found = true;
-        break;
-      }
-    } // end while
-    if (!found) {
-      ret = E_NOT_EXIST;
+    ASSERT(end_offset > start_offset);
+    int ret = E_OK;
+    int32_t read_size = (int32_t)(end_offset - start_offset);
+    int32_t ret_read_len = 0;
+    char *ti_buf = (char *)mem_alloc(read_size, MOD_TSFILE_READER);
+    if (IS_NULL(ti_buf)) {
+        return E_OOM;
     }
-  }
-  mem_free(ti_buf);
-  return ret;
+    if (RET_FAIL(
+            read_file_->read(start_offset, ti_buf, read_size, ret_read_len))) {
+    } else {
+        ByteStream bs;
+        bs.wrap_from(ti_buf, read_size);
+        const String target_measurement_name(
+            (char *)measurement_name_str.c_str(),
+            strlen(measurement_name_str.c_str()));
+        bool found = false;
+#if DEBUG_SE
+        std::cout << "do_load_timeseries_index, reader file at " << start_offset
+                  << " to " << end_offset << std::endl;
+#endif
+        while (IS_SUCC(ret)) {
+            TimeseriesIndex cur_timeseries_index;
+            PageArena cur_timeseries_index_pa;
+            cur_timeseries_index_pa.init(512, MOD_TSFILE_READER);  // TODO 512
+            if (RET_FAIL(cur_timeseries_index.deserialize_from(
+                    bs, &cur_timeseries_index_pa))) {
+            } else if (is_aligned &&
+                       cur_timeseries_index.get_measurement_name().equal_to(
+                           target_measurement_name)) {
+                void *buf = in_timeseries_index_pa.alloc(
+                    sizeof(AlignedTimeseriesIndex));
+                if (IS_NULL(buf)) {
+                    return E_OOM;
+                }
+                AlignedTimeseriesIndex *aligned_ts_idx =
+                    new (buf) AlignedTimeseriesIndex;
+                buf = in_timeseries_index_pa.alloc(sizeof(TimeseriesIndex));
+                if (IS_NULL(buf)) {
+                    return E_OOM;
+                }
+                aligned_ts_idx->value_ts_idx_ = new (buf) TimeseriesIndex;
+                aligned_ts_idx->value_ts_idx_->clone_from(
+                    cur_timeseries_index, &in_timeseries_index_pa);
+                ret_timeseries_index = aligned_ts_idx;
+                found = true;
+                break;
+            } else if (!is_aligned &&
+                       cur_timeseries_index.get_measurement_name().equal_to(
+                           target_measurement_name)) {
+                void *buf =
+                    in_timeseries_index_pa.alloc(sizeof(TimeseriesIndex));
+                auto ts_idx = new (buf) TimeseriesIndex;
+                ts_idx->clone_from(cur_timeseries_index,
+                                   &in_timeseries_index_pa);
+                ret_timeseries_index = ts_idx;
+                found = true;
+                break;
+            }
+        }  // end while
+        if (!found) {
+            ret = E_NOT_EXIST;
+        }
+    }
+    mem_free(ti_buf);
+    return ret;
 }
 
 int TsFileIOReader::do_load_all_timeseries_index(
-    std::vector<std::pair<std::shared_ptr<IMetaIndexEntry>, int64_t> > &
-    index_node_entry_list,
+    std::vector<std::pair<std::shared_ptr<IMetaIndexEntry>, int64_t> >
+        &index_node_entry_list,
     common::PageArena &in_timeseries_index_pa,
     std::vector<ITimeseriesIndex *> &ts_indexs) {
-  int ret = E_OK;
-  for (const auto &index_node_entry : index_node_entry_list) {
-    int64_t start_offset = index_node_entry.first->get_offset(),
-        end_offset = index_node_entry.second;
-    const std::string target_measurement_name(
-        index_node_entry.first->get_name().to_std_string());
-    ITimeseriesIndex *ts_idx;
-    ret = do_load_timeseries_index(target_measurement_name, start_offset,
-                                   end_offset, in_timeseries_index_pa,
-                                   ts_idx);
-    if (IS_SUCC(ret)) {
-      ts_indexs.push_back(ts_idx);
+    int ret = E_OK;
+    for (const auto &index_node_entry : index_node_entry_list) {
+        int64_t start_offset = index_node_entry.first->get_offset(),
+                end_offset = index_node_entry.second;
+        const std::string target_measurement_name(
+            index_node_entry.first->get_name().to_std_string());
+        ITimeseriesIndex *ts_idx;
+        ret = do_load_timeseries_index(target_measurement_name, start_offset,
+                                       end_offset, in_timeseries_index_pa,
+                                       ts_idx);
+        if (IS_SUCC(ret)) {
+            ts_indexs.push_back(ts_idx);
+        }
     }
-  }
-  return ret;
+    return ret;
 }
 
 int TsFileIOReader::get_all_leaf(
     std::shared_ptr<MetaIndexNode> index_node,
-    std::vector<std::pair<std::shared_ptr<IMetaIndexEntry>, int64_t> > &
-    index_node_entry_list) {
-  int ret = E_OK;
-  if (index_node->node_type_ == LEAF_MEASUREMENT ||
-      index_node->node_type_ == LEAF_DEVICE) {
-    for (size_t i = 0; i < index_node->children_.size(); i++) {
-      if (i + 1 < index_node->children_.size()) {
-        index_node_entry_list.push_back(
-            std::make_pair(index_node->children_[i],
-                           index_node->children_[i + 1]->get_offset()));
-      } else {
-        index_node_entry_list.push_back(std::make_pair(
-            index_node->children_[i], index_node->end_offset_));
-      }
-    }
-  } else {
-    // read next level index node
-    for (size_t i = 0; i < index_node->children_.size(); i++) {
-      int64_t end_offset = index_node->end_offset_;
-      if (i + 1 < index_node->children_.size()) {
-        end_offset = index_node->children_[i + 1]->get_offset();
-      }
-      const int read_size =
-          end_offset - index_node->children_[i]->get_offset();
+    std::vector<std::pair<std::shared_ptr<IMetaIndexEntry>, int64_t> >
+        &index_node_entry_list) {
+    int ret = E_OK;
+    if (index_node->node_type_ == LEAF_MEASUREMENT ||
+        index_node->node_type_ == LEAF_DEVICE) {
+        for (size_t i = 0; i < index_node->children_.size(); i++) {
+            if (i + 1 < index_node->children_.size()) {
+                index_node_entry_list.push_back(
+                    std::make_pair(index_node->children_[i],
+                                   index_node->children_[i + 1]->get_offset()));
+            } else {
+                index_node_entry_list.push_back(std::make_pair(
+                    index_node->children_[i], index_node->end_offset_));
+            }
+        }
+    } else {
+        // read next level index node
+        for (size_t i = 0; i < index_node->children_.size(); i++) {
+            int64_t end_offset = index_node->end_offset_;
+            if (i + 1 < index_node->children_.size()) {
+                end_offset = index_node->children_[i + 1]->get_offset();
+            }
+            const int read_size =
+                end_offset - index_node->children_[i]->get_offset();
 #if DEBUG_SE
-      std::cout << "search_from_internal_node, end_offset=" << end_offset
-                << ", index_entry.offset_=" << index_node->children_[i]->get_offset()
-                << std::endl;
+            std::cout << "search_from_internal_node, end_offset=" << end_offset
+                      << ", index_entry.offset_="
+                      << index_node->children_[i]->get_offset() << std::endl;
 #endif
-      ASSERT(read_size > 0 && read_size < (1 << 30));
-      PageArena cur_level_index_node_pa;
-      void *buf = cur_level_index_node_pa.alloc(sizeof(MetaIndexNode));
-      char *data_buf = (char *) cur_level_index_node_pa.alloc(read_size);
-      if (IS_NULL(buf) || IS_NULL(data_buf)) {
-        return E_OOM;
-      }
-      auto *cur_level_index_node_ptr = new(buf) MetaIndexNode(
-          &cur_level_index_node_pa);
-      auto cur_level_index_node = std::shared_ptr<MetaIndexNode>(
-          cur_level_index_node_ptr, MetaIndexNode::self_deleter);
+            ASSERT(read_size > 0 && read_size < (1 << 30));
+            PageArena cur_level_index_node_pa;
+            void *buf = cur_level_index_node_pa.alloc(sizeof(MetaIndexNode));
+            char *data_buf = (char *)cur_level_index_node_pa.alloc(read_size);
+            if (IS_NULL(buf) || IS_NULL(data_buf)) {
+                return E_OOM;
+            }
+            auto *cur_level_index_node_ptr =
+                new (buf) MetaIndexNode(&cur_level_index_node_pa);
+            auto cur_level_index_node = std::shared_ptr<MetaIndexNode>(
+                cur_level_index_node_ptr, MetaIndexNode::self_deleter);
 
-      int32_t ret_read_len = 0;
-      if (RET_FAIL(
-          read_file_->read(index_node->children_[i]->get_offset(),
-                           data_buf, read_size, ret_read_len))) {
-      } else if (read_size != ret_read_len) {
-        ret = E_TSFILE_CORRUPTED;
-      } else if (RET_FAIL(cur_level_index_node->deserialize_from(
-          data_buf, read_size))) {
-      } else {
-        ret = get_all_leaf(cur_level_index_node, index_node_entry_list);
-      }
+            int32_t ret_read_len = 0;
+            if (RET_FAIL(
+                    read_file_->read(index_node->children_[i]->get_offset(),
+                                     data_buf, read_size, ret_read_len))) {
+            } else if (read_size != ret_read_len) {
+                ret = E_TSFILE_CORRUPTED;
+            } else if (RET_FAIL(cur_level_index_node->deserialize_from(
+                           data_buf, read_size))) {
+            } else {
+                ret = get_all_leaf(cur_level_index_node, index_node_entry_list);
+            }
+        }
     }
-  }
-  return ret;
+    return ret;
 }
 #if 0
 int TsFileIOReader::get_next(const std::string &device_path,
@@ -873,4 +879,4 @@ int TsFileIOReader::load_timeseries_index(const ColumnDesc &col_desc)
   return ret;
 }
 #endif
-} // end namespace storage
+}  // end namespace storage

--- a/cpp/src/reader/block/device_ordered_tsblock_reader.cc
+++ b/cpp/src/reader/block/device_ordered_tsblock_reader.cc
@@ -23,7 +23,8 @@ namespace storage {
 
 int DeviceOrderedTsBlockReader::has_next(bool &has_next) {
     int ret = common::E_OK;
-    if (current_reader_ != nullptr && IS_SUCC(current_reader_->has_next(has_next)) && has_next) {
+    if (current_reader_ != nullptr &&
+        IS_SUCC(current_reader_->has_next(has_next)) && has_next) {
         return common::E_OK;
     }
     if (current_reader_ != nullptr) {
@@ -40,12 +41,13 @@ int DeviceOrderedTsBlockReader::has_next(bool &has_next) {
             current_reader_ = nullptr;
         }
         current_reader_ = new SingleDeviceTsBlockReader(
-            task, block_size_, metadata_querier_, tsfile_io_reader_, time_filter_,
-            field_filter_);
+            task, block_size_, metadata_querier_, tsfile_io_reader_,
+            time_filter_, field_filter_);
         if (current_reader_ == nullptr) {
             return common::E_OOM;
         }
-        if (RET_FAIL(current_reader_->init(task, block_size_, time_filter_, field_filter_))) {
+        if (RET_FAIL(current_reader_->init(task, block_size_, time_filter_,
+                                           field_filter_))) {
             delete current_reader_;
             current_reader_ = nullptr;
             return ret;

--- a/cpp/src/reader/chunk_reader.cc
+++ b/cpp/src/reader/chunk_reader.cc
@@ -240,8 +240,8 @@ int ChunkReader::read_from_file_and_rewrap(int want_size) {
         file_data_buf_size_ = read_size;
     }
     int ret_read_len = 0;
-    if (RET_FAIL(read_file_->read(offset, file_data_buf, read_size,
-                                  ret_read_len))) {
+    if (RET_FAIL(
+            read_file_->read(offset, file_data_buf, read_size, ret_read_len))) {
     } else {
         in_stream_.wrap_from(file_data_buf, ret_read_len);
         // DEBUG_hex_dump_buf("wrapped buf = ", file_data_buf, 256);
@@ -474,8 +474,8 @@ int ChunkReader::decode_tv_buf_into_tsblock_by_datatype(ByteStream &time_in,
                                          row_appender);
             break;
         case common::STRING:
-            ret = STRING_DECODE_TYPED_TV_INTO_TSBLOCK(time_in, value_in, row_appender,
-                                                *pa, filter);
+            ret = STRING_DECODE_TYPED_TV_INTO_TSBLOCK(
+                time_in, value_in, row_appender, *pa, filter);
             break;
         default:
             ret = E_NOT_SUPPORT;

--- a/cpp/src/reader/device_meta_iterator.cc
+++ b/cpp/src/reader/device_meta_iterator.cc
@@ -58,7 +58,8 @@ int DeviceMetaIterator::load_results() {
         } else {
             return common::E_INVALID_NODE_TYPE;
         }
-        // The first MetaIndexNode is the root and is not loaded here, so no need to destruct it here.
+        // The first MetaIndexNode is the root and is not loaded here, so no
+        // need to destruct it here.
         if (!is_root_idx_node) {
             meta_data_index_node->~MetaIndexNode();
         }

--- a/cpp/src/reader/filter/gt_eq.h
+++ b/cpp/src/reader/filter/gt_eq.h
@@ -26,7 +26,7 @@ namespace storage {
 template <typename T>
 class GtEq : public UnaryFilter<T> {
    public:
-    GtEq() : UnaryFilter<T>(){};
+    GtEq() : UnaryFilter<T>() {};
     GtEq(T value, FilterType type) : UnaryFilter<T>(value, type) {}
 
     virtual ~GtEq() {}

--- a/cpp/src/reader/filter/gt_eq.h
+++ b/cpp/src/reader/filter/gt_eq.h
@@ -26,7 +26,7 @@ namespace storage {
 template <typename T>
 class GtEq : public UnaryFilter<T> {
    public:
-    GtEq() : UnaryFilter<T>() {};
+    GtEq() : UnaryFilter<T>(){};
     GtEq(T value, FilterType type) : UnaryFilter<T>(value, type) {}
 
     virtual ~GtEq() {}

--- a/cpp/src/reader/meta_data_querier.cc
+++ b/cpp/src/reader/meta_data_querier.cc
@@ -36,29 +36,33 @@ MetadataQuerier::MetadataQuerier(TsFileIOReader* tsfile_io_reader)
 
 MetadataQuerier::~MetadataQuerier() {}
 
-
-std::vector<std::shared_ptr<ChunkMeta>> MetadataQuerier::get_chunk_metadata_list(
-    const Path& path) const {
+std::vector<std::shared_ptr<ChunkMeta>>
+MetadataQuerier::get_chunk_metadata_list(const Path& path) const {
     // std::vector<std::shared_ptr<ChunkMeta>> chunk_meta_list;
     // if (device_chunk_meta_cache_->tryGet(path.device_, chunk_meta_list)) {
     //     return chunk_meta_list;
     // } else {
-    //     io_reader_->get_chunk_metadata_list(path.device_, path.measurement_, chunk_meta_list);
+    //     io_reader_->get_chunk_metadata_list(path.device_, path.measurement_,
+    //     chunk_meta_list);
     // }
     // return io_reader_->get_chunk_metadata_list(path);
     ASSERT(false);
     return {};
 }
 
-std::vector<std::vector<std::shared_ptr<ChunkMeta>>> MetadataQuerier::get_chunk_metadata_lists(
-    std::shared_ptr<IDeviceID> device_id, const std::unordered_set<std::string>& field_names,
+std::vector<std::vector<std::shared_ptr<ChunkMeta>>>
+MetadataQuerier::get_chunk_metadata_lists(
+    std::shared_ptr<IDeviceID> device_id,
+    const std::unordered_set<std::string>& field_names,
     const MetaIndexNode* field_node) const {
-    // return io_reader_->get_chunk_metadata_lists(device_id, field_names, field_node);
+    // return io_reader_->get_chunk_metadata_lists(device_id, field_names,
+    // field_node);
     ASSERT(false);
     return {};
 }
 
-std::map<Path, std::vector<std::shared_ptr<ChunkMeta>>> MetadataQuerier::get_chunk_metadata_map(const std::vector<Path>& paths) const {
+std::map<Path, std::vector<std::shared_ptr<ChunkMeta>>>
+MetadataQuerier::get_chunk_metadata_map(const std::vector<Path>& paths) const {
     // return io_reader_->get_chunk_metadata_map(paths);
     ASSERT(false);
     return {};
@@ -86,8 +90,7 @@ std::vector<TimeRange> MetadataQuerier::convert_space_to_time_partition(
     return {};
 }
 
-void MetadataQuerier::clear() {
-}
+void MetadataQuerier::clear() {}
 
 std::unique_ptr<DeviceMetaIterator> MetadataQuerier::device_iterator(
     MetaIndexNode* root, const Filter* id_filter) {
@@ -95,8 +98,9 @@ std::unique_ptr<DeviceMetaIterator> MetadataQuerier::device_iterator(
         new DeviceMetaIterator(io_reader_, root, id_filter));
 }
 
-int MetadataQuerier::load_chunk_meta(const std::pair<IDeviceID, std::string>& key,
-                        std::vector<ChunkMeta*>& chunk_meta_list) {
+int MetadataQuerier::load_chunk_meta(
+    const std::pair<IDeviceID, std::string>& key,
+    std::vector<ChunkMeta*>& chunk_meta_list) {
     // return io_reader_->load_chunk_meta(key, chunk_meta_list);
     ASSERT(false);
     return common::E_NOT_SUPPORT;

--- a/cpp/src/reader/qds_with_timegenerator.cc
+++ b/cpp/src/reader/qds_with_timegenerator.cc
@@ -359,7 +359,8 @@ int QDSWithTimeGenerator::next(bool &has_next) {
         return E_OK;
     }
     row_record_->set_timestamp(timestamp);
-    row_record_->get_field(0)->set_value(TSDataType::INT64, &timestamp, sizeof(timestamp), pa_);
+    row_record_->get_field(0)->set_value(TSDataType::INT64, &timestamp,
+                                         sizeof(timestamp), pa_);
 #if DEBUG_SE
     std::cout << "QDSWithTimeGenerator::get_next: timestamp=" << timestamp
               << ", will generate row at this timestamp." << std::endl;
@@ -368,8 +369,8 @@ int QDSWithTimeGenerator::next(bool &has_next) {
     for (size_t i = 0; i < value_at_vec_.size(); i++) {
         ValueAt &va = value_at_vec_[i];
         void *val_obj_ptr = va.at(timestamp);
-        row_record_->get_field(i + 1)->set_value(va.data_type_, val_obj_ptr, get_len(va.data_type_),
-                                                 pa_);
+        row_record_->get_field(i + 1)->set_value(va.data_type_, val_obj_ptr,
+                                                 get_len(va.data_type_), pa_);
     }
 
     tree_->next_timestamp(timestamp);
@@ -399,7 +400,7 @@ std::shared_ptr<ResultSetMetadata> QDSWithTimeGenerator::get_metadata() {
     return result_set_metadata_;
 }
 
-int QDSWithTimeGenerator::construct_node_tree(Expression *expr, Node*& node) {
+int QDSWithTimeGenerator::construct_node_tree(Expression *expr, Node *&node) {
     int ret = E_OK;
     if (expr->type_ == AND_EXPR || expr->type_ == OR_EXPR) {
         if (expr->type_ == AND_EXPR) {

--- a/cpp/src/reader/qds_with_timegenerator.h
+++ b/cpp/src/reader/qds_with_timegenerator.h
@@ -126,7 +126,7 @@ class QDSWithTimeGenerator : public ResultSet {
     std::shared_ptr<ResultSetMetadata> get_metadata();
 
    private:
-    int construct_node_tree(Expression *expr, Node*& node);
+    int construct_node_tree(Expression *expr, Node *&node);
 
    private:
     RowRecord *row_record_;

--- a/cpp/src/reader/qds_without_timegenerator.cc
+++ b/cpp/src/reader/qds_without_timegenerator.cc
@@ -68,8 +68,9 @@ int QDSWithoutTimeGenerator::init(TsFileIOReader *io_reader,
 
     for (size_t i = 0; i < path_count; i++) {
         get_next_tsblock(i, true);
-        data_types.push_back(value_iters_[i] != nullptr ?
-            value_iters_[i]->get_data_type() : TSDataType::NULL_TYPE);
+        data_types.push_back(value_iters_[i] != nullptr
+                                 ? value_iters_[i]->get_data_type()
+                                 : TSDataType::NULL_TYPE);
     }
     result_set_metadata_ =
         std::make_shared<ResultSetMetadata>(column_names, data_types);

--- a/cpp/src/reader/result_set.h
+++ b/cpp/src/reader/result_set.h
@@ -20,10 +20,10 @@
 #ifndef READER_QUERY_DATA_SET_H
 #define READER_QUERY_DATA_SET_H
 
-#include <unordered_map>
+#include <algorithm>
 #include <iostream>
 #include <string>
-#include <algorithm>
+#include <unordered_map>
 
 #include "common/row_record.h"
 
@@ -169,14 +169,12 @@ class ResultSet {
      */
     virtual void close() = 0;
 
-protected:
+   protected:
     struct CaseInsensitiveHash {
         std::size_t operator()(const std::string& str) const {
             std::string lowerStr = str;
             std::transform(lowerStr.begin(), lowerStr.end(), lowerStr.begin(),
-                           [](unsigned char c) {
-                               return std::tolower(c);
-                           });
+                           [](unsigned char c) { return std::tolower(c); });
             return std::hash<std::string>()(lowerStr);
         }
     };
@@ -196,7 +194,8 @@ protected:
     };
 
     std::unordered_map<std::string, uint32_t, CaseInsensitiveHash,
-                       CaseInsensitiveEqual> index_lookup_;
+                       CaseInsensitiveEqual>
+        index_lookup_;
     common::PageArena pa_;
 };
 

--- a/cpp/src/reader/scan_iterator.cc
+++ b/cpp/src/reader/scan_iterator.cc
@@ -165,14 +165,16 @@ int DataRun::reinit_io_reader(SimpleList<OpenFile *>::Iterator &it,
         ////log_err("io_reader init error, ret=%d, file_path=%s",
         // ret, open_file->get_file_path().c_str());
     } else {
-        std::shared_ptr<IDeviceID> device_id = std::make_shared<StringArrayDeviceID>(col_schema_->get_device_name_str());
+        std::shared_ptr<IDeviceID> device_id =
+            std::make_shared<StringArrayDeviceID>(
+                col_schema_->get_device_name_str());
         std::string measurement_name = col_schema_->get_measurement_name_str();
         if (ssi_ != nullptr) {
             delete ssi_;
             ssi_ = nullptr;
         }
-        if (RET_FAIL(io_reader_.alloc_ssi(device_id, measurement_name, ssi_,
-                                          *pa))) {
+        if (RET_FAIL(
+                io_reader_.alloc_ssi(device_id, measurement_name, ssi_, *pa))) {
         }
     }
     return ret;

--- a/cpp/src/reader/table_query_executor.cc
+++ b/cpp/src/reader/table_query_executor.cc
@@ -31,8 +31,8 @@ int TableQueryExecutor::query(const std::string &table_name,
     pa.init(512, common::MOD_TSFILE_READER);
     MetaIndexNode *table_root = nullptr;
     std::shared_ptr<TableSchema> table_schema;
-    if (RET_FAIL(file_metadata->get_table_metaindex_node(table_name,
-                                                         table_root))) {
+    if (RET_FAIL(
+            file_metadata->get_table_metaindex_node(table_name, table_root))) {
     } else if (RET_FAIL(
                    file_metadata->get_table_schema(table_name, table_schema))) {
     }
@@ -45,9 +45,11 @@ int TableQueryExecutor::query(const std::string &table_name,
     for (auto &column : lower_case_column_names) {
         to_lowercase_inplace(column);
     }
-    std::shared_ptr<ColumnMapping> column_mapping = std::make_shared<ColumnMapping>();
+    std::shared_ptr<ColumnMapping> column_mapping =
+        std::make_shared<ColumnMapping>();
     for (size_t i = 0; i < lower_case_column_names.size(); ++i) {
-        column_mapping->add(lower_case_column_names[i], static_cast<int>(i), *table_schema);
+        column_mapping->add(lower_case_column_names[i], static_cast<int>(i),
+                            *table_schema);
     }
     std::vector<common::TSDataType> data_types;
     data_types.reserve(lower_case_column_names.size());
@@ -78,8 +80,8 @@ int TableQueryExecutor::query(const std::string &table_name,
             ret = common::E_UNSUPPORTED_ORDER;
     }
     assert(tsblock_reader != nullptr);
-    ret_qds = new TableResultSet(std::move(tsblock_reader), columns,
-                                 data_types);
+    ret_qds =
+        new TableResultSet(std::move(tsblock_reader), columns, data_types);
     return ret;
 }
 

--- a/cpp/src/reader/table_result_set.cc
+++ b/cpp/src/reader/table_result_set.cc
@@ -72,8 +72,8 @@ int TableResultSet::next(bool& has_next) {
         for (uint32_t i = 0; i < row_iterator_->get_column_count(); ++i) {
             const auto value = row_iterator_->read(i, &len, &null);
             if (!null) {
-                row_record_->get_field(i)->set_value(row_iterator_->get_data_type(i),
-                    value, len, pa_);
+                row_record_->get_field(i)->set_value(
+                    row_iterator_->get_data_type(i), value, len, pa_);
                 row_iterator_->next(i);
             }
         }

--- a/cpp/src/reader/task/device_query_task.cc
+++ b/cpp/src/reader/task/device_query_task.cc
@@ -33,7 +33,7 @@ DeviceQueryTask *DeviceQueryTask::create_device_query_task(
     return task;
 }
 
- DeviceQueryTask::~DeviceQueryTask() {
+DeviceQueryTask::~DeviceQueryTask() {
     if (index_root_) {
         index_root_->~MetaIndexNode();
     }

--- a/cpp/src/reader/task/device_task_iterator.cc
+++ b/cpp/src/reader/task/device_task_iterator.cc
@@ -30,8 +30,8 @@ int DeviceTaskIterator::next(DeviceQueryTask *&task) {
     if (RET_FAIL(device_meta_iterator_->next(device_meta_pair))) {
     } else {
         task = DeviceQueryTask::create_device_query_task(
-            device_meta_pair.first, column_names_, column_mapping_, device_meta_pair.second,
-            table_schema_, pa_);
+            device_meta_pair.first, column_names_, column_mapping_,
+            device_meta_pair.second, table_schema_, pa_);
     }
     return ret;
 }

--- a/cpp/src/reader/tsfile_reader.cc
+++ b/cpp/src/reader/tsfile_reader.cc
@@ -27,8 +27,9 @@ using namespace storage;
 
 namespace storage {
 TsFileReader::TsFileReader()
-    : read_file_(nullptr), tsfile_executor_(nullptr), table_query_executor_(nullptr) {
-}
+    : read_file_(nullptr),
+      tsfile_executor_(nullptr),
+      table_query_executor_(nullptr) {}
 
 TsFileReader::~TsFileReader() { close(); }
 
@@ -83,12 +84,12 @@ int TsFileReader::query(std::vector<std::string>& path_list, int64_t start_time,
     return ret;
 }
 
-int TsFileReader::query(const std::string &table_name,
-                        const std::vector<std::string> &columns_names,
+int TsFileReader::query(const std::string& table_name,
+                        const std::vector<std::string>& columns_names,
                         int64_t start_time, int64_t end_time,
-                        ResultSet *&result_set) {
+                        ResultSet*& result_set) {
     int ret = E_OK;
-    TsFileMeta *tsfile_meta = tsfile_executor_->get_tsfile_meta();
+    TsFileMeta* tsfile_meta = tsfile_executor_->get_tsfile_meta();
     if (tsfile_meta == nullptr) {
         return E_TSFILE_WRITER_META_ERR;
     }
@@ -101,11 +102,13 @@ int TsFileReader::query(const std::string &table_name,
     std::vector<TSDataType> data_types = table_schema->get_data_types();
 
     Filter* time_filter = new TimeBetween(start_time, end_time, false);
-    ret = table_query_executor_->query(to_lower(table_name), columns_names, time_filter, nullptr, nullptr, result_set);
+    ret =
+        table_query_executor_->query(to_lower(table_name), columns_names,
+                                     time_filter, nullptr, nullptr, result_set);
     return ret;
 }
 
-void TsFileReader::destroy_query_data_set(storage::ResultSet *qds) {
+void TsFileReader::destroy_query_data_set(storage::ResultSet* qds) {
     tsfile_executor_->destroy_query_data_set(qds);
 }
 
@@ -197,26 +200,27 @@ ResultSet* TsFileReader::read_timeseries(
     return nullptr;
 }
 
-std::shared_ptr<TableSchema> TsFileReader::get_table_schema(const std::string &table_name) {
-    TsFileMeta *file_metadata = tsfile_executor_->get_tsfile_meta();
-    MetaIndexNode *table_root = nullptr;
+std::shared_ptr<TableSchema> TsFileReader::get_table_schema(
+    const std::string& table_name) {
+    TsFileMeta* file_metadata = tsfile_executor_->get_tsfile_meta();
+    MetaIndexNode* table_root = nullptr;
     std::shared_ptr<TableSchema> table_schema;
     if (IS_FAIL(file_metadata->get_table_metaindex_node(to_lower(table_name),
-                                                         table_root))) {
-    } else if (IS_FAIL(
-                   file_metadata->get_table_schema(to_lower(table_name), table_schema))) {
+                                                        table_root))) {
+    } else if (IS_FAIL(file_metadata->get_table_schema(to_lower(table_name),
+                                                       table_schema))) {
     }
     return table_schema;
 }
 
-std::vector<std::shared_ptr<TableSchema>> TsFileReader::get_all_table_schemas() {
-    TsFileMeta *file_metadata = tsfile_executor_->get_tsfile_meta();
+std::vector<std::shared_ptr<TableSchema>>
+TsFileReader::get_all_table_schemas() {
+    TsFileMeta* file_metadata = tsfile_executor_->get_tsfile_meta();
     std::vector<std::shared_ptr<TableSchema>> table_schemas;
     for (const auto& table_schema : file_metadata->table_schemas_) {
         table_schemas.push_back(table_schema.second);
     }
     return table_schemas;
 }
-
 
 }  // namespace storage

--- a/cpp/src/utils/db_utils.h
+++ b/cpp/src/utils/db_utils.h
@@ -70,7 +70,7 @@ struct TsID {
     NodeID device_nid_;
     NodeID measurement_nid_;
 
-    TsID() : db_nid_(0), device_nid_(0), measurement_nid_(0) {};
+    TsID() : db_nid_(0), device_nid_(0), measurement_nid_(0){};
 
     TsID(NodeID db_nid, NodeID device_nid, NodeID measurement_nid)
         : db_nid_(db_nid),

--- a/cpp/src/utils/db_utils.h
+++ b/cpp/src/utils/db_utils.h
@@ -70,7 +70,7 @@ struct TsID {
     NodeID device_nid_;
     NodeID measurement_nid_;
 
-    TsID() : db_nid_(0), device_nid_(0), measurement_nid_(0){};
+    TsID() : db_nid_(0), device_nid_(0), measurement_nid_(0) {};
 
     TsID(NodeID db_nid, NodeID device_nid, NodeID measurement_nid)
         : db_nid_(db_nid),
@@ -149,7 +149,6 @@ struct TsID {
         return std::string(buf);
     }
 };
-
 
 /**
  * @brief Represents the schema information for a single measurement.

--- a/cpp/src/utils/storage_utils.h
+++ b/cpp/src/utils/storage_utils.h
@@ -21,6 +21,7 @@
 
 #include <inttypes.h>
 #include <stdint.h>
+
 #include <algorithm>
 
 #include "common/datatype/value.h"

--- a/cpp/src/writer/chunk_writer.cc
+++ b/cpp/src/writer/chunk_writer.cc
@@ -26,8 +26,8 @@ using namespace common;
 namespace storage {
 
 int ChunkWriter::init(const ColumnSchema &col_schema) {
-    return init(col_schema.column_name_, col_schema.data_type_, col_schema.encoding_,
-                col_schema.compression_);
+    return init(col_schema.column_name_, col_schema.data_type_,
+                col_schema.encoding_, col_schema.compression_);
 }
 
 int ChunkWriter::init(const std::string &measurement_name, TSDataType data_type,
@@ -140,9 +140,11 @@ void ChunkWriter::save_first_page_data(PageWriter &first_page_writer) {
     first_page_statistic_->deep_copy_from(first_page_writer.get_statistic());
 }
 
-int ChunkWriter::write_first_page_data(ByteStream &pages_data, bool with_statistic) {
+int ChunkWriter::write_first_page_data(ByteStream &pages_data,
+                                       bool with_statistic) {
     int ret = E_OK;
-    if (with_statistic && RET_FAIL(first_page_statistic_->serialize_to(pages_data))) {
+    if (with_statistic &&
+        RET_FAIL(first_page_statistic_->serialize_to(pages_data))) {
     } else if (RET_FAIL(
                    pages_data.write_buf(first_page_data_.compressed_buf_,
                                         first_page_data_.compressed_size_))) {

--- a/cpp/src/writer/tsfile_table_writer.cc
+++ b/cpp/src/writer/tsfile_table_writer.cc
@@ -21,7 +21,8 @@
 
 storage::TsFileTableWriter::~TsFileTableWriter() = default;
 
-int storage::TsFileTableWriter::register_table(const std::shared_ptr<TableSchema>& table_schema) {
+int storage::TsFileTableWriter::register_table(
+    const std::shared_ptr<TableSchema>& table_schema) {
     int ret = tsfile_writer_->register_table(table_schema);
     // if multiple tables are registered, set
     exclusive_table_name_ = "";
@@ -35,7 +36,8 @@ int storage::TsFileTableWriter::write_table(storage::Tablet& tablet) const {
     }
     if (tablet.get_table_name().empty()) {
         tablet.set_table_name(exclusive_table_name_);
-    } else if (!exclusive_table_name_.empty() && tablet.get_table_name() != exclusive_table_name_) {
+    } else if (!exclusive_table_name_.empty() &&
+               tablet.get_table_name() != exclusive_table_name_) {
         return common::E_TABLE_NOT_EXIST;
     }
     tablet.set_table_name(to_lower(tablet.get_table_name()));

--- a/cpp/test/common/device_id_test.cc
+++ b/cpp/test/common/device_id_test.cc
@@ -20,6 +20,7 @@
 #include "common/device_id.h"
 
 #include <gtest/gtest.h>
+
 #include "common/tablet.h"
 
 namespace storage {
@@ -32,12 +33,15 @@ TEST(DeviceIdTest, NormalTest) {
 
 TEST(DeviceIdTest, TabletDeviceId) {
     std::vector<TSDataType> measurement_types{
-        TSDataType::STRING, TSDataType::STRING, TSDataType::STRING, TSDataType::INT32};
-    std::vector<ColumnCategory> column_categories{ColumnCategory::TAG, ColumnCategory::TAG, ColumnCategory::TAG, ColumnCategory::FIELD};
-    std::vector<std::string> measurement_names{"tag1", "tag2",
-                                               "tag3", "value"};
+        TSDataType::STRING, TSDataType::STRING, TSDataType::STRING,
+        TSDataType::INT32};
+    std::vector<ColumnCategory> column_categories{
+        ColumnCategory::TAG, ColumnCategory::TAG, ColumnCategory::TAG,
+        ColumnCategory::FIELD};
+    std::vector<std::string> measurement_names{"tag1", "tag2", "tag3", "value"};
 
-    Tablet tablet("test_device0", measurement_names, measurement_types, column_categories);
+    Tablet tablet("test_device0", measurement_names, measurement_types,
+                  column_categories);
     tablet.add_timestamp(0, 1);
     tablet.add_value(0, 0, "t1");
     tablet.add_value(0, 1, "t2");
@@ -52,8 +56,9 @@ TEST(DeviceIdTest, TabletDeviceId) {
     auto device_id2 = tablet.get_device_id(0);
     ASSERT_TRUE(*device_id2 == *device_id);
 
-    ASSERT_EQ("test_device0..t2.t3", tablet.get_device_id(1)->get_device_name());
-    ASSERT_EQ("test_device0.null.t2.t3", tablet.get_device_id(2)->get_device_name());
-
+    ASSERT_EQ("test_device0..t2.t3",
+              tablet.get_device_id(1)->get_device_name());
+    ASSERT_EQ("test_device0.null.t2.t3",
+              tablet.get_device_id(2)->get_device_name());
 }
-}
+}  // namespace storage

--- a/cpp/test/common/row_record_test.cc
+++ b/cpp/test/common/row_record_test.cc
@@ -62,14 +62,16 @@ TEST(FieldTest, IsLiteral) {
 
 TEST(FieldTest, SetValue) {
     Field field;
-    common::PageArena pa; // dosen't matter
+    common::PageArena pa;  // dosen't matter
     int32_t i32_val = 123;
-    field.set_value(common::INT32, &i32_val, common::get_len(common::INT32), pa);
+    field.set_value(common::INT32, &i32_val, common::get_len(common::INT32),
+                    pa);
     EXPECT_EQ(field.type_, common::INT32);
     EXPECT_EQ(field.value_.ival_, 123);
 
     double d_val = 3.14;
-    field.set_value(common::DOUBLE, &d_val, common::get_len(common::DOUBLE), pa);
+    field.set_value(common::DOUBLE, &d_val, common::get_len(common::DOUBLE),
+                    pa);
     EXPECT_EQ(field.type_, common::DOUBLE);
     EXPECT_DOUBLE_EQ(field.value_.dval_, 3.14);
 }

--- a/cpp/test/common/schema_test.cc
+++ b/cpp/test/common/schema_test.cc
@@ -33,23 +33,21 @@ TEST(MeasurementSchemaTest, DefaultConstructor) {
 
 #if DEBUG_SE
 TEST(MeasurementSchemaTest, JavaCppGap) {
-    MeasurementSchema* measurement = new MeasurementSchema("measurement_name",
-        common::INT64, common::PLAIN, common::UNCOMPRESSED);
+    MeasurementSchema* measurement = new MeasurementSchema(
+        "measurement_name", common::INT64, common::PLAIN, common::UNCOMPRESSED);
     common::ByteStream stream(1024, common::MOD_DEFAULT);
     measurement->serialize_to(stream);
     auto buf_len = stream.total_size();
     auto buf = new char[buf_len];
     common::copy_bs_to_buf(stream, buf, buf_len);
     const ssize_t expected_size = 27;
-    uint8_t expected_buf[expected_size] = {0, 0, 0, 16, 109, 101, 97, 115, 117,
-                                           114, 101,
-                                           109, 101, 110, 116, 95, 110, 97, 109,
-                                           101, 2, 0,
-                                           0, 0, 0, 0, 0};
+    uint8_t expected_buf[expected_size] = {
+        0,   0,  0,   16, 109, 101, 97, 115, 117, 114, 101, 109, 101, 110,
+        116, 95, 110, 97, 109, 101, 2,  0,   0,   0,   0,   0,   0};
     for (int i = 0; i < expected_size; i++) {
         EXPECT_EQ(buf[i], expected_buf[i]);
     }
-    delete [] buf;
+    delete[] buf;
     delete measurement;
 }
 #endif
@@ -82,22 +80,19 @@ TEST(TableSchemaTest, BasicTest) {
     int id_schema_num = 5;
     int measurement_schema_num = 5;
     for (int i = 0; i < id_schema_num; i++) {
-        measurement_schemas.emplace_back(
-            new MeasurementSchema(
-                "__level" + to_string(i), TSDataType::TEXT, TSEncoding::PLAIN,
-                CompressionType::UNCOMPRESSED));
+        measurement_schemas.emplace_back(new MeasurementSchema(
+            "__level" + to_string(i), TSDataType::TEXT, TSEncoding::PLAIN,
+            CompressionType::UNCOMPRESSED));
         column_categories.emplace_back(ColumnCategory::TAG);
     }
     for (int i = 0; i < measurement_schema_num; i++) {
-        measurement_schemas.emplace_back(
-            new MeasurementSchema(
-                "s" + to_string(i), TSDataType::INT64, TSEncoding::PLAIN,
-                CompressionType::UNCOMPRESSED));
+        measurement_schemas.emplace_back(new MeasurementSchema(
+            "s" + to_string(i), TSDataType::INT64, TSEncoding::PLAIN,
+            CompressionType::UNCOMPRESSED));
         column_categories.emplace_back(ColumnCategory::FIELD);
     }
-    auto table_schema = new TableSchema("test_table",
-                                        measurement_schemas,
-                                        column_categories);
+    auto table_schema =
+        new TableSchema("test_table", measurement_schemas, column_categories);
     common::ByteStream stream(1024, common::MOD_DEFAULT);
     table_schema->serialize_to(stream);
     delete table_schema;
@@ -106,35 +101,26 @@ TEST(TableSchemaTest, BasicTest) {
     auto buf = new char[buf_len];
     common::copy_bs_to_buf(stream, buf, buf_len);
     const ssize_t expected_size = 201;
-    uint8_t expected_buf[expected_size] = {10, 0, 0, 0, 8, 95, 95, 108, 101,
-                                           118, 101, 108, 48, 5, 0, 0,
-                                           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8,
-                                           95, 95, 108, 101,
-                                           118, 101, 108, 49, 5, 0, 0, 0, 0, 0,
-                                           0, 0, 0, 0, 0, 0,
-                                           0, 0, 8, 95, 95, 108, 101, 118, 101,
-                                           108, 50, 5, 0, 0, 0, 0,
-                                           0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 95, 95,
-                                           108, 101, 118, 101,
-                                           108, 51, 5, 0, 0, 0, 0, 0, 0, 0, 0,
-                                           0, 0, 0, 0, 0,
-                                           8, 95, 95, 108, 101, 118, 101, 108,
-                                           52, 5, 0, 0, 0, 0, 0, 0,
-                                           0, 0, 0, 0, 0, 0, 0, 2, 115, 48, 2,
-                                           0, 0, 0, 0, 0,
-                                           0, 0, 0, 0, 1, 0, 0, 0, 2, 115, 49,
-                                           2, 0, 0, 0, 0,
-                                           0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 115,
-                                           50, 2, 0, 0, 0,
-                                           0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 115,
-                                           51, 2, 0, 0,
-                                           0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2,
-                                           115, 52, 2, 0,
-                                           0, 0, 0, 0, 0, 0, 0, 0, 1};
+    uint8_t expected_buf[expected_size] = {
+        10,  0,   0,   0,   8,   95,  95,  108, 101, 118, 101, 108, 48,  5,
+        0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   8,
+        95,  95,  108, 101, 118, 101, 108, 49,  5,   0,   0,   0,   0,   0,
+        0,   0,   0,   0,   0,   0,   0,   0,   8,   95,  95,  108, 101, 118,
+        101, 108, 50,  5,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+        0,   0,   0,   8,   95,  95,  108, 101, 118, 101, 108, 51,  5,   0,
+        0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   8,   95,
+        95,  108, 101, 118, 101, 108, 52,  5,   0,   0,   0,   0,   0,   0,
+        0,   0,   0,   0,   0,   0,   0,   2,   115, 48,  2,   0,   0,   0,
+        0,   0,   0,   0,   0,   0,   1,   0,   0,   0,   2,   115, 49,  2,
+        0,   0,   0,   0,   0,   0,   0,   0,   0,   1,   0,   0,   0,   2,
+        115, 50,  2,   0,   0,   0,   0,   0,   0,   0,   0,   0,   1,   0,
+        0,   0,   2,   115, 51,  2,   0,   0,   0,   0,   0,   0,   0,   0,
+        0,   1,   0,   0,   0,   2,   115, 52,  2,   0,   0,   0,   0,   0,
+        0,   0,   0,   0,   1};
     for (int i = 0; i < expected_size; i++) {
         EXPECT_EQ(buf[i], expected_buf[i]);
     }
-    delete [] buf;
+    delete[] buf;
 }
 #endif
-} // namespace storage
+}  // namespace storage

--- a/cpp/test/common/statistic_test.cc
+++ b/cpp/test/common/statistic_test.cc
@@ -221,4 +221,4 @@ TEST(TimeStatisticTest, BasicFunctionality) {
     EXPECT_EQ(stat.end_time_, 2000);
 }
 
-} // namespace storage
+}  // namespace storage

--- a/cpp/test/compress/gzip_compressor_test.cc
+++ b/cpp/test/compress/gzip_compressor_test.cc
@@ -108,7 +108,7 @@ TEST_F(GZIPTest, TestBytes2) {
     compressor.compress(uncompressed.data(), uncompressed.size(),
                         compressed_buf, compressed_buf_len);
     compressor.after_compress(compressed_buf);
-    
+
     compressor.reset(true);
     compressor.compress(uncompressed.data(), uncompressed.size(),
                         compressed_buf, compressed_buf_len_new);

--- a/cpp/test/cwrapper/c_release_test.cc
+++ b/cpp/test/cwrapper/c_release_test.cc
@@ -69,7 +69,8 @@ TEST_F(CReleaseTest, TsFileWriterNew) {
     remove("test_empty_schema.tsfile");
 
     // Invalid schema with memory threshold
-    file = write_file_new("test_empty_schema_memory_threshold.tsfile", &error_code);
+    file = write_file_new("test_empty_schema_memory_threshold.tsfile",
+                          &error_code);
     ASSERT_EQ(RET_OK, error_code);
     // Invalid schema
     writer = tsfile_writer_new_with_memory_threshold(file, &test_schema, 100,
@@ -108,7 +109,6 @@ TEST_F(CReleaseTest, TsFileWriterNew) {
 
     free_table_schema(table_schema);
     free_table_schema(test_schema);
-
 }
 
 TEST_F(CReleaseTest, TsFileWriterWriteDataAbnormalColumn) {
@@ -219,8 +219,8 @@ TEST_F(CReleaseTest, TsFileWriterWriteDataAbnormalColumn) {
 TEST_F(CReleaseTest, TsFileWriterMultiDataType) {
     ERRNO error_code = RET_OK;
     remove("TsFileWriterMultiDataType.tsfile");
-    WriteFile file = write_file_new(
-        "TsFileWriterMultiDataType.tsfile", &error_code);
+    WriteFile file =
+        write_file_new("TsFileWriterMultiDataType.tsfile", &error_code);
     ASSERT_EQ(RET_OK, error_code);
     TableSchema all_type_schema;
     all_type_schema.table_name = strdup("All_Datatype");
@@ -291,8 +291,8 @@ TEST_F(CReleaseTest, TsFileWriterMultiDataType) {
     ASSERT_EQ(RET_OK, tsfile_writer_close(writer));
     free_write_file(&file);
 
-    TsFileReader reader = tsfile_reader_new(
-        "TsFileWriterMultiDataType.tsfile", &error_code);
+    TsFileReader reader =
+        tsfile_reader_new("TsFileWriterMultiDataType.tsfile", &error_code);
     ASSERT_EQ(RET_OK, error_code);
     ResultSet result_set = tsfile_query_table(
         reader, "all_datatype", column_list, 6, 0, 1000, &error_code);

--- a/cpp/test/cwrapper/cwrapper_test.cc
+++ b/cpp/test/cwrapper/cwrapper_test.cc
@@ -116,7 +116,6 @@ TEST_F(CWrapperTest, WriterFlushTabletAndReadData) {
     ASSERT_EQ(code, RET_OK);
     ASSERT_EQ(tsfile_writer_close(writer), 0);
 
-
     TsFileReader reader =
         tsfile_reader_new("cwrapper_write_flush_and_read.tsfile", &code);
     ASSERT_EQ(code, 0);
@@ -182,6 +181,5 @@ TEST_F(CWrapperTest, WriterFlushTabletAndReadData) {
     free(column_names);
     free(data_types);
     free_write_file(&file);
-
 }
 }  // namespace cwrapper

--- a/cpp/test/encoding/ts2diff_codec_test.cc
+++ b/cpp/test/encoding/ts2diff_codec_test.cc
@@ -190,12 +190,17 @@ TEST_F(TS2DIFFCodecTest, LargeDataTest) {
     std::vector<int32_t> decoded(row_num);
     auto start_decode = std::chrono::steady_clock::now();
     for (int i = 0; i < row_num; i++) {
-        EXPECT_EQ(decoder_int_->read_int32(decoded[i], out_stream), common::E_OK);
+        EXPECT_EQ(decoder_int_->read_int32(decoded[i], out_stream),
+                  common::E_OK);
     }
     auto end_decode = std::chrono::steady_clock::now();
 
-    auto encode_duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_encode - start_encode);
-    auto decode_duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_decode - start_decode);
+    auto encode_duration =
+        std::chrono::duration_cast<std::chrono::milliseconds>(end_encode -
+                                                              start_encode);
+    auto decode_duration =
+        std::chrono::duration_cast<std::chrono::milliseconds>(end_decode -
+                                                              start_decode);
 
     std::cout << "Encode time: " << encode_duration.count() << "ms\n";
     std::cout << "Decode time: " << decode_duration.count() << "ms\n";

--- a/cpp/test/file/write_file_test.cc
+++ b/cpp/test/file/write_file_test.cc
@@ -44,9 +44,9 @@ TEST_F(WriteFileTest, CreateFile) {
     remove(file_name.c_str());
 }
 
-#if defined(__GNUC__) && !defined(__clang__)  
-    #pragma GCC push_options
-    #pragma GCC optimize ("O0")  
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize("O0")
 #endif
 TEST_F(WriteFileTest, WriteToFile) {
     WriteFile write_file;
@@ -73,7 +73,7 @@ TEST_F(WriteFileTest, WriteToFile) {
     remove(file_name.c_str());
 }
 #if defined(__GNUC__) && !defined(__clang__)
-    #pragma GCC pop_options
+#pragma GCC pop_options
 #endif
 
 TEST_F(WriteFileTest, SyncFile) {

--- a/cpp/test/parser/path_name_test.cc
+++ b/cpp/test/parser/path_name_test.cc
@@ -127,49 +127,40 @@ TEST_F(PathNameTest, TestLegalPath) {
 }
 
 TEST_F(PathNameTest, TestIllegalPathName) {
-    EXPECT_THROW ({
-      Path("root.sg`", true);
-    } , std::runtime_error);
+    EXPECT_THROW({ Path("root.sg`", true); }, std::runtime_error);
 
-    EXPECT_THROW ({
-      Path("root.sg\na", true);
-    }, std::runtime_error);
+    EXPECT_THROW({ Path("root.sg\na", true); }, std::runtime_error);
 
-    EXPECT_THROW ({
-      Path("root.select`", true);
-    } , std::runtime_error);
+    EXPECT_THROW({ Path("root.select`", true); }, std::runtime_error);
 
-    EXPECT_THROW ({
-      // pure digits
-      Path("root.111", true);
-    } , std::runtime_error);
+    EXPECT_THROW(
+        {
+            // pure digits
+            Path("root.111", true);
+        },
+        std::runtime_error);
 
-    EXPECT_THROW ({
-      // single ` in quoted node
-      Path("root.`a``", true);
-    } , std::runtime_error);
+    EXPECT_THROW(
+        {
+            // single ` in quoted node
+            Path("root.`a``", true);
+        },
+        std::runtime_error);
 
-    EXPECT_THROW ({
-      // single ` in quoted node
-      Path("root.``a`", true);
-    } , std::runtime_error);
+    EXPECT_THROW(
+        {
+            // single ` in quoted node
+            Path("root.``a`", true);
+        },
+        std::runtime_error);
 
-    EXPECT_THROW ({
-      Path("root.a*%", true);
-    } , std::runtime_error);
+    EXPECT_THROW({ Path("root.a*%", true); }, std::runtime_error);
 
-    EXPECT_THROW ({
-      Path("root.a*b", true);
-    } , std::runtime_error);
+    EXPECT_THROW({ Path("root.a*b", true); }, std::runtime_error);
 
-    EXPECT_THROW ({
-      Path("root.0e38", true);
-    } , std::runtime_error);
+    EXPECT_THROW({ Path("root.0e38", true); }, std::runtime_error);
 
-    EXPECT_THROW ({
-      Path("root.0000", true);
-    }, std::runtime_error);
+    EXPECT_THROW({ Path("root.0000", true); }, std::runtime_error);
 }
- 
 
 }  // namespace storage

--- a/cpp/test/reader/table_view/tsfile_reader_table_test.cc
+++ b/cpp/test/reader/table_view/tsfile_reader_table_test.cc
@@ -47,9 +47,7 @@ class TsFileTableReaderTest : public ::testing::Test {
         mode_t mode = 0666;
         write_file_.create(file_name_, flags, mode);
     }
-    void TearDown() override {
-        remove(file_name_.c_str());
-    }
+    void TearDown() override { remove(file_name_.c_str()); }
     std::string file_name_;
     WriteFile write_file_;
 
@@ -133,12 +131,15 @@ class TsFileTableReaderTest : public ::testing::Test {
         return tablet;
     }
 
-    void test_table_model_query(uint32_t points_per_device = 10, uint32_t device_num = 1, int64_t end_time = 1000000000000) {
+    void test_table_model_query(uint32_t points_per_device = 10,
+                                uint32_t device_num = 1,
+                                int64_t end_time = 1000000000000) {
         auto table_schema = gen_table_schema(0);
         auto tsfile_table_writer_ =
             std::make_shared<TsFileTableWriter>(&write_file_, table_schema);
 
-        auto tablet = gen_tablet(table_schema, 0, device_num, points_per_device);
+        auto tablet =
+            gen_tablet(table_schema, 0, device_num, points_per_device);
         ASSERT_EQ(tsfile_table_writer_->write_table(tablet), common::E_OK);
         ASSERT_EQ(tsfile_table_writer_->flush(), common::E_OK);
         ASSERT_EQ(tsfile_table_writer_->close(), common::E_OK);
@@ -148,8 +149,8 @@ class TsFileTableReaderTest : public ::testing::Test {
 
         ResultSet* tmp_result_set = nullptr;
         ret = reader.query(table_schema->get_table_name(),
-                           table_schema->get_measurement_names(), 0,
-                           end_time, tmp_result_set);
+                           table_schema->get_measurement_names(), 0, end_time,
+                           tmp_result_set);
         auto* table_result_set = (TableResultSet*)tmp_result_set;
         char* literal = new char[std::strlen("device_id") + 1];
         std::strcpy(literal, "device_id");
@@ -183,12 +184,15 @@ class TsFileTableReaderTest : public ::testing::Test {
                     0);
             }
             for (int i = 7; i <= 11; i++) {
-                ASSERT_EQ(table_result_set->get_value<int64_t>(i),  (row_num / points_per_device) % device_num);
+                ASSERT_EQ(table_result_set->get_value<int64_t>(i),
+                          (row_num / points_per_device) % device_num);
             }
-            ASSERT_EQ(table_result_set->get_value<int64_t>(1), row_num % points_per_device);
+            ASSERT_EQ(table_result_set->get_value<int64_t>(1),
+                      row_num % points_per_device);
             row_num++;
         }
-        ASSERT_EQ(row_num, std::min<int64_t>(points_per_device * device_num, end_time + 1));
+        ASSERT_EQ(row_num, std::min<int64_t>(points_per_device * device_num,
+                                             end_time + 1));
         reader.destroy_query_data_set(table_result_set);
         delete[] literal;
         ASSERT_EQ(reader.close(), common::E_OK);
@@ -350,9 +354,8 @@ TEST_F(TsFileTableReaderTest, TableModelQueryWithMultiTabletsMultiFlush) {
     int ret = reader.open(file_name_);
     ASSERT_EQ(ret, common::E_OK);
     storage::ResultSet* tmp_result_set = nullptr;
-    ret = reader.query("testtable0",
-                       tmp_table_schema->get_measurement_names(), 0, 1000000000000,
-                       tmp_result_set);
+    ret = reader.query("testtable0", tmp_table_schema->get_measurement_names(),
+                       0, 1000000000000, tmp_result_set);
     std::cout << "begin to dump data from tsfile ---" << std::endl;
     auto* table_result_set = (storage::TableResultSet*)tmp_result_set;
     bool has_next = false;
@@ -365,10 +368,14 @@ TEST_F(TsFileTableReaderTest, TableModelQueryWithMultiTabletsMultiFlush) {
             for (int j = 0; j < column_schemas.size(); j++) {
                 switch (column_schemas[j]->data_type_) {
                     case TSDataType::INT64:
-                        ASSERT_EQ(table_result_set->get_value<int64_t>(j + 2), i);
+                        ASSERT_EQ(table_result_set->get_value<int64_t>(j + 2),
+                                  i);
                         break;
                     case TSDataType::STRING:
-                        ASSERT_EQ(table_result_set->get_value<common::String*>(j + 2)->compare(literal_str), 0);
+                        ASSERT_EQ(
+                            table_result_set->get_value<common::String*>(j + 2)
+                                ->compare(literal_str),
+                            0);
                         break;
                     default:
                         break;

--- a/cpp/test/reader/tsfile_reader_test.cc
+++ b/cpp/test/reader/tsfile_reader_test.cc
@@ -35,7 +35,7 @@ using namespace storage;
 using namespace common;
 
 class TsFileReaderTest : public ::testing::Test {
-protected:
+   protected:
     void SetUp() override {
         tsfile_writer_ = new TsFileWriter();
         libtsfile_init();
@@ -58,7 +58,7 @@ protected:
     std::string file_name_;
     TsFileWriter* tsfile_writer_ = nullptr;
 
-public:
+   public:
     static std::string generate_random_string(int length) {
         std::mt19937 gen(static_cast<unsigned int>(
             std::chrono::system_clock::now().time_since_epoch().count()));
@@ -141,7 +141,8 @@ TEST_F(TsFileReaderTest, ResultSetMetadata) {
                        tmp_qds);
     auto* qds = (QDSWithoutTimeGenerator*)tmp_qds;
 
-    std::shared_ptr<ResultSetMetadata> result_set_metadata = qds->get_metadata();
+    std::shared_ptr<ResultSetMetadata> result_set_metadata =
+        qds->get_metadata();
     ASSERT_EQ(result_set_metadata->get_column_type(1), INT64);
     ASSERT_EQ(result_set_metadata->get_column_name(1), "time");
     ASSERT_EQ(result_set_metadata->get_column_type(2), data_type);
@@ -180,12 +181,12 @@ TEST_F(TsFileReaderTest, GetAllDevice) {
     ASSERT_EQ(devices.size(), 1024);
     std::vector<std::shared_ptr<IDeviceID> > devices_name_expected;
     for (size_t i = 0; i < 1024; i++) {
-        devices_name_expected.push_back(
-            std::make_shared<StringArrayDeviceID>(
-                "device.ln" + std::to_string(i)));
+        devices_name_expected.push_back(std::make_shared<StringArrayDeviceID>(
+            "device.ln" + std::to_string(i)));
     }
     std::sort(devices_name_expected.begin(), devices_name_expected.end(),
-              [](const std::shared_ptr<IDeviceID>& left_str, const std::shared_ptr<IDeviceID>& right_str) {
+              [](const std::shared_ptr<IDeviceID>& left_str,
+                 const std::shared_ptr<IDeviceID>& right_str) {
                   return left_str->operator<(*right_str);
               });
 

--- a/cpp/test/writer/table_view/tsfile_writer_table_test.cc
+++ b/cpp/test/writer/table_view/tsfile_writer_table_test.cc
@@ -45,7 +45,8 @@ class TsFileWriterTableTest : public ::testing::Test {
         mode_t mode = 0666;
         write_file_.create(file_name_, flags, mode);
     }
-    void TearDown() override { /*remove(file_name_.c_str());*/ }
+    void TearDown() override { /*remove(file_name_.c_str());*/
+    }
     std::string file_name_;
     WriteFile write_file_;
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -98,4 +98,37 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.diffplug.spotless</groupId>
+                    <artifactId>spotless-maven-plugin</artifactId>
+                    <version>${spotless.version}</version>
+                    <configuration>
+                        <java>
+                            <googleJavaFormat>
+                                <version>${google.java.format.version}</version>
+                                <style>GOOGLE</style>
+                            </googleJavaFormat>
+                            <importOrder>
+                                <order>org.apache.tsfile,,javax,java,\#</order>
+                            </importOrder>
+                            <removeUnusedImports/>
+                        </java>
+                        <lineEndings>UNIX</lineEndings>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>spotless-check</id>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <phase>validate</phase>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -649,6 +649,7 @@
                 <cmake.generator>Unix Makefiles</cmake.generator>
                 <python.venv.bin>venv/bin/</python.venv.bin>
                 <python.exe.bin>python3</python.exe.bin>
+                <!--ubuntu20 only support clang-format-10-->
                 <clang.format.version>10.0.0</clang.format.version>
             </properties>
         </profile>
@@ -668,6 +669,7 @@
                 <cmake.generator>Unix Makefiles</cmake.generator>
                 <python.venv.bin>venv/bin/</python.venv.bin>
                 <python.exe.bin>python3</python.exe.bin>
+                <!--ubuntu20 only support clang-format-10-->
                 <clang.format.version>10.0.0</clang.format.version>
             </properties>
         </profile>
@@ -687,6 +689,7 @@
                 <cmake.generator>Unix Makefiles</cmake.generator>
                 <python.venv.bin>venv/bin/</python.venv.bin>
                 <python.exe.bin>python3</python.exe.bin>
+                <!--ubuntu20 only support clang-format-10-->
                 <clang.format.version>10.0.0</clang.format.version>
             </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <cmake.version>3.30.2-b1</cmake.version>
         <spotless.version>2.44.3</spotless.version>
         <google.java.format.version>1.22.0</google.java.format.version>
-        <clang.format.version>20.1.7</clang.format.version>
+        <clang.format.version>17.0.6</clang.format.version>
         <drill.freemarker.maven.plugin.version>1.21.1</drill.freemarker.maven.plugin.version>
         <groovy.version>4.0.22</groovy.version>
     </properties>
@@ -649,7 +649,6 @@
                 <cmake.generator>Unix Makefiles</cmake.generator>
                 <python.venv.bin>venv/bin/</python.venv.bin>
                 <python.exe.bin>python3</python.exe.bin>
-                <clang.format.version>18.1.3</clang.format.version>
             </properties>
         </profile>
         <!-- Profile for linux amd64 (mainly AMD Processors) (Self-Enabling) -->
@@ -668,7 +667,6 @@
                 <cmake.generator>Unix Makefiles</cmake.generator>
                 <python.venv.bin>venv/bin/</python.venv.bin>
                 <python.exe.bin>python3</python.exe.bin>
-                <clang.format.version>18.1.3</clang.format.version>
             </properties>
         </profile>
         <!-- Profile for linux aarch64 (mainly ARM64 Processors) (Self-Enabling) -->
@@ -687,7 +685,6 @@
                 <cmake.generator>Unix Makefiles</cmake.generator>
                 <python.venv.bin>venv/bin/</python.venv.bin>
                 <python.exe.bin>python3</python.exe.bin>
-                <clang.format.version>18.1.3</clang.format.version>
             </properties>
         </profile>
         <!-- Profile for mac x86_64 (mainly Intel Processors) (Self-Enabling) -->

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,9 @@
         <argLine/>
         <spotless.skip>false</spotless.skip>
         <cmake.version>3.30.2-b1</cmake.version>
-        <spotless.version>2.43.0</spotless.version>
+        <spotless.version>2.44.3</spotless.version>
         <google.java.format.version>1.22.0</google.java.format.version>
+        <clang.format.version>20.1.7</clang.format.version>
         <drill.freemarker.maven.plugin.version>1.21.1</drill.freemarker.maven.plugin.version>
         <groovy.version>4.0.22</groovy.version>
     </properties>
@@ -138,33 +139,6 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>com.diffplug.spotless</groupId>
-                    <artifactId>spotless-maven-plugin</artifactId>
-                    <version>${spotless.version}</version>
-                    <configuration>
-                        <java>
-                            <googleJavaFormat>
-                                <version>${google.java.format.version}</version>
-                                <style>GOOGLE</style>
-                            </googleJavaFormat>
-                            <importOrder>
-                                <order>org.apache.tsfile,,javax,java,\#</order>
-                            </importOrder>
-                            <removeUnusedImports/>
-                        </java>
-                        <lineEndings>UNIX</lineEndings>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>spotless-check</id>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                            <phase>validate</phase>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
                     <groupId>org.eluder.coveralls</groupId>
                     <artifactId>coveralls-maven-plugin</artifactId>
                     <version>4.3.0</version>
@@ -226,6 +200,7 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.version}</version>
                 <configuration>
                     <skip>${spotless.skip}</skip>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -649,8 +649,7 @@
                 <cmake.generator>Unix Makefiles</cmake.generator>
                 <python.venv.bin>venv/bin/</python.venv.bin>
                 <python.exe.bin>python3</python.exe.bin>
-                <!--ubuntu20 only support clang-format-10-->
-                <clang.format.version>10.0.0</clang.format.version>
+                <clang.format.version>18.1.3</clang.format.version>
             </properties>
         </profile>
         <!-- Profile for linux amd64 (mainly AMD Processors) (Self-Enabling) -->
@@ -669,8 +668,7 @@
                 <cmake.generator>Unix Makefiles</cmake.generator>
                 <python.venv.bin>venv/bin/</python.venv.bin>
                 <python.exe.bin>python3</python.exe.bin>
-                <!--ubuntu20 only support clang-format-10-->
-                <clang.format.version>10.0.0</clang.format.version>
+                <clang.format.version>18.1.3</clang.format.version>
             </properties>
         </profile>
         <!-- Profile for linux aarch64 (mainly ARM64 Processors) (Self-Enabling) -->
@@ -689,8 +687,7 @@
                 <cmake.generator>Unix Makefiles</cmake.generator>
                 <python.venv.bin>venv/bin/</python.venv.bin>
                 <python.exe.bin>python3</python.exe.bin>
-                <!--ubuntu20 only support clang-format-10-->
-                <clang.format.version>10.0.0</clang.format.version>
+                <clang.format.version>18.1.3</clang.format.version>
             </properties>
         </profile>
         <!-- Profile for mac x86_64 (mainly Intel Processors) (Self-Enabling) -->

--- a/pom.xml
+++ b/pom.xml
@@ -649,6 +649,7 @@
                 <cmake.generator>Unix Makefiles</cmake.generator>
                 <python.venv.bin>venv/bin/</python.venv.bin>
                 <python.exe.bin>python3</python.exe.bin>
+                <clang.format.version>10.0.0</clang.format.version>
             </properties>
         </profile>
         <!-- Profile for linux amd64 (mainly AMD Processors) (Self-Enabling) -->
@@ -667,6 +668,7 @@
                 <cmake.generator>Unix Makefiles</cmake.generator>
                 <python.venv.bin>venv/bin/</python.venv.bin>
                 <python.exe.bin>python3</python.exe.bin>
+                <clang.format.version>10.0.0</clang.format.version>
             </properties>
         </profile>
         <!-- Profile for linux aarch64 (mainly ARM64 Processors) (Self-Enabling) -->
@@ -685,6 +687,7 @@
                 <cmake.generator>Unix Makefiles</cmake.generator>
                 <python.venv.bin>venv/bin/</python.venv.bin>
                 <python.exe.bin>python3</python.exe.bin>
+                <clang.format.version>10.0.0</clang.format.version>
             </properties>
         </profile>
         <!-- Profile for mac x86_64 (mainly Intel Processors) (Self-Enabling) -->


### PR DESCRIPTION
In this PR, spotless will use clang-format v17.0.6 to format the CPP code.

**How to install clang-format v17.0.6?**
Mac

```sh
brew install llvm@17 
ln -sf /opt/homebrew/opt/llvm@17/bin/clang-format /opt/homebrew/bin/clang-format
```

Windows
```cmd
choco install llvm --version 17.0.6 --force
```

You can now use `mvn spotless:apply -P with-cpp` to format the code.
You can also add `-Dspotless.skip=true` to skip code formatting.

