### PR TITLE
Fix wrong Private-Package declaration (related to #551)

### DIFF
--- a/java/tsfile/pom.xml
+++ b/java/tsfile/pom.xml
@@ -193,6 +193,7 @@
                         <Export-Package>org.apache.tsfile.*</Export-Package>
                         <Embed-Dependency>common;inline=true</Embed-Dependency>
                         <Embed-Transitive>false</Embed-Transitive>
+                        <Private-Package/>
                         <_removeheaders>Bnd-LastModified,Built-By</_removeheaders>
                         <Bundle-SymbolicName>org.apache.tsfile</Bundle-SymbolicName>
                     </instructions>


### PR DESCRIPTION
This simple PR fixes the incorrect declarations of private packages in the MANIFEST of tsfile.jar.  
This was introduced by #510 due to the default behavior of maven-bundle-plugin (if no `Private-Package` property is declared, all local packages are included). This unwanted declaration has no negative effect, however, as `Export-Package` takes precedence over `Private-Package`.

This fix is simply to clarify the MANIFEST.

This PR would also partially correct #551 before merging #510 as the same default behavior caused `org.apache.tsfile.read.expression.impl` to be declared as a private package.