### PR TITLE
Feature/codec/camel

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -56,7 +56,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.15.0</version>
+                <version>3.18.0</version>
             </dependency>
             <dependency>
                 <groupId>org.lz4</groupId>

--- a/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitInputStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitInputStream.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.tsfile.common.bitStream;
 
 import java.io.EOFException;
@@ -148,10 +167,10 @@ public class BitInputStream extends BitStream {
         int shift = 0;
 
         while (true) {
-            int chunk = in.readInt(7);
+            long chunk = in.readInt(7);
             boolean hasNext = in.readBit();
 
-            result |= ((long) chunk) << shift;
+            result |= (chunk) << shift;
             shift += 7;
 
             if (!hasNext) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitInputStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitInputStream.java
@@ -1,0 +1,209 @@
+package org.apache.tsfile.common.bitStream;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * A stream for reading individual bits or groups of bits from an InputStream.
+ */
+public class BitInputStream extends BitStream {
+
+    protected InputStream in;
+    protected int buffer;
+    protected int bufferBitCount;
+    protected final long totalBits; // Total valid bits
+    protected long bitsRead = 0;    // Number of bits read so far
+
+    protected int markedBuffer = 0;
+    protected int markedBufferBitCount = 0;
+    protected long markedBitsRead = 0;
+
+    /**
+     * Constructs a BitInputStream with a given InputStream and total number of valid bits.
+     *
+     * @param in        the underlying InputStream
+     * @param totalBits the total number of valid bits to read
+     */
+    public BitInputStream(InputStream in, long totalBits) {
+        this.in = in;
+        this.totalBits = totalBits;
+        this.bufferBitCount = 0;
+    }
+
+    /**
+     * Reads an integer value using the specified number of bits.
+     * If fewer bits are available, only the available bits are returned.
+     *
+     * @param numBits the number of bits to read (≤ 32)
+     * @return an integer whose lower bits contain the read value
+     * @throws EOFException if no data is available to read
+     * @throws IOException  if an I/O error occurs
+     */
+    public int readInt(int numBits) throws IOException {
+        if (availableBits() <= 0) {
+            throw new EOFException();
+        }
+
+        bitsRead += numBits;
+        int result = 0;
+        boolean hasReadData = false;
+
+        while (numBits > 0) {
+            if (bufferBitCount == 0) {
+                buffer = in.read();
+                if (buffer < 0) {
+                    if (!hasReadData) {
+                        throw new EOFException();
+                    }
+                    return result;
+                }
+                bufferBitCount = BITS_PER_BYTE;
+            }
+
+            if (bufferBitCount > numBits) {
+                result = ((buffer >> (bufferBitCount - numBits)) & MASKS[numBits]) | result;
+                bufferBitCount -= numBits;
+                numBits = 0;
+            } else {
+                result = ((buffer & MASKS[bufferBitCount]) << (numBits - bufferBitCount)) | result;
+                numBits -= bufferBitCount;
+                bufferBitCount = 0;
+            }
+
+            hasReadData = true;
+        }
+
+        return result;
+    }
+
+    /**
+     * Reads a long value using the specified number of bits.
+     *
+     * @param numBits the number of bits to read (0 to 64)
+     * @return a long value containing the read bits
+     * @throws EOFException if no data is available to read
+     * @throws IOException  if an I/O error occurs
+     */
+    public long readLong(int numBits) throws IOException {
+        if (availableBits() <= 0) {
+            throw new EOFException();
+        }
+        bitsRead += numBits;
+        if (numBits > 64 || numBits < 0) {
+            throw new IllegalArgumentException("numBits must be between 0 and 64");
+        }
+
+        long result = 0;
+        boolean hasReadData = false;
+
+        while (numBits > 0) {
+            if (bufferBitCount == 0) {
+                buffer = in.read();
+                if (buffer < 0) {
+                    if (!hasReadData) {
+                        throw new EOFException();
+                    }
+                    return result;
+                }
+                bufferBitCount = BITS_PER_BYTE;
+            }
+
+            if (bufferBitCount > numBits) {
+                int shift = bufferBitCount - numBits;
+                result = (result << numBits) | ((buffer >> shift) & MASKS[numBits]);
+                bufferBitCount -= numBits;
+                buffer &= MASKS[bufferBitCount];
+                numBits = 0;
+            } else {
+                result = (result << bufferBitCount) | (buffer & MASKS[bufferBitCount]);
+                numBits -= bufferBitCount;
+                bufferBitCount = 0;
+            }
+
+            hasReadData = true;
+        }
+
+        return result;
+    }
+
+    /**
+     * Reads a single bit from the stream.
+     *
+     * @return true if the bit is 1, false if it is 0
+     * @throws EOFException if no bits are available
+     * @throws IOException  if an I/O error occurs
+     */
+    public boolean readBit() throws IOException {
+        if (availableBits() <= 0) {
+            throw new EOFException();
+        }
+        bitsRead += 1;
+        if (bufferBitCount == 0) {
+            buffer = in.read();
+            if (buffer < 0) {
+                throw new EOFException();
+            }
+            bufferBitCount = BITS_PER_BYTE;
+        }
+
+        boolean bit = ((buffer >> (bufferBitCount - 1)) & 1) != 0;
+        bufferBitCount--;
+        return bit;
+    }
+
+    /**
+     * Returns whether this stream supports mark/reset.
+     *
+     * @return true if mark/reset is supported
+     */
+    public boolean markSupported() {
+        return in.markSupported();
+    }
+
+    /**
+     * Marks the current position in the stream.
+     *
+     * @param readLimit the maximum number of bits that can be read before the mark becomes invalid
+     */
+    public void mark(int readLimit) {
+        in.mark((readLimit + BITS_PER_BYTE - 1) / BITS_PER_BYTE);
+        markedBuffer = buffer;
+        markedBufferBitCount = bufferBitCount;
+        markedBitsRead = bitsRead;
+    }
+
+    /**
+     * Resets the stream to the most recent marked position.
+     *
+     * @throws IOException if mark was not called or has been invalidated
+     */
+    public void reset() throws IOException {
+        in.reset();
+        buffer = markedBuffer;
+        bufferBitCount = markedBufferBitCount;
+        bitsRead = markedBitsRead;
+    }
+
+    /**
+     * Returns the number of bits still available to read.
+     *
+     * @return the number of remaining available bits
+     * @throws IOException if an I/O error occurs
+     */
+    public int availableBits() throws IOException {
+        return (int) Math.min(
+                ((long) in.available() * BITS_PER_BYTE) + bufferBitCount,
+                totalBits - bitsRead
+        );
+    }
+
+    /**
+     * Closes the underlying InputStream.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    public void close() throws IOException {
+        in.close();
+    }
+}

--- a/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitInputStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitInputStream.java
@@ -23,246 +23,242 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 
-/**
- * A stream for reading individual bits or groups of bits from an InputStream.
- */
+/** A stream for reading individual bits or groups of bits from an InputStream. */
 public class BitInputStream extends BitStream {
 
-    protected InputStream in;
-    protected int buffer;
-    protected int bufferBitCount;
-    protected final long totalBits; // Total valid bits
-    protected long bitsRead = 0;    // Number of bits read so far
+  protected InputStream in;
+  protected int buffer;
+  protected int bufferBitCount;
+  protected final long totalBits; // Total valid bits
+  protected long bitsRead = 0; // Number of bits read so far
 
-    protected int markedBuffer = 0;
-    protected int markedBufferBitCount = 0;
-    protected long markedBitsRead = 0;
+  protected int markedBuffer = 0;
+  protected int markedBufferBitCount = 0;
+  protected long markedBitsRead = 0;
 
-    /**
-     * Constructs a BitInputStream with a given InputStream and total number of valid bits.
-     *
-     * @param in        the underlying InputStream
-     * @param totalBits the total number of valid bits to read
-     */
-    public BitInputStream(InputStream in, long totalBits) {
-        this.in = in;
-        this.totalBits = totalBits;
-        this.bufferBitCount = 0;
+  /**
+   * Constructs a BitInputStream with a given InputStream and total number of valid bits.
+   *
+   * @param in the underlying InputStream
+   * @param totalBits the total number of valid bits to read
+   */
+  public BitInputStream(InputStream in, long totalBits) {
+    this.in = in;
+    this.totalBits = totalBits;
+    this.bufferBitCount = 0;
+  }
+
+  /**
+   * Reads an integer value using the specified number of bits. If fewer bits are available, only
+   * the available bits are returned.
+   *
+   * @param numBits the number of bits to read (≤ 32)
+   * @return an integer whose lower bits contain the read value
+   * @throws EOFException if no data is available to read
+   * @throws IOException if an I/O error occurs
+   */
+  public int readInt(int numBits) throws IOException {
+    if (availableBits() <= 0) {
+      throw new EOFException();
     }
 
-    /**
-     * Reads an integer value using the specified number of bits.
-     * If fewer bits are available, only the available bits are returned.
-     *
-     * @param numBits the number of bits to read (≤ 32)
-     * @return an integer whose lower bits contain the read value
-     * @throws EOFException if no data is available to read
-     * @throws IOException  if an I/O error occurs
-     */
-    public int readInt(int numBits) throws IOException {
-        if (availableBits() <= 0) {
+    bitsRead += numBits;
+    int result = 0;
+    boolean hasReadData = false;
+
+    while (numBits > 0) {
+      if (bufferBitCount == 0) {
+        buffer = in.read();
+        if (buffer < 0) {
+          if (!hasReadData) {
             throw new EOFException();
+          }
+          return result;
         }
+        bufferBitCount = BITS_PER_BYTE;
+      }
 
-        bitsRead += numBits;
-        int result = 0;
-        boolean hasReadData = false;
+      if (bufferBitCount > numBits) {
+        result = ((buffer >> (bufferBitCount - numBits)) & MASKS[numBits]) | result;
+        bufferBitCount -= numBits;
+        numBits = 0;
+      } else {
+        result = ((buffer & MASKS[bufferBitCount]) << (numBits - bufferBitCount)) | result;
+        numBits -= bufferBitCount;
+        bufferBitCount = 0;
+      }
 
-        while (numBits > 0) {
-            if (bufferBitCount == 0) {
-                buffer = in.read();
-                if (buffer < 0) {
-                    if (!hasReadData) {
-                        throw new EOFException();
-                    }
-                    return result;
-                }
-                bufferBitCount = BITS_PER_BYTE;
-            }
-
-            if (bufferBitCount > numBits) {
-                result = ((buffer >> (bufferBitCount - numBits)) & MASKS[numBits]) | result;
-                bufferBitCount -= numBits;
-                numBits = 0;
-            } else {
-                result = ((buffer & MASKS[bufferBitCount]) << (numBits - bufferBitCount)) | result;
-                numBits -= bufferBitCount;
-                bufferBitCount = 0;
-            }
-
-            hasReadData = true;
-        }
-
-        return result;
+      hasReadData = true;
     }
 
-    /**
-     * Reads a long value using the specified number of bits.
-     *
-     * @param numBits the number of bits to read (0 to 64)
-     * @return a long value containing the read bits
-     * @throws EOFException if no data is available to read
-     * @throws IOException  if an I/O error occurs
-     */
-    public long readLong(int numBits) throws IOException {
-        if (availableBits() <= 0) {
+    return result;
+  }
+
+  /**
+   * Reads a long value using the specified number of bits.
+   *
+   * @param numBits the number of bits to read (0 to 64)
+   * @return a long value containing the read bits
+   * @throws EOFException if no data is available to read
+   * @throws IOException if an I/O error occurs
+   */
+  public long readLong(int numBits) throws IOException {
+    if (availableBits() <= 0) {
+      throw new EOFException();
+    }
+    bitsRead += numBits;
+    if (numBits > 64 || numBits < 0) {
+      throw new IllegalArgumentException("numBits must be between 0 and 64");
+    }
+
+    long result = 0;
+    boolean hasReadData = false;
+
+    while (numBits > 0) {
+      if (bufferBitCount == 0) {
+        buffer = in.read();
+        if (buffer < 0) {
+          if (!hasReadData) {
             throw new EOFException();
+          }
+          return result;
         }
-        bitsRead += numBits;
-        if (numBits > 64 || numBits < 0) {
-            throw new IllegalArgumentException("numBits must be between 0 and 64");
-        }
+        bufferBitCount = BITS_PER_BYTE;
+      }
 
-        long result = 0;
-        boolean hasReadData = false;
+      if (bufferBitCount > numBits) {
+        int shift = bufferBitCount - numBits;
+        result = (result << numBits) | ((buffer >> shift) & MASKS[numBits]);
+        bufferBitCount -= numBits;
+        buffer &= MASKS[bufferBitCount];
+        numBits = 0;
+      } else {
+        result = (result << bufferBitCount) | (buffer & MASKS[bufferBitCount]);
+        numBits -= bufferBitCount;
+        bufferBitCount = 0;
+      }
 
-        while (numBits > 0) {
-            if (bufferBitCount == 0) {
-                buffer = in.read();
-                if (buffer < 0) {
-                    if (!hasReadData) {
-                        throw new EOFException();
-                    }
-                    return result;
-                }
-                bufferBitCount = BITS_PER_BYTE;
-            }
-
-            if (bufferBitCount > numBits) {
-                int shift = bufferBitCount - numBits;
-                result = (result << numBits) | ((buffer >> shift) & MASKS[numBits]);
-                bufferBitCount -= numBits;
-                buffer &= MASKS[bufferBitCount];
-                numBits = 0;
-            } else {
-                result = (result << bufferBitCount) | (buffer & MASKS[bufferBitCount]);
-                numBits -= bufferBitCount;
-                bufferBitCount = 0;
-            }
-
-            hasReadData = true;
-        }
-
-        return result;
+      hasReadData = true;
     }
 
-    public static int readVarInt(BitInputStream in) throws IOException {
-        int result = 0;
-        int shift = 0;
+    return result;
+  }
 
-        while (true) {
-            int chunk = in.readInt(7);
-            boolean hasNext = in.readBit();
-            result |= chunk << shift;
-            if (!hasNext) break;
-            shift += 7;
-            if (shift >= 32) throw new IOException("VarInt too long");
-        }
+  public static int readVarInt(BitInputStream in) throws IOException {
+    int result = 0;
+    int shift = 0;
 
-        return (result >>> 1) ^ -(result & 1);
+    while (true) {
+      int chunk = in.readInt(7);
+      boolean hasNext = in.readBit();
+      result |= chunk << shift;
+      if (!hasNext) break;
+      shift += 7;
+      if (shift >= 32) throw new IOException("VarInt too long");
     }
 
-    public static long readVarLong(BitInputStream in) throws IOException {
-        long result = 0;
-        int shift = 0;
+    return (result >>> 1) ^ -(result & 1);
+  }
 
-        while (true) {
-            long chunk = in.readInt(7);
-            boolean hasNext = in.readBit();
+  public static long readVarLong(BitInputStream in) throws IOException {
+    long result = 0;
+    int shift = 0;
 
-            result |= (chunk) << shift;
-            shift += 7;
+    while (true) {
+      long chunk = in.readInt(7);
+      boolean hasNext = in.readBit();
 
-            if (!hasNext) {
-                break;
-            }
+      result |= (chunk) << shift;
+      shift += 7;
 
-            if (shift >= 64) {
-                throw new IOException("VarLong too long: overflow");
-            }
-        }
+      if (!hasNext) {
+        break;
+      }
 
-        // ZigZag 解码
-        return (result >>> 1) ^ -(result & 1);
+      if (shift >= 64) {
+        throw new IOException("VarLong too long: overflow");
+      }
     }
 
-    /**
-     * Reads a single bit from the stream.
-     *
-     * @return true if the bit is 1, false if it is 0
-     * @throws EOFException if no bits are available
-     * @throws IOException  if an I/O error occurs
-     */
-    public boolean readBit() throws IOException {
-        if (availableBits() <= 0) {
-            throw new EOFException();
-        }
-        bitsRead += 1;
-        if (bufferBitCount == 0) {
-            buffer = in.read();
-            if (buffer < 0) {
-                throw new EOFException();
-            }
-            bufferBitCount = BITS_PER_BYTE;
-        }
+    // ZigZag 解码
+    return (result >>> 1) ^ -(result & 1);
+  }
 
-        boolean bit = ((buffer >> (bufferBitCount - 1)) & 1) != 0;
-        bufferBitCount--;
-        return bit;
+  /**
+   * Reads a single bit from the stream.
+   *
+   * @return true if the bit is 1, false if it is 0
+   * @throws EOFException if no bits are available
+   * @throws IOException if an I/O error occurs
+   */
+  public boolean readBit() throws IOException {
+    if (availableBits() <= 0) {
+      throw new EOFException();
+    }
+    bitsRead += 1;
+    if (bufferBitCount == 0) {
+      buffer = in.read();
+      if (buffer < 0) {
+        throw new EOFException();
+      }
+      bufferBitCount = BITS_PER_BYTE;
     }
 
-    /**
-     * Returns whether this stream supports mark/reset.
-     *
-     * @return true if mark/reset is supported
-     */
-    public boolean markSupported() {
-        return in.markSupported();
-    }
+    boolean bit = ((buffer >> (bufferBitCount - 1)) & 1) != 0;
+    bufferBitCount--;
+    return bit;
+  }
 
-    /**
-     * Marks the current position in the stream.
-     *
-     * @param readLimit the maximum number of bits that can be read before the mark becomes invalid
-     */
-    public void mark(int readLimit) {
-        in.mark((readLimit + BITS_PER_BYTE - 1) / BITS_PER_BYTE);
-        markedBuffer = buffer;
-        markedBufferBitCount = bufferBitCount;
-        markedBitsRead = bitsRead;
-    }
+  /**
+   * Returns whether this stream supports mark/reset.
+   *
+   * @return true if mark/reset is supported
+   */
+  public boolean markSupported() {
+    return in.markSupported();
+  }
 
-    /**
-     * Resets the stream to the most recent marked position.
-     *
-     * @throws IOException if mark was not called or has been invalidated
-     */
-    public void reset() throws IOException {
-        in.reset();
-        buffer = markedBuffer;
-        bufferBitCount = markedBufferBitCount;
-        bitsRead = markedBitsRead;
-    }
+  /**
+   * Marks the current position in the stream.
+   *
+   * @param readLimit the maximum number of bits that can be read before the mark becomes invalid
+   */
+  public void mark(int readLimit) {
+    in.mark((readLimit + BITS_PER_BYTE - 1) / BITS_PER_BYTE);
+    markedBuffer = buffer;
+    markedBufferBitCount = bufferBitCount;
+    markedBitsRead = bitsRead;
+  }
 
-    /**
-     * Returns the number of bits still available to read.
-     *
-     * @return the number of remaining available bits
-     * @throws IOException if an I/O error occurs
-     */
-    public int availableBits() throws IOException {
-        return (int) Math.min(
-                ((long) in.available() * BITS_PER_BYTE) + bufferBitCount,
-                totalBits - bitsRead
-        );
-    }
+  /**
+   * Resets the stream to the most recent marked position.
+   *
+   * @throws IOException if mark was not called or has been invalidated
+   */
+  public void reset() throws IOException {
+    in.reset();
+    buffer = markedBuffer;
+    bufferBitCount = markedBufferBitCount;
+    bitsRead = markedBitsRead;
+  }
 
-    /**
-     * Closes the underlying InputStream.
-     *
-     * @throws IOException if an I/O error occurs
-     */
-    public void close() throws IOException {
-        in.close();
-    }
+  /**
+   * Returns the number of bits still available to read.
+   *
+   * @return the number of remaining available bits
+   * @throws IOException if an I/O error occurs
+   */
+  public int availableBits() throws IOException {
+    return (int)
+        Math.min(((long) in.available() * BITS_PER_BYTE) + bufferBitCount, totalBits - bitsRead);
+  }
+
+  /**
+   * Closes the underlying InputStream.
+   *
+   * @throws IOException if an I/O error occurs
+   */
+  public void close() throws IOException {
+    in.close();
+  }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitInputStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitInputStream.java
@@ -127,6 +127,46 @@ public class BitInputStream extends BitStream {
         return result;
     }
 
+    public static int readVarInt(BitInputStream in) throws IOException {
+        int result = 0;
+        int shift = 0;
+
+        while (true) {
+            int chunk = in.readInt(7);
+            boolean hasNext = in.readBit();
+            result |= chunk << shift;
+            if (!hasNext) break;
+            shift += 7;
+            if (shift >= 32) throw new IOException("VarInt too long");
+        }
+
+        return (result >>> 1) ^ -(result & 1);
+    }
+
+    public static long readVarLong(BitInputStream in) throws IOException {
+        long result = 0;
+        int shift = 0;
+
+        while (true) {
+            int chunk = in.readInt(7);
+            boolean hasNext = in.readBit();
+
+            result |= ((long) chunk) << shift;
+            shift += 7;
+
+            if (!hasNext) {
+                break;
+            }
+
+            if (shift >= 64) {
+                throw new IOException("VarLong too long: overflow");
+            }
+        }
+
+        // ZigZag 解码
+        return (result >>> 1) ^ -(result & 1);
+    }
+
     /**
      * Reads a single bit from the stream.
      *

--- a/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitOutputStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitOutputStream.java
@@ -32,7 +32,7 @@ public class BitOutputStream extends BitStream {
   protected int buffer; // Bit buffer (8-bit)
   protected int bufferBitCount; // Number of bits currently in the buffer
 
-  protected int bitsWritten = 0; // Total number of bits written
+  protected int bitsWritten; // Total number of bits written
 
   /**
    * Constructs a BitOutputStream from the given OutputStream.
@@ -41,7 +41,16 @@ public class BitOutputStream extends BitStream {
    */
   public BitOutputStream(OutputStream out) {
     this.out = out;
+    this.buffer = 0;
     this.bufferBitCount = 0;
+    this.bitsWritten = 0;
+  }
+
+  public void reset(OutputStream out) {
+    this.out = out;
+    this.buffer = 0;
+    this.bufferBitCount = 0;
+    this.bitsWritten = 0;
   }
 
   /**

--- a/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitOutputStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitOutputStream.java
@@ -107,37 +107,39 @@ public class BitOutputStream extends BitStream {
   }
 
   public static int writeVarInt(int value, BitOutputStream out) throws IOException {
-    int uValue = (value << 1) ^ (value >> 31); // ZigZag 编码：正偶负奇
+    int uValue =
+        (value << 1) ^ (value >> 31); // ZigZag encoding: even for positive, odd for negative
     int bits = 0;
 
     while ((uValue & ~0x7F) != 0) {
-      out.writeInt(uValue & 0x7F, 7); // 写低 7 位
-      out.writeBit(true); // 后续标志位 1
+      out.writeInt(uValue & 0x7F, 7); // Write lower 7 bits
+      out.writeBit(true); // Continuation flag 1
       uValue >>>= 7;
       bits += 8;
     }
 
-    out.writeInt(uValue, 7); // 最后一组 7 位
-    out.writeBit(false); // 终止标志位 0
+    out.writeInt(uValue, 7); // Last 7 bits
+    out.writeBit(false); // Termination flag 0
     bits += 8;
 
     return bits;
   }
 
   public static int writeVarLong(long value, BitOutputStream out) throws IOException {
-    long uValue = (value << 1) ^ (value >> 63); // ZigZag 编码：正偶负奇
+    long uValue =
+        (value << 1) ^ (value >> 63); // ZigZag encoding: even for positive, odd for negative
     int bitsWritten = 0;
 
     while ((uValue & ~0x7FL) != 0) {
-      int chunk = (int) (uValue & 0x7F); // 低 7 位
-      out.writeInt(chunk, 7); // 写数据位
-      out.writeBit(true); // 还有后续
+      int chunk = (int) (uValue & 0x7F); // Lower 7 bits
+      out.writeInt(chunk, 7); // Write data bits
+      out.writeBit(true); // Has more data
       uValue >>>= 7;
       bitsWritten += 8;
     }
 
-    out.writeInt((int) (uValue & 0x7F), 7); // 最后一个字节
-    out.writeBit(false); // 结束标志
+    out.writeInt((int) (uValue & 0x7F), 7); // Last byte
+    out.writeBit(false); // End flag
     bitsWritten += 8;
     return bitsWritten;
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitOutputStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitOutputStream.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.tsfile.common.bitStream;
 
 import java.io.IOException;

--- a/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitOutputStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitOutputStream.java
@@ -1,0 +1,131 @@
+package org.apache.tsfile.common.bitStream;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * A bit-level output stream that writes bits to an underlying byte-oriented OutputStream.
+ * Bits are written in MSB-first (most significant bit first) order within each byte.
+ */
+public class BitOutputStream extends BitStream {
+
+    protected OutputStream out;
+    protected int buffer;             // Bit buffer (8-bit)
+    protected int bufferBitCount;     // Number of bits currently in the buffer
+
+    protected int bitsWritten = 0;    // Total number of bits written
+
+    /**
+     * Constructs a BitOutputStream from the given OutputStream.
+     *
+     * @param out the underlying OutputStream
+     */
+    public BitOutputStream(OutputStream out) {
+        this.out = out;
+        this.bufferBitCount = 0;
+    }
+
+    /**
+     * Writes the specified number of bits from the given integer.
+     * Bits are taken from the lower bits of the data and written MSB-first.
+     *
+     * @param data     the data to write (bits from the LSB end)
+     * @param numBits  number of bits to write (0–32)
+     * @throws IOException if an I/O error occurs
+     */
+    public void writeInt(int data, int numBits) throws IOException {
+        bitsWritten += numBits;
+        while (numBits > 0) {
+            int rest = 8 - bufferBitCount;
+
+            if (rest > numBits) {
+                buffer |= ((data & MASKS[numBits]) << (rest - numBits));
+                bufferBitCount += numBits;
+                numBits = 0;
+            } else {
+                buffer |= ((data >> (numBits - rest)) & MASKS[rest]);
+                out.write(buffer);
+                buffer = 0;
+                bufferBitCount = 0;
+                numBits -= rest;
+            }
+        }
+    }
+
+    /**
+     * Writes the specified number of bits from the given long value.
+     * Bits are taken from the lower bits of the data and written MSB-first.
+     *
+     * @param data     the data to write (bits from the LSB end)
+     * @param numBits  number of bits to write (0–64)
+     * @throws IOException if an I/O error occurs
+     */
+    public void writeLong(long data, int numBits) throws IOException {
+        if (numBits > 64 || numBits < 0) {
+            throw new IllegalArgumentException("numBits must be between 0 and 64");
+        }
+
+        bitsWritten += numBits;
+        while (numBits > 0) {
+            int rest = 8 - bufferBitCount;
+
+            if (rest > numBits) {
+                int shift = rest - numBits;
+                int toWrite = (int)((data & MASKS[numBits]) << shift);
+                buffer |= toWrite;
+                bufferBitCount += numBits;
+                numBits = 0;
+            } else {
+                int shift = numBits - rest;
+                int toWrite = (int)((data >> shift) & MASKS[rest]);
+                buffer |= toWrite;
+                out.write(buffer);
+                buffer = 0;
+                bufferBitCount = 0;
+                numBits -= rest;
+            }
+        }
+    }
+
+    /**
+     * Writes a single bit.
+     * The bit is stored in the buffer until a full byte is collected.
+     *
+     * @param bit true to write 1, false to write 0
+     * @throws IOException if an I/O error occurs
+     */
+    public void writeBit(boolean bit) throws IOException {
+        bitsWritten += 1;
+
+        buffer |= (bit ? 1 : 0) << (7 - bufferBitCount);
+        bufferBitCount++;
+
+        if (bufferBitCount == 8) {
+            out.write(buffer);
+            buffer = 0;
+            bufferBitCount = 0;
+        }
+    }
+
+    /**
+     * Flushes the remaining bits in the buffer to the stream (if any),
+     * padding the remaining bits with zeros in the lower positions.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    public void close() throws IOException {
+        if (bufferBitCount > 0) {
+            out.write(buffer);
+        }
+        out.close();
+    }
+
+    /**
+     * Returns the total number of bits written so far.
+     *
+     * @return the number of bits written
+     */
+    public int getBitsWritten() {
+        return bitsWritten;
+    }
+}

--- a/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitOutputStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitOutputStream.java
@@ -23,165 +23,163 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 /**
- * A bit-level output stream that writes bits to an underlying byte-oriented OutputStream.
- * Bits are written in MSB-first (most significant bit first) order within each byte.
+ * A bit-level output stream that writes bits to an underlying byte-oriented OutputStream. Bits are
+ * written in MSB-first (most significant bit first) order within each byte.
  */
 public class BitOutputStream extends BitStream {
 
-    protected OutputStream out;
-    protected int buffer;             // Bit buffer (8-bit)
-    protected int bufferBitCount;     // Number of bits currently in the buffer
+  protected OutputStream out;
+  protected int buffer; // Bit buffer (8-bit)
+  protected int bufferBitCount; // Number of bits currently in the buffer
 
-    protected int bitsWritten = 0;    // Total number of bits written
+  protected int bitsWritten = 0; // Total number of bits written
 
-    /**
-     * Constructs a BitOutputStream from the given OutputStream.
-     *
-     * @param out the underlying OutputStream
-     */
-    public BitOutputStream(OutputStream out) {
-        this.out = out;
-        this.bufferBitCount = 0;
+  /**
+   * Constructs a BitOutputStream from the given OutputStream.
+   *
+   * @param out the underlying OutputStream
+   */
+  public BitOutputStream(OutputStream out) {
+    this.out = out;
+    this.bufferBitCount = 0;
+  }
+
+  /**
+   * Writes the specified number of bits from the given integer. Bits are taken from the lower bits
+   * of the data and written MSB-first.
+   *
+   * @param data the data to write (bits from the LSB end)
+   * @param numBits number of bits to write (0–32)
+   * @throws IOException if an I/O error occurs
+   */
+  public void writeInt(int data, int numBits) throws IOException {
+    bitsWritten += numBits;
+    while (numBits > 0) {
+      int rest = 8 - bufferBitCount;
+
+      if (rest > numBits) {
+        buffer |= ((data & MASKS[numBits]) << (rest - numBits));
+        bufferBitCount += numBits;
+        numBits = 0;
+      } else {
+        buffer |= ((data >> (numBits - rest)) & MASKS[rest]);
+        out.write(buffer);
+        buffer = 0;
+        bufferBitCount = 0;
+        numBits -= rest;
+      }
+    }
+  }
+
+  /**
+   * Writes the specified number of bits from the given long value. Bits are taken from the lower
+   * bits of the data and written MSB-first.
+   *
+   * @param data the data to write (bits from the LSB end)
+   * @param numBits number of bits to write (0–64)
+   * @throws IOException if an I/O error occurs
+   */
+  public void writeLong(long data, int numBits) throws IOException {
+    if (numBits > 64 || numBits < 0) {
+      throw new IllegalArgumentException("numBits must be between 0 and 64");
     }
 
-    /**
-     * Writes the specified number of bits from the given integer.
-     * Bits are taken from the lower bits of the data and written MSB-first.
-     *
-     * @param data     the data to write (bits from the LSB end)
-     * @param numBits  number of bits to write (0–32)
-     * @throws IOException if an I/O error occurs
-     */
-    public void writeInt(int data, int numBits) throws IOException {
-        bitsWritten += numBits;
-        while (numBits > 0) {
-            int rest = 8 - bufferBitCount;
+    bitsWritten += numBits;
+    while (numBits > 0) {
+      int rest = 8 - bufferBitCount;
 
-            if (rest > numBits) {
-                buffer |= ((data & MASKS[numBits]) << (rest - numBits));
-                bufferBitCount += numBits;
-                numBits = 0;
-            } else {
-                buffer |= ((data >> (numBits - rest)) & MASKS[rest]);
-                out.write(buffer);
-                buffer = 0;
-                bufferBitCount = 0;
-                numBits -= rest;
-            }
-        }
+      if (rest > numBits) {
+        int shift = rest - numBits;
+        int toWrite = (int) ((data & MASKS[numBits]) << shift);
+        buffer |= toWrite;
+        bufferBitCount += numBits;
+        numBits = 0;
+      } else {
+        int shift = numBits - rest;
+        int toWrite = (int) ((data >> shift) & MASKS[rest]);
+        buffer |= toWrite;
+        out.write(buffer);
+        buffer = 0;
+        bufferBitCount = 0;
+        numBits -= rest;
+      }
+    }
+  }
+
+  public static int writeVarInt(int value, BitOutputStream out) throws IOException {
+    int uValue = (value << 1) ^ (value >> 31); // ZigZag 编码：正偶负奇
+    int bits = 0;
+
+    while ((uValue & ~0x7F) != 0) {
+      out.writeInt(uValue & 0x7F, 7); // 写低 7 位
+      out.writeBit(true); // 后续标志位 1
+      uValue >>>= 7;
+      bits += 8;
     }
 
-    /**
-     * Writes the specified number of bits from the given long value.
-     * Bits are taken from the lower bits of the data and written MSB-first.
-     *
-     * @param data     the data to write (bits from the LSB end)
-     * @param numBits  number of bits to write (0–64)
-     * @throws IOException if an I/O error occurs
-     */
-    public void writeLong(long data, int numBits) throws IOException {
-        if (numBits > 64 || numBits < 0) {
-            throw new IllegalArgumentException("numBits must be between 0 and 64");
-        }
+    out.writeInt(uValue, 7); // 最后一组 7 位
+    out.writeBit(false); // 终止标志位 0
+    bits += 8;
 
-        bitsWritten += numBits;
-        while (numBits > 0) {
-            int rest = 8 - bufferBitCount;
+    return bits;
+  }
 
-            if (rest > numBits) {
-                int shift = rest - numBits;
-                int toWrite = (int)((data & MASKS[numBits]) << shift);
-                buffer |= toWrite;
-                bufferBitCount += numBits;
-                numBits = 0;
-            } else {
-                int shift = numBits - rest;
-                int toWrite = (int)((data >> shift) & MASKS[rest]);
-                buffer |= toWrite;
-                out.write(buffer);
-                buffer = 0;
-                bufferBitCount = 0;
-                numBits -= rest;
-            }
-        }
+  public static int writeVarLong(long value, BitOutputStream out) throws IOException {
+    long uValue = (value << 1) ^ (value >> 63); // ZigZag 编码：正偶负奇
+    int bitsWritten = 0;
+
+    while ((uValue & ~0x7FL) != 0) {
+      int chunk = (int) (uValue & 0x7F); // 低 7 位
+      out.writeInt(chunk, 7); // 写数据位
+      out.writeBit(true); // 还有后续
+      uValue >>>= 7;
+      bitsWritten += 8;
     }
 
-    public static int writeVarInt(int value, BitOutputStream out) throws IOException {
-        int uValue = (value << 1) ^ (value >> 31);  // ZigZag 编码：正偶负奇
-        int bits = 0;
+    out.writeInt((int) (uValue & 0x7F), 7); // 最后一个字节
+    out.writeBit(false); // 结束标志
+    bitsWritten += 8;
+    return bitsWritten;
+  }
 
-        while ((uValue & ~0x7F) != 0) {
-            out.writeInt(uValue & 0x7F, 7); // 写低 7 位
-            out.writeBit(true);             // 后续标志位 1
-            uValue >>>= 7;
-            bits += 8;
-        }
+  /**
+   * Writes a single bit. The bit is stored in the buffer until a full byte is collected.
+   *
+   * @param bit true to write 1, false to write 0
+   * @throws IOException if an I/O error occurs
+   */
+  public void writeBit(boolean bit) throws IOException {
+    bitsWritten += 1;
 
-        out.writeInt(uValue, 7);           // 最后一组 7 位
-        out.writeBit(false);               // 终止标志位 0
-        bits += 8;
+    buffer |= (bit ? 1 : 0) << (7 - bufferBitCount);
+    bufferBitCount++;
 
-        return bits;
+    if (bufferBitCount == 8) {
+      out.write(buffer);
+      buffer = 0;
+      bufferBitCount = 0;
     }
+  }
 
-    public static int writeVarLong(long value, BitOutputStream out) throws IOException {
-        long uValue = (value << 1) ^ (value >> 63); // ZigZag 编码：正偶负奇
-        int bitsWritten = 0;
-
-        while ((uValue & ~0x7FL) != 0) {
-            int chunk = (int)(uValue & 0x7F);     // 低 7 位
-            out.writeInt(chunk, 7);               // 写数据位
-            out.writeBit(true);                   // 还有后续
-            uValue >>>= 7;
-            bitsWritten += 8;
-        }
-
-        out.writeInt((int)(uValue & 0x7F), 7);    // 最后一个字节
-        out.writeBit(false);                     // 结束标志
-        bitsWritten += 8;
-        return bitsWritten;
+  /**
+   * Flushes the remaining bits in the buffer to the stream (if any), padding the remaining bits
+   * with zeros in the lower positions.
+   *
+   * @throws IOException if an I/O error occurs
+   */
+  public void close() throws IOException {
+    if (bufferBitCount > 0) {
+      out.write(buffer);
     }
+    out.close();
+  }
 
-
-    /**
-     * Writes a single bit.
-     * The bit is stored in the buffer until a full byte is collected.
-     *
-     * @param bit true to write 1, false to write 0
-     * @throws IOException if an I/O error occurs
-     */
-    public void writeBit(boolean bit) throws IOException {
-        bitsWritten += 1;
-
-        buffer |= (bit ? 1 : 0) << (7 - bufferBitCount);
-        bufferBitCount++;
-
-        if (bufferBitCount == 8) {
-            out.write(buffer);
-            buffer = 0;
-            bufferBitCount = 0;
-        }
-    }
-
-    /**
-     * Flushes the remaining bits in the buffer to the stream (if any),
-     * padding the remaining bits with zeros in the lower positions.
-     *
-     * @throws IOException if an I/O error occurs
-     */
-    public void close() throws IOException {
-        if (bufferBitCount > 0) {
-            out.write(buffer);
-        }
-        out.close();
-    }
-
-    /**
-     * Returns the total number of bits written so far.
-     *
-     * @return the number of bits written
-     */
-    public int getBitsWritten() {
-        return bitsWritten;
-    }
+  /**
+   * Returns the total number of bits written so far.
+   *
+   * @return the number of bits written
+   */
+  public int getBitsWritten() {
+    return bitsWritten;
+  }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitOutputStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitOutputStream.java
@@ -87,6 +87,43 @@ public class BitOutputStream extends BitStream {
         }
     }
 
+    public static int writeVarInt(int value, BitOutputStream out) throws IOException {
+        int uValue = (value << 1) ^ (value >> 31);  // ZigZag 编码：正偶负奇
+        int bits = 0;
+
+        while ((uValue & ~0x7F) != 0) {
+            out.writeInt(uValue & 0x7F, 7); // 写低 7 位
+            out.writeBit(true);             // 后续标志位 1
+            uValue >>>= 7;
+            bits += 8;
+        }
+
+        out.writeInt(uValue, 7);           // 最后一组 7 位
+        out.writeBit(false);               // 终止标志位 0
+        bits += 8;
+
+        return bits;
+    }
+
+    public static int writeVarLong(long value, BitOutputStream out) throws IOException {
+        long uValue = (value << 1) ^ (value >> 63); // ZigZag 编码：正偶负奇
+        int bitsWritten = 0;
+
+        while ((uValue & ~0x7FL) != 0) {
+            int chunk = (int)(uValue & 0x7F);     // 低 7 位
+            out.writeInt(chunk, 7);               // 写数据位
+            out.writeBit(true);                   // 还有后续
+            uValue >>>= 7;
+            bitsWritten += 8;
+        }
+
+        out.writeInt((int)(uValue & 0x7F), 7);    // 最后一个字节
+        out.writeBit(false);                     // 结束标志
+        bitsWritten += 8;
+        return bitsWritten;
+    }
+
+
     /**
      * Writes a single bit.
      * The bit is stored in the buffer until a full byte is collected.

--- a/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitStream.java
@@ -20,25 +20,18 @@
 package org.apache.tsfile.common.bitStream;
 
 /**
- * Base class for bit-level stream operations.
- * Provides shared constants and bit masks for bitwise manipulation.
+ * Base class for bit-level stream operations. Provides shared constants and bit masks for bitwise
+ * manipulation.
  */
 public class BitStream {
 
-    /** Number of bits per byte (always 8) */
-    protected static final int BITS_PER_BYTE = 8;
+  /** Number of bits per byte (always 8) */
+  protected static final int BITS_PER_BYTE = 8;
 
-    /**
-     * Bit masks used to extract the lowest N bits of a value.
-     * MASKS[n] contains a bitmask with the lowest n bits set to 1.
-     * For example:
-     * MASKS[0] = 0b00000000
-     * MASKS[1] = 0b00000001
-     * MASKS[2] = 0b00000011
-     * ...
-     * MASKS[8] = 0b11111111
-     */
-    protected static final int[] MASKS = new int[] {
-            0, 1, 3, 7, 0xf, 0x1f, 0x3f, 0x7f, 0xff
-    };
+  /**
+   * Bit masks used to extract the lowest N bits of a value. MASKS[n] contains a bitmask with the
+   * lowest n bits set to 1. For example: MASKS[0] = 0b00000000 MASKS[1] = 0b00000001 MASKS[2] =
+   * 0b00000011 ... MASKS[8] = 0b11111111
+   */
+  protected static final int[] MASKS = new int[] {0, 1, 3, 7, 0xf, 0x1f, 0x3f, 0x7f, 0xff};
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitStream.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.tsfile.common.bitStream;
 
 /**

--- a/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/BitStream.java
@@ -1,0 +1,25 @@
+package org.apache.tsfile.common.bitStream;
+
+/**
+ * Base class for bit-level stream operations.
+ * Provides shared constants and bit masks for bitwise manipulation.
+ */
+public class BitStream {
+
+    /** Number of bits per byte (always 8) */
+    protected static final int BITS_PER_BYTE = 8;
+
+    /**
+     * Bit masks used to extract the lowest N bits of a value.
+     * MASKS[n] contains a bitmask with the lowest n bits set to 1.
+     * For example:
+     * MASKS[0] = 0b00000000
+     * MASKS[1] = 0b00000001
+     * MASKS[2] = 0b00000011
+     * ...
+     * MASKS[8] = 0b11111111
+     */
+    protected static final int[] MASKS = new int[] {
+            0, 1, 3, 7, 0xf, 0x1f, 0x3f, 0x7f, 0xff
+    };
+}

--- a/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/ByteBufferBackedInputStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/ByteBufferBackedInputStream.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.tsfile.common.bitStream;
 
 import java.io.IOException;

--- a/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/ByteBufferBackedInputStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/bitStream/ByteBufferBackedInputStream.java
@@ -1,0 +1,32 @@
+package org.apache.tsfile.common.bitStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+public class ByteBufferBackedInputStream extends InputStream {
+  private final ByteBuffer buf;
+  private final int startPos;
+
+  public ByteBufferBackedInputStream(ByteBuffer buf) {
+    this.buf = buf;
+    this.startPos = buf.position();
+  }
+
+  @Override
+  public int read() throws IOException {
+    if (!buf.hasRemaining()) {
+      return -1;
+    }
+    return buf.get() & 0xFF;
+  }
+
+  @Override
+  public int available() {
+    return buf.remaining();
+  }
+
+  public int getConsumed() {
+    return buf.position() - startPos;
+  }
+}

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
@@ -27,179 +27,163 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class CamelDecoder {
-    // === Constants for decoding ===
-    private static final int BITS_FOR_SIGN = 1;
-    private static final int BITS_FOR_TYPE = 1;
-    private static final int BITS_FOR_FIRST_VALUE = 64;
-    private static final int BITS_FOR_LEADING_ZEROS = 6;
-    private static final int BITS_FOR_SIGNIFICANT_BITS = 6;
-    private static final int BITS_FOR_DECIMAL_COUNT = 4;
-    private static final int DOUBLE_TOTAL_BITS = 64;
-    private static final int DOUBLE_MANTISSA_BITS = 52;
-    private static final int DECIMAL_MAX_COUNT = 15;
+  // === Constants for decoding ===
+  private static final int BITS_FOR_SIGN = 1;
+  private static final int BITS_FOR_TYPE = 1;
+  private static final int BITS_FOR_FIRST_VALUE = 64;
+  private static final int BITS_FOR_LEADING_ZEROS = 6;
+  private static final int BITS_FOR_SIGNIFICANT_BITS = 6;
+  private static final int BITS_FOR_DECIMAL_COUNT = 4;
+  private static final int DOUBLE_TOTAL_BITS = 64;
+  private static final int DOUBLE_MANTISSA_BITS = 52;
+  private static final int DECIMAL_MAX_COUNT = 15;
 
-    // === Camel state ===
-    private long previousValue = 0;
-    private boolean isFirst = true;
-    private long storedVal = 0;
+  // === Camel state ===
+  private long previousValue = 0;
+  private boolean isFirst = true;
+  private long storedVal = 0;
 
-    // === Precomputed tables ===
-    public static final long[] powers = new long[DECIMAL_MAX_COUNT];
-    public static final long[] threshold = new long[DECIMAL_MAX_COUNT];
-    public static final int[] mValueBits = new int[DECIMAL_MAX_COUNT];
+  // === Precomputed tables ===
+  public static final long[] powers = new long[DECIMAL_MAX_COUNT];
+  public static final long[] threshold = new long[DECIMAL_MAX_COUNT];
+  public static final int[] mValueBits = new int[DECIMAL_MAX_COUNT];
 
-    static {
-        for (int l = 1; l <= DECIMAL_MAX_COUNT; l++) {
-            int idx = l - 1;
-            powers[idx] = (long) Math.pow(10, l);
-            long divisor = 1L << l;
-            threshold[idx] = powers[idx] / divisor;
-            mValueBits[idx] = (int) Math.ceil(Math.log(threshold[idx]) / Math.log(2));
+  static {
+    for (int l = 1; l <= DECIMAL_MAX_COUNT; l++) {
+      int idx = l - 1;
+      powers[idx] = (long) Math.pow(10, l);
+      long divisor = 1L << l;
+      threshold[idx] = powers[idx] / divisor;
+      mValueBits[idx] = (int) Math.ceil(Math.log(threshold[idx]) / Math.log(2));
+    }
+  }
+
+  private final BitInputStream in;
+  private final GorillaDecoder gorillaDecoder;
+
+  public CamelDecoder(InputStream inputStream, long totalBits) {
+    // Initialize bit-level reader and nested Gorilla decoder
+    this.in = new BitInputStream(inputStream, totalBits);
+    this.gorillaDecoder = new GorillaDecoder();
+  }
+
+  /** Nested class to handle fallback encoding (Gorilla) for double values. */
+  public class GorillaDecoder {
+    private int leadingZeros = Integer.MAX_VALUE;
+    private int trailingZeros = 0;
+
+    /** Decode next value using Gorilla algorithm. */
+    public double decode(BitInputStream in) throws IOException {
+      if (isFirst) {
+        previousValue = in.readLong(BITS_FOR_FIRST_VALUE);
+        isFirst = false;
+        return Double.longBitsToDouble(previousValue);
+      }
+
+      boolean controlBit = in.readBit();
+      if (!controlBit) {
+        return Double.longBitsToDouble(previousValue);
+      }
+
+      boolean reuseBlock = !in.readBit();
+      long xor;
+      if (reuseBlock) {
+        int sigBits = DOUBLE_TOTAL_BITS - leadingZeros - trailingZeros;
+        if (sigBits == 0) {
+          return Double.longBitsToDouble(previousValue);
         }
+        xor = in.readLong(sigBits) << trailingZeros;
+      } else {
+        leadingZeros = in.readInt(BITS_FOR_LEADING_ZEROS);
+        int sigBits = in.readInt(BITS_FOR_SIGNIFICANT_BITS) + 1;
+        trailingZeros = DOUBLE_TOTAL_BITS - leadingZeros - sigBits;
+        xor = in.readLong(sigBits) << trailingZeros;
+      }
+
+      previousValue ^= xor;
+      return Double.longBitsToDouble(previousValue);
     }
+  }
 
-    private final BitInputStream in;
-    private final GorillaDecoder gorillaDecoder;
+  /** Retrieve nested GorillaDecoder. */
+  public GorillaDecoder getGorillaDecoder() {
+    return gorillaDecoder;
+  }
 
-    public CamelDecoder(InputStream inputStream, long totalBits) {
-        // Initialize bit-level reader and nested Gorilla decoder
-        this.in = new BitInputStream(inputStream, totalBits);
-        this.gorillaDecoder = new GorillaDecoder();
+  /** Read all values until stream is exhausted. */
+  public List<Double> getValues() throws IOException {
+    List<Double> list = new LinkedList<>();
+    Double val;
+    while ((val = next()) != null) {
+      list.add(val);
     }
+    return list;
+  }
 
-    /**
-     * Nested class to handle fallback encoding (Gorilla) for double values.
-     */
-    public class GorillaDecoder {
-        private int leadingZeros = Integer.MAX_VALUE;
-        private int trailingZeros = 0;
-
-        /**
-         * Decode next value using Gorilla algorithm.
-         */
-        public double decode(BitInputStream in) throws IOException {
-            if (isFirst) {
-                previousValue = in.readLong(BITS_FOR_FIRST_VALUE);
-                isFirst = false;
-                return Double.longBitsToDouble(previousValue);
-            }
-
-            boolean controlBit = in.readBit();
-            if (!controlBit) {
-                return Double.longBitsToDouble(previousValue);
-            }
-
-            boolean reuseBlock = !in.readBit();
-            long xor;
-            if (reuseBlock) {
-                int sigBits = DOUBLE_TOTAL_BITS - leadingZeros - trailingZeros;
-                if (sigBits == 0) {
-                    return Double.longBitsToDouble(previousValue);
-                }
-                xor = in.readLong(sigBits) << trailingZeros;
-            } else {
-                leadingZeros = in.readInt(BITS_FOR_LEADING_ZEROS);
-                int sigBits = in.readInt(BITS_FOR_SIGNIFICANT_BITS) + 1;
-                trailingZeros = DOUBLE_TOTAL_BITS - leadingZeros - sigBits;
-                xor = in.readLong(sigBits) << trailingZeros;
-            }
-
-            previousValue ^= xor;
-            return Double.longBitsToDouble(previousValue);
-        }
+  /** Decode next available value, return null if no more bits. */
+  private Double next() throws IOException {
+    if (in.availableBits() <= 0) {
+      return null;
     }
-
-    /**
-     * Retrieve nested GorillaDecoder.
-     */
-    public GorillaDecoder getGorillaDecoder() {
-        return gorillaDecoder;
+    double result;
+    if (isFirst) {
+      isFirst = false;
+      long firstBits = in.readLong(BITS_FOR_FIRST_VALUE);
+      result = Double.longBitsToDouble(firstBits);
+      storedVal = (long) result;
+    } else {
+      result = nextValue();
     }
+    previousValue = Double.doubleToLongBits(result);
+    return result;
+  }
 
-    /**
-     * Read all values until stream is exhausted.
-     */
-    public List<Double> getValues() throws IOException {
-        List<Double> list = new LinkedList<>();
-        Double val;
-        while ((val = next()) != null) {
-            list.add(val);
-        }
-        return list;
+  /** Decode according to Camel vs Gorilla path. */
+  private double nextValue() throws IOException {
+    // Read sign bit
+    int signBit = in.readInt(BITS_FOR_SIGN);
+    double sign = signBit == 1 ? -1.0 : 1.0;
+    // Read encoding type bit
+    int typeBit = in.readInt(BITS_FOR_TYPE);
+    boolean useCamel = typeBit == 1;
+
+    if (useCamel) {
+      long intPart = readLong();
+      double decPart = readDecimal();
+      double value = (intPart >= 0 ? intPart + decPart : -(-intPart + decPart));
+      return sign * value;
+    } else {
+      return sign * gorillaDecoder.decode(in);
     }
+  }
 
-    /**
-     * Decode next available value, return null if no more bits.
-     */
-    private Double next() throws IOException {
-        if (in.availableBits() <= 0) {
-            return null;
-        }
-        double result;
-        if (isFirst) {
-            isFirst = false;
-            long firstBits = in.readLong(BITS_FOR_FIRST_VALUE);
-            result = Double.longBitsToDouble(firstBits);
-            storedVal = (long) result;
-        } else {
-            result = nextValue();
-        }
-        previousValue = Double.doubleToLongBits(result);
-        return result;
+  /** Read variable-length integer diff and update storedVal. */
+  private long readLong() throws IOException {
+    long diff = BitInputStream.readVarLong(in);
+    storedVal += diff;
+    return storedVal;
+  }
+
+  /** Read and reconstruct decimal component. */
+  private double readDecimal() throws IOException {
+    int count = in.readInt(BITS_FOR_DECIMAL_COUNT) + 1;
+    boolean hasXor = in.readBit();
+    long xor = 0;
+    if (hasXor) {
+      long bits = in.readLong(count);
+      xor = bits << (DOUBLE_MANTISSA_BITS - count);
     }
-
-    /**
-     * Decode according to Camel vs Gorilla path.
-     */
-    private double nextValue() throws IOException {
-        // Read sign bit
-        int signBit = in.readInt(BITS_FOR_SIGN);
-        double sign = signBit == 1 ? -1.0 : 1.0;
-        // Read encoding type bit
-        int typeBit = in.readInt(BITS_FOR_TYPE);
-        boolean useCamel = typeBit == 1;
-
-        if (useCamel) {
-            long intPart = readLong();
-            double decPart = readDecimal();
-            double value = (intPart >= 0 ? intPart + decPart : -(-intPart + decPart));
-            return sign * value;
-        } else {
-            return sign * gorillaDecoder.decode(in);
-        }
+    long mVal = BitInputStream.readVarLong(in);
+    double frac;
+    if (hasXor) {
+      double base = (double) mVal / powers[count - 1] + 1;
+      long merged = xor ^ Double.doubleToLongBits(base);
+      frac = Double.longBitsToDouble(merged) - 1;
+    } else {
+      frac = (double) mVal / powers[count - 1];
     }
-
-    /**
-     * Read variable-length integer diff and update storedVal.
-     */
-    private long readLong() throws IOException {
-        long diff = BitInputStream.readVarLong(in);
-        storedVal += diff;
-        return storedVal;
-    }
-
-    /**
-     * Read and reconstruct decimal component.
-     */
-    private double readDecimal() throws IOException {
-        int count = in.readInt(BITS_FOR_DECIMAL_COUNT) + 1;
-        boolean hasXor = in.readBit();
-        long xor = 0;
-        if (hasXor) {
-            long bits = in.readLong(count);
-            xor = bits << (DOUBLE_MANTISSA_BITS - count);
-        }
-        long mVal = BitInputStream.readVarLong(in);
-        double frac;
-        if (hasXor) {
-            double base = (double) mVal / powers[count - 1] + 1;
-            long merged = xor ^ Double.doubleToLongBits(base);
-            frac = Double.longBitsToDouble(merged) - 1;
-        } else {
-            frac = (double) mVal / powers[count - 1];
-        }
-        // Round to original scale
-        double scale = Math.pow(10, count);
-        return Math.round(frac * scale) / scale;
-    }
+    // Round to original scale
+    double scale = Math.pow(10, count);
+    return Math.round(frac * scale) / scale;
+  }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.tsfile.encoding.decoder;
 
 import org.apache.tsfile.common.bitStream.BitInputStream;
@@ -8,12 +27,15 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class CamelDecoder {
+    GorillaDecoder gorillaDecoder;
 
-    public static class GorillaDecoder {
-        private long previousValue = 0;
+    private long previousValue = 0;
+
+    private boolean isFirst = true;
+
+    public class GorillaDecoder {
         private int leadingZeros = Integer.MAX_VALUE;
         private int trailingZeros = 0;
-        private boolean isFirst = true;
 
         public boolean hasNext(BitInputStream in) throws IOException {
             return in.availableBits() >= 0;
@@ -41,9 +63,6 @@ public class CamelDecoder {
             } else {
                 leadingZeros = in.readInt(6);
                 int significantBits = in.readInt(6) + 1;
-                if (significantBits == 0) {
-                    //return Double.longBitsToDouble(previousValue); // no change
-                }
                 trailingZeros = 64 - leadingZeros - significantBits;
                 xor = in.readLong(significantBits) << trailingZeros;
             }
@@ -58,9 +77,7 @@ public class CamelDecoder {
 
     private long storedVal = 0;
 
-    private boolean first = true;
-
-    private final static int DECIMAL_MAX_COUNT = 10;
+    private final static int DECIMAL_MAX_COUNT = 15;
     public static final long[] powers = new long[DECIMAL_MAX_COUNT];
 
     // threshold[l-1] = 10^l / 2^l
@@ -78,6 +95,11 @@ public class CamelDecoder {
             mValueBits[idx] = (int) Math.ceil(Math.log(threshold[idx]) / Math.log(2));
         }
         this.in = new BitInputStream(in, totalBits);
+        gorillaDecoder = new GorillaDecoder();
+    }
+
+    public GorillaDecoder getGorillaDecoder() {
+        return gorillaDecoder;
     }
 
     public List<Double> getValues() throws IOException {
@@ -92,25 +114,34 @@ public class CamelDecoder {
 
     private Double next() throws IOException {
         if (in.availableBits() <= 0) return null;
-        if (first) {
-            first = false;
-            long fistVal_long = in.readLong(64);
-            double firstVal = Double.longBitsToDouble(fistVal_long);
-            storedVal = (int)firstVal;
-            return firstVal;
+        double retVal = 0;
+        if (isFirst) {
+            isFirst = false;
+            long fistValLong = in.readLong(64);
+            double firstVal = Double.longBitsToDouble(fistValLong);
+            storedVal = (long)firstVal;
+            retVal = firstVal;
         } else {
-            return nextValue();
+            retVal = nextValue();
         }
+        previousValue = Double.doubleToLongBits(retVal);
+        return retVal;
     }
 
     private Double nextValue() throws IOException {
-        // 读取第一位符号位 0表示负数 1表示正数
-        long longVal = readLong();
-        double decimal = readDecimal();
-        if (longVal >= 0) {
-            return longVal + decimal;
+        boolean positive = in.readBit();
+        double posVal = positive ? -1.0 : 1.0;
+        boolean useCamel = in.readBit();
+        if (useCamel) {
+            long longVal = readLong();
+            double decimal = readDecimal();
+            if (longVal >= 0) {
+                return posVal * (longVal + decimal);
+            } else {
+                return posVal * -1 * (-1 * longVal + decimal);
+            }
         } else {
-            return -1 * (-1 * longVal + decimal);
+            return posVal * gorillaDecoder.decode(in);
         }
     }
 
@@ -125,7 +156,7 @@ public class CamelDecoder {
     // 解压小数部分
     private double readDecimal() throws IOException {
         // 读取小数位数
-        int decimal_count = in.readInt(2) + 1;
+        int decimalCount = in.readInt(4) + 1;
         // 是否计算m的值
         int isCalM = in.readInt(1);
         long xor;
@@ -133,21 +164,23 @@ public class CamelDecoder {
         long xorString = 0;
         if (isCalM == 1) {
             // 查找保存的xor值
-            xor = in.readInt(decimal_count);
+            xor = in.readInt(decimalCount);
             // 根据leadingZeroSNum和XOR拼接xorVal
-            long shiftedValue = xor << (52 - decimal_count);
+            long shiftedValue = xor << (52 - decimalCount);
             for (int i = 0; i < 64; i++) {
                 xorString ^= (shiftedValue & (1L << i)); // 使用异或操作符直接计算xorValue
             }
         }
         long m_long = BitInputStream.readVarLong(in);
         if (isCalM == 1){
-            m = (double) m_long / powers[decimal_count-1] + 1;
+            m = (double) m_long / powers[decimalCount-1] + 1;
             long m_prime = Double.doubleToLongBits(m);
             long decimalLong = xorString ^ m_prime;;
-            decimalVal = Double.longBitsToDouble(decimalLong) - 1;
+            double temp = Double.longBitsToDouble(decimalLong) - 1;
+            double scale = Math.pow(10, decimalCount);
+            decimalVal = Math.round(temp * scale) / scale;
         } else {
-            m = (double) m_long / powers[decimal_count-1];
+            m = (double) m_long / powers[decimalCount-1];
             decimalVal = m;
         }
         return decimalVal;

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
@@ -1,0 +1,226 @@
+package org.apache.tsfile.encoding.decoder;
+
+import org.apache.tsfile.common.bitStream.BitInputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.DecimalFormat;
+import java.util.LinkedList;
+import java.util.List;
+
+public class CamelDecoder {
+
+    private final BitInputStream in;
+
+    private long storedVal = 0;
+
+    private boolean first = true;
+
+    private boolean endOfStream = false;
+
+    private long totalBits = 0;
+
+    private static final int DEFAULT_BLOCK_SIZE = 1000;
+    private static final long[] powers = {10L, 100L, 1000L, 10000L};
+    private long readNum = 0;
+
+    // 1位小数对应的centerbits与前导数0的关系
+    public final static int[] leadingZerosNumOne = {12};
+    public final static int[] centerBitsNumOne = {1};
+
+    // 2位小数对应的centerbits与前导数0的关系
+    public final static int[] leadingZerosNumTwo = {13, 12};
+    public final static int[] centerBitsNumTwo = {1, 2};
+
+    // 3位小数对应的centerbits与前导数0的关系
+    public final static int[] centerBitsNumThree = {1, 2, 3};
+    public final static int[] leadingZerosNumThree = {14, 13, 12};
+
+    // 4位小数对应的centerbits与前导数0的关系
+    public final static int[] centerBitsNumFour = {1, 2, 3, 4};
+    public final static int[] leadingZerosNumFour = {15, 14, 13, 12};
+
+    // 5位小数对应的centerbits与前导数0的关系
+    public final static int[] centerBitsNumFive = {1, 2, 3, 4, 5};
+    public final static int[] leadingZerosNumFive  = {16, 15, 14, 13, 12};
+
+    // 按照寻找到的m的值进行保存
+    public final static int[] mValueBits = {3, 5, 7, 10, 15};
+
+    public CamelDecoder(InputStream in, long totalBits) {
+        this.in = new BitInputStream(in, totalBits);
+        this.totalBits = totalBits;
+    }
+
+    public List<Double> getValues() {
+        List<Double> list = new LinkedList<>();
+        Double value = readPair();
+        while (value != null) {
+            list.add(value);
+            value = readPair();
+        }
+        return list;
+    }
+
+    public Double readPair() {
+        Double decoded_val;
+        try {
+            decoded_val = next();
+        } catch (IOException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+        if(endOfStream) {
+            return null;
+        }
+        return decoded_val;
+    }
+
+    private Double next() throws IOException {
+        if (in.availableBits() <= 0) return null;
+        readNum ++;
+        if (first) {
+            first = false;
+            long fistVal_long = in.readLong(64);
+            double firstVal = Double.longBitsToDouble(fistVal_long);
+            storedVal = (int)firstVal;
+            return firstVal;
+        } else {
+            if (readNum-1 == DEFAULT_BLOCK_SIZE) {
+                endOfStream = true;
+                return null;
+            }
+            return nextValue();
+        }
+    }
+
+    private Double nextValue() throws IOException {
+        // 读取第一位符号位 0表示负数 1表示正数
+        long intVal = readInt();
+        double decimal = readDecimal();
+        if (intVal >= 0) {
+            return intVal + decimal;
+        } else {
+            return -1 * (-1 * intVal + decimal);
+        }
+    }
+
+    // 解压整数部分
+    private long readInt() throws IOException {
+        int integerNum = in.readInt(2);
+        long diffVal;
+        if (integerNum < 3) {
+            diffVal = integerNum-1;
+        } else {
+            // 读取差值的符号 0表示负数 1表示正数
+            boolean diffSymbol = in.readBit();
+            int range = in.readInt(1);
+            if (range == 0) {
+                diffVal = in.readInt(3);
+            } else {
+                diffVal = in.readInt(32);
+            }
+            diffVal = (!diffSymbol ? -1: 1) * diffVal;
+        }
+        storedVal = diffVal + storedVal;
+        return  storedVal;
+
+    }
+
+
+    // 解压小数部分
+    private double readDecimal() throws IOException {
+        // 读取小数位数
+        int decimal_count = in.readInt(2) + 1;
+        // 是否计算m的值
+        int isM = in.readInt(1);
+        long xor;
+        double decimalVal, m;
+        long xorString = 0;
+        if (isM == 1) {
+            // 查找保存的xor值
+            xor = in.readInt(decimal_count);
+            // 根据leadingZeroSNum和XOR拼接xorVal
+            long shiftedValue = xor << (52 - decimal_count);
+//            xorString = shiftedValue;
+//            xorString = String.format("%64s", Long.toBinaryString(shiftedValue)).replace(' ', '0');
+            for (int i = 0; i < 64; i++) {
+                xorString ^= (shiftedValue & (1L << i)); // 使用异或操作符直接计算xorValue
+            }
+        }
+        // 将m用二进制数表示
+        int m_int = 0;
+        if (decimal_count <= 1) { // 如果是1 直接往后读decimal_count+1位
+            m_int = in.readInt(decimal_count+1);
+        } else if (decimal_count ==2) {
+            int temp = in.readInt(1);
+            if ( temp == 0) {
+                m_int = in.readInt(3);
+            }  else {
+                m_int = in.readInt(5);
+            }
+        } else if (decimal_count == 3) {
+            int temp = in.readInt(2);
+            if ( temp == 0) {
+                m_int = in.readInt(1);
+            }  else if (temp == 1) {
+                m_int = in.readInt(3);
+            } else if (temp == 2) {
+                m_int = in.readInt(5);
+            } else {
+                m_int = in.readInt(mValueBits[decimal_count-1]);
+            }
+        } else {
+            int temp = in.readInt(2);
+            if (temp == 0) {
+                m_int = in.readInt(4);
+            } else if (temp == 1) {
+                m_int = in.readInt(6);
+            } else if (temp == 2) {
+                m_int = in.readInt(8);
+            } else {
+                m_int = in.readInt(mValueBits[decimal_count - 1]);
+            }
+
+        }
+
+        if (isM == 1){
+            m = (double) m_int / powers[decimal_count-1] + 1;
+            long m_prime = Double.doubleToLongBits(m);
+            long decimalLong = xorString ^ m_prime;;
+            // 使用 Double.longBitsToDouble 将 long 转换为 double
+            decimalVal = Double.longBitsToDouble(decimalLong) - 1;
+        } else {
+            m = (double) m_int / powers[decimal_count-1];
+            decimalVal = m;
+        }
+
+        return decimalVal;
+
+    }
+
+    public static String xorBinaryStrings(String binary1, String binary2) {
+        // 确保两个二进制字符串长度一致
+        int maxLength = Math.max(binary1.length(), binary2.length());
+        binary1 = String.format("%" + maxLength + "s", binary1).replace(' ', '0');
+        binary2 = String.format("%" + maxLength + "s", binary2).replace(' ', '0');
+
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < maxLength; i++) {
+            if (binary1.charAt(i) == binary2.charAt(i)) {
+                result.append('0');
+            } else {
+                result.append('1');
+            }
+        }
+        return result.toString();
+    }
+
+    public long getTotalBits() {
+        return totalBits;
+    }
+
+    public void setTotalBits(long totalBits) {
+        this.totalBits = totalBits;
+    }
+}
+

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
@@ -20,11 +20,11 @@
 package org.apache.tsfile.encoding.decoder;
 
 import org.apache.tsfile.common.bitStream.BitInputStream;
+import org.apache.tsfile.common.bitStream.ByteBufferBackedInputStream;
 import org.apache.tsfile.exception.encoding.TsFileDecodingException;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -114,13 +114,8 @@ public class CamelDecoder extends Decoder {
             throw new TsFileDecodingException("No more data to decode");
           }
 
-          // Copy current buffer slice into a byte array to support non-zero array offset or direct buffer
-          ByteBuffer slice = buffer.slice(); // Creates a new view starting at current position
-          byte[] temp = new byte[slice.remaining()];
-          slice.get(temp); // Read data without modifying original buffer's position
-
-          // Use the copied data to construct an input stream
-          ByteArrayInputStream bais = new ByteArrayInputStream(temp);
+          ByteBuffer slice = buffer.slice(); // Keep this
+          ByteBufferBackedInputStream bais = new ByteBufferBackedInputStream(slice);
 
           // Read the number of bits in the current block
           int blockBits = ReadWriteForEncodingUtils.readVarInt(bais);
@@ -142,7 +137,9 @@ public class CamelDecoder extends Decoder {
           cacheIndex = 0;
 
           // Advance the buffer position by the number of bytes consumed
-          int consumed = temp.length - bais.available();
+          // int consumed = temp.length - bais.available();
+          int consumed = bais.getConsumed();
+
           buffer.position(buffer.position() + consumed);
         }
       }
@@ -153,7 +150,6 @@ public class CamelDecoder extends Decoder {
       throw new TsFileDecodingException(e.getMessage());
     }
   }
-
 
   /** Nested class to handle fallback encoding (Gorilla) for double values. */
   public class GorillaDecoder {

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
@@ -4,11 +4,55 @@ import org.apache.tsfile.common.bitStream.BitInputStream;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.text.DecimalFormat;
 import java.util.LinkedList;
 import java.util.List;
 
 public class CamelDecoder {
+
+    public static class GorillaDecoder {
+        private long previousValue = 0;
+        private int leadingZeros = Integer.MAX_VALUE;
+        private int trailingZeros = 0;
+        private boolean isFirst = true;
+
+        public boolean hasNext(BitInputStream in) throws IOException {
+            return in.availableBits() >= 0;
+        }
+
+        public double decode(BitInputStream in) throws IOException {
+            if (isFirst) {
+                previousValue = in.readLong(64);
+                isFirst = false;
+                return Double.longBitsToDouble(previousValue);
+            }
+
+            if (!in.readBit()) {
+                return Double.longBitsToDouble(previousValue); // same value
+            }
+
+            boolean hasNewControl = in.readBit();
+            long xor;
+            if (!hasNewControl) {
+                int significantBits = 64 - leadingZeros - trailingZeros;
+                if (significantBits == 0) {
+                    return Double.longBitsToDouble(previousValue); // no change
+                }
+                xor = in.readLong(significantBits) << trailingZeros;
+            } else {
+                leadingZeros = in.readInt(6);
+                int significantBits = in.readInt(6) + 1;
+                if (significantBits == 0) {
+                    //return Double.longBitsToDouble(previousValue); // no change
+                }
+                trailingZeros = 64 - leadingZeros - significantBits;
+                xor = in.readLong(significantBits) << trailingZeros;
+            }
+
+            previousValue ^= xor;
+            return Double.longBitsToDouble(previousValue);
+        }
+    }
+
 
     private final BitInputStream in;
 
@@ -16,48 +60,38 @@ public class CamelDecoder {
 
     private boolean first = true;
 
-    private boolean endOfStream = false;
+    private final static int DECIMAL_MAX_COUNT = 10;
+    public static final long[] powers = new long[DECIMAL_MAX_COUNT];
 
-    private long totalBits = 0;
+    // threshold[l-1] = 10^l / 2^l
+    public static final long[] threshold = new long[DECIMAL_MAX_COUNT];
 
-    private static final int DEFAULT_BLOCK_SIZE = Integer.MAX_VALUE;
-    private static final long[] powers = {10L, 100L, 1000L, 10000L};
-    private long readNum = 0;
-
-    // 按照寻找到的m的值进行保存
-    public final static int[] mValueBits = {3, 5, 7, 10, 15};
+    // mValueBits[l-1] = ceil(log2(threshold[l-1]))
+    public static final int[] mValueBits = new int[DECIMAL_MAX_COUNT];
 
     public CamelDecoder(InputStream in, long totalBits) {
+        for (int l = 1; l <= DECIMAL_MAX_COUNT; l++) {
+            int idx = l - 1;
+            powers[idx] = (long) Math.pow(10, l);
+            long divisor = 1L << l;  // 2^l
+            threshold[idx] = powers[idx] / divisor;
+            mValueBits[idx] = (int) Math.ceil(Math.log(threshold[idx]) / Math.log(2));
+        }
         this.in = new BitInputStream(in, totalBits);
-        this.totalBits = totalBits;
     }
 
-    public List<Double> getValues() {
+    public List<Double> getValues() throws IOException {
         List<Double> list = new LinkedList<>();
-        Double value = readPair();
+        Double value = next();
         while (value != null) {
             list.add(value);
-            value = readPair();
+            value = next();
         }
         return list;
     }
 
-    public Double readPair() {
-        Double decoded_val;
-        try {
-            decoded_val = next();
-        } catch (IOException e) {
-            throw new RuntimeException(e.getMessage());
-        }
-        if(endOfStream) {
-            return null;
-        }
-        return decoded_val;
-    }
-
     private Double next() throws IOException {
         if (in.availableBits() <= 0) return null;
-        readNum ++;
         if (first) {
             first = false;
             long fistVal_long = in.readLong(64);
@@ -65,142 +99,58 @@ public class CamelDecoder {
             storedVal = (int)firstVal;
             return firstVal;
         } else {
-            if (readNum-1 == DEFAULT_BLOCK_SIZE) {
-                endOfStream = true;
-                return null;
-            }
             return nextValue();
         }
     }
 
     private Double nextValue() throws IOException {
         // 读取第一位符号位 0表示负数 1表示正数
-        long intVal = readInt();
+        long longVal = readLong();
         double decimal = readDecimal();
-        if (intVal >= 0) {
-            return intVal + decimal;
+        if (longVal >= 0) {
+            return longVal + decimal;
         } else {
-            return -1 * (-1 * intVal + decimal);
+            return -1 * (-1 * longVal + decimal);
         }
     }
 
     // 解压整数部分
-    private long readInt() throws IOException {
-        int integerNum = in.readInt(2);
-        long diffVal;
-        if (integerNum < 3) {
-            diffVal = integerNum-1;
-        } else {
-            // 读取差值的符号 0表示负数 1表示正数
-            boolean diffSymbol = in.readBit();
-            int range = in.readInt(1);
-            if (range == 0) {
-                diffVal = in.readInt(3);
-            } else {
-                diffVal = in.readInt(32);
-            }
-            diffVal = (!diffSymbol ? -1: 1) * diffVal;
-        }
+    private long readLong() throws IOException {
+        long diffVal = BitInputStream.readVarLong(in);
         storedVal = diffVal + storedVal;
         return  storedVal;
 
     }
-
 
     // 解压小数部分
     private double readDecimal() throws IOException {
         // 读取小数位数
         int decimal_count = in.readInt(2) + 1;
         // 是否计算m的值
-        int isM = in.readInt(1);
+        int isCalM = in.readInt(1);
         long xor;
         double decimalVal, m;
         long xorString = 0;
-        if (isM == 1) {
+        if (isCalM == 1) {
             // 查找保存的xor值
             xor = in.readInt(decimal_count);
             // 根据leadingZeroSNum和XOR拼接xorVal
             long shiftedValue = xor << (52 - decimal_count);
-//            xorString = shiftedValue;
-//            xorString = String.format("%64s", Long.toBinaryString(shiftedValue)).replace(' ', '0');
             for (int i = 0; i < 64; i++) {
                 xorString ^= (shiftedValue & (1L << i)); // 使用异或操作符直接计算xorValue
             }
         }
-        // 将m用二进制数表示
-        int m_int = 0;
-        if (decimal_count <= 1) { // 如果是1 直接往后读decimal_count+1位
-            m_int = in.readInt(decimal_count+1);
-        } else if (decimal_count ==2) {
-            int temp = in.readInt(1);
-            if ( temp == 0) {
-                m_int = in.readInt(3);
-            }  else {
-                m_int = in.readInt(5);
-            }
-        } else if (decimal_count == 3) {
-            int temp = in.readInt(2);
-            if ( temp == 0) {
-                m_int = in.readInt(1);
-            }  else if (temp == 1) {
-                m_int = in.readInt(3);
-            } else if (temp == 2) {
-                m_int = in.readInt(5);
-            } else {
-                m_int = in.readInt(mValueBits[decimal_count-1]);
-            }
-        } else {
-            int temp = in.readInt(2);
-            if (temp == 0) {
-                m_int = in.readInt(4);
-            } else if (temp == 1) {
-                m_int = in.readInt(6);
-            } else if (temp == 2) {
-                m_int = in.readInt(8);
-            } else {
-                m_int = in.readInt(mValueBits[decimal_count - 1]);
-            }
-
-        }
-
-        if (isM == 1){
-            m = (double) m_int / powers[decimal_count-1] + 1;
+        long m_long = BitInputStream.readVarLong(in);
+        if (isCalM == 1){
+            m = (double) m_long / powers[decimal_count-1] + 1;
             long m_prime = Double.doubleToLongBits(m);
             long decimalLong = xorString ^ m_prime;;
-            // 使用 Double.longBitsToDouble 将 long 转换为 double
             decimalVal = Double.longBitsToDouble(decimalLong) - 1;
         } else {
-            m = (double) m_int / powers[decimal_count-1];
+            m = (double) m_long / powers[decimal_count-1];
             decimalVal = m;
         }
-
         return decimalVal;
-
-    }
-
-    public static String xorBinaryStrings(String binary1, String binary2) {
-        // 确保两个二进制字符串长度一致
-        int maxLength = Math.max(binary1.length(), binary2.length());
-        binary1 = String.format("%" + maxLength + "s", binary1).replace(' ', '0');
-        binary2 = String.format("%" + maxLength + "s", binary2).replace(' ', '0');
-
-        StringBuilder result = new StringBuilder();
-        for (int i = 0; i < maxLength; i++) {
-            if (binary1.charAt(i) == binary2.charAt(i)) {
-                result.append('0');
-            } else {
-                result.append('1');
-            }
-        }
-        return result.toString();
-    }
-
-    public long getTotalBits() {
-        return totalBits;
-    }
-
-    public void setTotalBits(long totalBits) {
-        this.totalBits = totalBits;
     }
 }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
@@ -106,31 +106,34 @@ public class CamelDecoder extends Decoder {
   @Override
   public double readDouble(ByteBuffer buffer) {
     try {
-      // If cache exhausted, load next block
+      // If the current block has been fully read, load the next block
       if (cacheIndex >= valueCache.size()) {
+        // If no BitInputStream is available or all bits have been consumed
         if (in == null || in.availableBits() == 0) {
           if (!buffer.hasRemaining()) {
             throw new TsFileDecodingException("No more data to decode");
           }
 
-          // Record current buffer position and length for later update
-          int pos = buffer.position();
-          int len = buffer.remaining();
-          byte[] arr = buffer.array();
-          ByteArrayInputStream bais = new ByteArrayInputStream(arr, pos, len);
+          // Copy current buffer slice into a byte array to support non-zero array offset or direct buffer
+          ByteBuffer slice = buffer.slice(); // Creates a new view starting at current position
+          byte[] temp = new byte[slice.remaining()];
+          slice.get(temp); // Read data without modifying original buffer's position
 
-          // Read next block bits and initialize stream
+          // Use the copied data to construct an input stream
+          ByteArrayInputStream bais = new ByteArrayInputStream(temp);
+
+          // Read the number of bits in the current block
           int blockBits = ReadWriteForEncodingUtils.readVarInt(bais);
           this.in = new BitInputStream(bais, blockBits);
 
-          // Reset state for new block
+          // Reset decoder state for the new block
           this.isFirst = true;
           this.storedVal = 0L;
           this.previousValue = 0L;
           this.gorillaDecoder.leadingZeros = Integer.MAX_VALUE;
           this.gorillaDecoder.trailingZeros = 0;
 
-          // Decode entire block into cache
+          // Decode the entire block into a temporary value cache
           List<Double> newValues = getValues();
           if (newValues.isEmpty()) {
             throw new TsFileDecodingException("Unexpected empty block");
@@ -138,18 +141,19 @@ public class CamelDecoder extends Decoder {
           valueCache = newValues;
           cacheIndex = 0;
 
-          // Advance buffer position by consumed bytes after full decode
-          int consumed = len - bais.available();
-          buffer.position(pos + consumed);
+          // Advance the buffer position by the number of bytes consumed
+          int consumed = temp.length - bais.available();
+          buffer.position(buffer.position() + consumed);
         }
       }
 
-      // Return next cached value
+      // Return the next decoded value from the cache
       return valueCache.get(cacheIndex++);
     } catch (IOException e) {
       throw new TsFileDecodingException(e.getMessage());
     }
   }
+
 
   /** Nested class to handle fallback encoding (Gorilla) for double values. */
   public class GorillaDecoder {

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
@@ -20,29 +20,9 @@ public class CamelDecoder {
 
     private long totalBits = 0;
 
-    private static final int DEFAULT_BLOCK_SIZE = 1000;
+    private static final int DEFAULT_BLOCK_SIZE = Integer.MAX_VALUE;
     private static final long[] powers = {10L, 100L, 1000L, 10000L};
     private long readNum = 0;
-
-    // 1位小数对应的centerbits与前导数0的关系
-    public final static int[] leadingZerosNumOne = {12};
-    public final static int[] centerBitsNumOne = {1};
-
-    // 2位小数对应的centerbits与前导数0的关系
-    public final static int[] leadingZerosNumTwo = {13, 12};
-    public final static int[] centerBitsNumTwo = {1, 2};
-
-    // 3位小数对应的centerbits与前导数0的关系
-    public final static int[] centerBitsNumThree = {1, 2, 3};
-    public final static int[] leadingZerosNumThree = {14, 13, 12};
-
-    // 4位小数对应的centerbits与前导数0的关系
-    public final static int[] centerBitsNumFour = {1, 2, 3, 4};
-    public final static int[] leadingZerosNumFour = {15, 14, 13, 12};
-
-    // 5位小数对应的centerbits与前导数0的关系
-    public final static int[] centerBitsNumFive = {1, 2, 3, 4, 5};
-    public final static int[] leadingZerosNumFive  = {16, 15, 14, 13, 12};
 
     // 按照寻找到的m的值进行保存
     public final static int[] mValueBits = {3, 5, 7, 10, 15};

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
@@ -28,8 +28,6 @@ import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Arrays;
 
 public class CamelDecoder extends Decoder {
@@ -48,6 +46,8 @@ public class CamelDecoder extends Decoder {
   private long previousValue = 0;
   private boolean isFirst = true;
   private long storedVal = 0;
+
+  private double scale;
 
   // === Precomputed tables ===
   public static final long[] powers = new long[DECIMAL_MAX_COUNT];
@@ -230,8 +230,12 @@ public class CamelDecoder extends Decoder {
 
     if (useCamel) {
       long intPart = readLong();
+      // decimal = decPart / scale
       double decPart = readDecimal();
-      double value = (intPart >= 0 ? intPart + decPart : -(-intPart + decPart));
+      double value =
+          (intPart >= 0
+              ? (intPart * scale + decPart) / scale
+              : -(intPart * scale + decPart) / scale);
       return sign * value;
     } else {
       return sign * gorillaDecoder.decode(in);
@@ -264,7 +268,7 @@ public class CamelDecoder extends Decoder {
       frac = (double) mVal / powers[count - 1];
     }
     // Round to original scale
-    double scale = Math.pow(10, count);
-    return Math.round(frac * scale) / scale;
+    scale = Math.pow(10, count);
+    return Math.round(frac * scale);
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
@@ -105,6 +105,9 @@ public class CamelDecoder extends Decoder {
   private int cacheIndex = 0;
   private int cacheSize = 0;
 
+  // === Added reusable buffer for getValues ===
+  private double[] valuesBuffer = new double[16];
+
   @Override
   public double readDouble(ByteBuffer buffer) {
     try {
@@ -185,23 +188,17 @@ public class CamelDecoder extends Decoder {
     return gorillaDecoder;
   }
 
-  /** Read all values until the stream is exhausted. */
+  /** Read all values until the stream is exhausted, reusing valuesBuffer. */
   public double[] getValues() throws IOException {
-    // Dynamically expanding array, initial capacity set to 16
-    double[] arr = new double[16];
     int count = 0;
     while (in.availableBits() > 0) {
       double val = next();
-      if (count == arr.length) {
-        // Double the capacity when full
-        arr = Arrays.copyOf(arr, arr.length * 2);
+      if (count == valuesBuffer.length) {
+        valuesBuffer = Arrays.copyOf(valuesBuffer, valuesBuffer.length * 2);
       }
-      arr[count++] = val;
+      valuesBuffer[count++] = val;
     }
-    // Copy only the valid portion to a new array
-    double[] result = new double[count];
-    System.arraycopy(arr, 0, result, 0, count);
-    return result;
+    return Arrays.copyOf(valuesBuffer, count);
   }
 
   /** Decode next available value, return null if no more bits. */

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
@@ -52,7 +52,6 @@ public class CamelDecoder extends Decoder {
   // === Precomputed tables ===
   public static final long[] powers = new long[DECIMAL_MAX_COUNT];
   public static final long[] threshold = new long[DECIMAL_MAX_COUNT];
-  public static final int[] mValueBits = new int[DECIMAL_MAX_COUNT];
 
   static {
     for (int l = 1; l <= DECIMAL_MAX_COUNT; l++) {
@@ -60,7 +59,6 @@ public class CamelDecoder extends Decoder {
       powers[idx] = (long) Math.pow(10, l);
       long divisor = 1L << l;
       threshold[idx] = powers[idx] / divisor;
-      mValueBits[idx] = (int) Math.ceil(Math.log(threshold[idx]) / Math.log(2));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
@@ -20,13 +20,18 @@
 package org.apache.tsfile.encoding.decoder;
 
 import org.apache.tsfile.common.bitStream.BitInputStream;
+import org.apache.tsfile.exception.encoding.TsFileDecodingException;
+import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.LinkedList;
 import java.util.List;
 
-public class CamelDecoder {
+public class CamelDecoder extends Decoder {
   // === Constants for decoding ===
   private static final int BITS_FOR_SIGN = 1;
   private static final int BITS_FOR_TYPE = 1;
@@ -58,13 +63,92 @@ public class CamelDecoder {
     }
   }
 
-  private final BitInputStream in;
+  private BitInputStream in;
   private final GorillaDecoder gorillaDecoder;
 
   public CamelDecoder(InputStream inputStream, long totalBits) {
+    super(TSEncoding.CAMEL);
     // Initialize bit-level reader and nested Gorilla decoder
     this.in = new BitInputStream(inputStream, totalBits);
     this.gorillaDecoder = new GorillaDecoder();
+  }
+
+  public CamelDecoder() {
+    super(TSEncoding.CAMEL);
+    this.gorillaDecoder = new GorillaDecoder();
+  }
+
+  @Override
+  public boolean hasNext(ByteBuffer buffer) throws IOException {
+    if (cacheIndex < valueCache.size()) {
+      return true;
+    }
+    if (in != null && in.availableBits() > 0) {
+      return true;
+    }
+    return buffer.hasRemaining();
+  }
+
+  @Override
+  public void reset() {
+    this.in = null;
+    this.isFirst = true;
+    this.previousValue = 0L;
+    this.storedVal = 0L;
+    this.gorillaDecoder.leadingZeros = Integer.MAX_VALUE;
+    this.gorillaDecoder.trailingZeros = 0;
+  }
+
+  // Cache for batch decoding
+  private List<Double> valueCache = new LinkedList<>();
+  private int cacheIndex = 0;
+
+  @Override
+  public double readDouble(ByteBuffer buffer) {
+    try {
+      // If cache exhausted, load next block
+      if (cacheIndex >= valueCache.size()) {
+        if (in == null || in.availableBits() == 0) {
+          if (!buffer.hasRemaining()) {
+            throw new TsFileDecodingException("No more data to decode");
+          }
+
+          // Record current buffer position and length for later update
+          int pos = buffer.position();
+          int len = buffer.remaining();
+          byte[] arr = buffer.array();
+          ByteArrayInputStream bais = new ByteArrayInputStream(arr, pos, len);
+
+          // Read next block bits and initialize stream
+          int blockBits = ReadWriteForEncodingUtils.readVarInt(bais);
+          this.in = new BitInputStream(bais, blockBits);
+
+          // Reset state for new block
+          this.isFirst = true;
+          this.storedVal = 0L;
+          this.previousValue = 0L;
+          this.gorillaDecoder.leadingZeros = Integer.MAX_VALUE;
+          this.gorillaDecoder.trailingZeros = 0;
+
+          // Decode entire block into cache
+          List<Double> newValues = getValues();
+          if (newValues.isEmpty()) {
+            throw new TsFileDecodingException("Unexpected empty block");
+          }
+          valueCache = newValues;
+          cacheIndex = 0;
+
+          // Advance buffer position by consumed bytes after full decode
+          int consumed = len - bais.available();
+          buffer.position(pos + consumed);
+        }
+      }
+
+      // Return next cached value
+      return valueCache.get(cacheIndex++);
+    } catch (IOException e) {
+      throw new TsFileDecodingException(e.getMessage());
+    }
   }
 
   /** Nested class to handle fallback encoding (Gorilla) for double values. */

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
@@ -1,18 +1,18 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
+ * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
+ * regarding copyright ownership. The ASF licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * with the License. You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -27,44 +27,81 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class CamelDecoder {
-    GorillaDecoder gorillaDecoder;
+    // === Constants for decoding ===
+    private static final int BITS_FOR_SIGN = 1;
+    private static final int BITS_FOR_TYPE = 1;
+    private static final int BITS_FOR_FIRST_VALUE = 64;
+    private static final int BITS_FOR_LEADING_ZEROS = 6;
+    private static final int BITS_FOR_SIGNIFICANT_BITS = 6;
+    private static final int BITS_FOR_DECIMAL_COUNT = 4;
+    private static final int DOUBLE_TOTAL_BITS = 64;
+    private static final int DOUBLE_MANTISSA_BITS = 52;
+    private static final int DECIMAL_MAX_COUNT = 15;
 
+    // === Camel state ===
     private long previousValue = 0;
-
     private boolean isFirst = true;
+    private long storedVal = 0;
 
+    // === Precomputed tables ===
+    public static final long[] powers = new long[DECIMAL_MAX_COUNT];
+    public static final long[] threshold = new long[DECIMAL_MAX_COUNT];
+    public static final int[] mValueBits = new int[DECIMAL_MAX_COUNT];
+
+    static {
+        for (int l = 1; l <= DECIMAL_MAX_COUNT; l++) {
+            int idx = l - 1;
+            powers[idx] = (long) Math.pow(10, l);
+            long divisor = 1L << l;
+            threshold[idx] = powers[idx] / divisor;
+            mValueBits[idx] = (int) Math.ceil(Math.log(threshold[idx]) / Math.log(2));
+        }
+    }
+
+    private final BitInputStream in;
+    private final GorillaDecoder gorillaDecoder;
+
+    public CamelDecoder(InputStream inputStream, long totalBits) {
+        // Initialize bit-level reader and nested Gorilla decoder
+        this.in = new BitInputStream(inputStream, totalBits);
+        this.gorillaDecoder = new GorillaDecoder();
+    }
+
+    /**
+     * Nested class to handle fallback encoding (Gorilla) for double values.
+     */
     public class GorillaDecoder {
         private int leadingZeros = Integer.MAX_VALUE;
         private int trailingZeros = 0;
 
-        public boolean hasNext(BitInputStream in) throws IOException {
-            return in.availableBits() >= 0;
-        }
-
+        /**
+         * Decode next value using Gorilla algorithm.
+         */
         public double decode(BitInputStream in) throws IOException {
             if (isFirst) {
-                previousValue = in.readLong(64);
+                previousValue = in.readLong(BITS_FOR_FIRST_VALUE);
                 isFirst = false;
                 return Double.longBitsToDouble(previousValue);
             }
 
-            if (!in.readBit()) {
-                return Double.longBitsToDouble(previousValue); // same value
+            boolean controlBit = in.readBit();
+            if (!controlBit) {
+                return Double.longBitsToDouble(previousValue);
             }
 
-            boolean hasNewControl = in.readBit();
+            boolean reuseBlock = !in.readBit();
             long xor;
-            if (!hasNewControl) {
-                int significantBits = 64 - leadingZeros - trailingZeros;
-                if (significantBits == 0) {
-                    return Double.longBitsToDouble(previousValue); // no change
+            if (reuseBlock) {
+                int sigBits = DOUBLE_TOTAL_BITS - leadingZeros - trailingZeros;
+                if (sigBits == 0) {
+                    return Double.longBitsToDouble(previousValue);
                 }
-                xor = in.readLong(significantBits) << trailingZeros;
+                xor = in.readLong(sigBits) << trailingZeros;
             } else {
-                leadingZeros = in.readInt(6);
-                int significantBits = in.readInt(6) + 1;
-                trailingZeros = 64 - leadingZeros - significantBits;
-                xor = in.readLong(significantBits) << trailingZeros;
+                leadingZeros = in.readInt(BITS_FOR_LEADING_ZEROS);
+                int sigBits = in.readInt(BITS_FOR_SIGNIFICANT_BITS) + 1;
+                trailingZeros = DOUBLE_TOTAL_BITS - leadingZeros - sigBits;
+                xor = in.readLong(sigBits) << trailingZeros;
             }
 
             previousValue ^= xor;
@@ -72,118 +109,97 @@ public class CamelDecoder {
         }
     }
 
-
-    private final BitInputStream in;
-
-    private long storedVal = 0;
-
-    private final static int DECIMAL_MAX_COUNT = 15;
-    public static final long[] powers = new long[DECIMAL_MAX_COUNT];
-
-    // threshold[l-1] = 10^l / 2^l
-    public static final long[] threshold = new long[DECIMAL_MAX_COUNT];
-
-    // mValueBits[l-1] = ceil(log2(threshold[l-1]))
-    public static final int[] mValueBits = new int[DECIMAL_MAX_COUNT];
-
-    public CamelDecoder(InputStream in, long totalBits) {
-        for (int l = 1; l <= DECIMAL_MAX_COUNT; l++) {
-            int idx = l - 1;
-            powers[idx] = (long) Math.pow(10, l);
-            long divisor = 1L << l;  // 2^l
-            threshold[idx] = powers[idx] / divisor;
-            mValueBits[idx] = (int) Math.ceil(Math.log(threshold[idx]) / Math.log(2));
-        }
-        this.in = new BitInputStream(in, totalBits);
-        gorillaDecoder = new GorillaDecoder();
-    }
-
+    /**
+     * Retrieve nested GorillaDecoder.
+     */
     public GorillaDecoder getGorillaDecoder() {
         return gorillaDecoder;
     }
 
+    /**
+     * Read all values until stream is exhausted.
+     */
     public List<Double> getValues() throws IOException {
         List<Double> list = new LinkedList<>();
-        Double value = next();
-        while (value != null) {
-            list.add(value);
-            value = next();
+        Double val;
+        while ((val = next()) != null) {
+            list.add(val);
         }
         return list;
     }
 
+    /**
+     * Decode next available value, return null if no more bits.
+     */
     private Double next() throws IOException {
-        if (in.availableBits() <= 0) return null;
-        double retVal = 0;
+        if (in.availableBits() <= 0) {
+            return null;
+        }
+        double result;
         if (isFirst) {
             isFirst = false;
-            long fistValLong = in.readLong(64);
-            double firstVal = Double.longBitsToDouble(fistValLong);
-            storedVal = (long)firstVal;
-            retVal = firstVal;
+            long firstBits = in.readLong(BITS_FOR_FIRST_VALUE);
+            result = Double.longBitsToDouble(firstBits);
+            storedVal = (long) result;
         } else {
-            retVal = nextValue();
+            result = nextValue();
         }
-        previousValue = Double.doubleToLongBits(retVal);
-        return retVal;
+        previousValue = Double.doubleToLongBits(result);
+        return result;
     }
 
-    private Double nextValue() throws IOException {
-        boolean positive = in.readBit();
-        double posVal = positive ? -1.0 : 1.0;
-        boolean useCamel = in.readBit();
+    /**
+     * Decode according to Camel vs Gorilla path.
+     */
+    private double nextValue() throws IOException {
+        // Read sign bit
+        int signBit = in.readInt(BITS_FOR_SIGN);
+        double sign = signBit == 1 ? -1.0 : 1.0;
+        // Read encoding type bit
+        int typeBit = in.readInt(BITS_FOR_TYPE);
+        boolean useCamel = typeBit == 1;
+
         if (useCamel) {
-            long longVal = readLong();
-            double decimal = readDecimal();
-            if (longVal >= 0) {
-                return posVal * (longVal + decimal);
-            } else {
-                return posVal * -1 * (-1 * longVal + decimal);
-            }
+            long intPart = readLong();
+            double decPart = readDecimal();
+            double value = (intPart >= 0 ? intPart + decPart : -(-intPart + decPart));
+            return sign * value;
         } else {
-            return posVal * gorillaDecoder.decode(in);
+            return sign * gorillaDecoder.decode(in);
         }
     }
 
-    // 解压整数部分
+    /**
+     * Read variable-length integer diff and update storedVal.
+     */
     private long readLong() throws IOException {
-        long diffVal = BitInputStream.readVarLong(in);
-        storedVal = diffVal + storedVal;
-        return  storedVal;
-
+        long diff = BitInputStream.readVarLong(in);
+        storedVal += diff;
+        return storedVal;
     }
 
-    // 解压小数部分
+    /**
+     * Read and reconstruct decimal component.
+     */
     private double readDecimal() throws IOException {
-        // 读取小数位数
-        int decimalCount = in.readInt(4) + 1;
-        // 是否计算m的值
-        int isCalM = in.readInt(1);
-        long xor;
-        double decimalVal, m;
-        long xorString = 0;
-        if (isCalM == 1) {
-            // 查找保存的xor值
-            xor = in.readInt(decimalCount);
-            // 根据leadingZeroSNum和XOR拼接xorVal
-            long shiftedValue = xor << (52 - decimalCount);
-            for (int i = 0; i < 64; i++) {
-                xorString ^= (shiftedValue & (1L << i)); // 使用异或操作符直接计算xorValue
-            }
+        int count = in.readInt(BITS_FOR_DECIMAL_COUNT) + 1;
+        boolean hasXor = in.readBit();
+        long xor = 0;
+        if (hasXor) {
+            long bits = in.readLong(count);
+            xor = bits << (DOUBLE_MANTISSA_BITS - count);
         }
-        long m_long = BitInputStream.readVarLong(in);
-        if (isCalM == 1){
-            m = (double) m_long / powers[decimalCount-1] + 1;
-            long m_prime = Double.doubleToLongBits(m);
-            long decimalLong = xorString ^ m_prime;;
-            double temp = Double.longBitsToDouble(decimalLong) - 1;
-            double scale = Math.pow(10, decimalCount);
-            decimalVal = Math.round(temp * scale) / scale;
+        long mVal = BitInputStream.readVarLong(in);
+        double frac;
+        if (hasXor) {
+            double base = (double) mVal / powers[count - 1] + 1;
+            long merged = xor ^ Double.doubleToLongBits(base);
+            frac = Double.longBitsToDouble(merged) - 1;
         } else {
-            m = (double) m_long / powers[decimalCount-1];
-            decimalVal = m;
+            frac = (double) mVal / powers[count - 1];
         }
-        return decimalVal;
+        // Round to original scale
+        double scale = Math.pow(10, count);
+        return Math.round(frac * scale) / scale;
     }
 }
-

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Arrays;
 
 public class CamelDecoder extends Decoder {
   // === Constants for decoding ===
@@ -80,7 +81,7 @@ public class CamelDecoder extends Decoder {
 
   @Override
   public boolean hasNext(ByteBuffer buffer) throws IOException {
-    if (cacheIndex < valueCache.size()) {
+    if (cacheIndex < cacheSize) {
       return true;
     }
     if (in != null && in.availableBits() > 0) {
@@ -100,52 +101,42 @@ public class CamelDecoder extends Decoder {
   }
 
   // Cache for batch decoding
-  private List<Double> valueCache = new LinkedList<>();
+  private double[] valueCache = new double[0];
   private int cacheIndex = 0;
+  private int cacheSize = 0;
 
   @Override
   public double readDouble(ByteBuffer buffer) {
     try {
-      // If the current block has been fully read, load the next block
-      if (cacheIndex >= valueCache.size()) {
-        // If no BitInputStream is available or all bits have been consumed
+      if (cacheIndex >= cacheSize) {
         if (in == null || in.availableBits() == 0) {
           if (!buffer.hasRemaining()) {
             throw new TsFileDecodingException("No more data to decode");
           }
-
-          ByteBuffer slice = buffer.slice(); // Keep this
+          // read next chunk
+          ByteBuffer slice = buffer.slice();
           ByteBufferBackedInputStream bais = new ByteBufferBackedInputStream(slice);
-
-          // Read the number of bits in the current block
           int blockBits = ReadWriteForEncodingUtils.readVarInt(bais);
           this.in = new BitInputStream(bais, blockBits);
-
-          // Reset decoder state for the new block
+          // reset state
           this.isFirst = true;
           this.storedVal = 0L;
           this.previousValue = 0L;
           this.gorillaDecoder.leadingZeros = Integer.MAX_VALUE;
           this.gorillaDecoder.trailingZeros = 0;
-
-          // Decode the entire block into a temporary value cache
-          List<Double> newValues = getValues();
-          if (newValues.isEmpty()) {
+          // decode current block
+          double[] newValues = getValues();
+          if (newValues.length == 0) {
             throw new TsFileDecodingException("Unexpected empty block");
           }
           valueCache = newValues;
+          cacheSize = newValues.length;
           cacheIndex = 0;
-
-          // Advance the buffer position by the number of bytes consumed
-          // int consumed = temp.length - bais.available();
           int consumed = bais.getConsumed();
-
           buffer.position(buffer.position() + consumed);
         }
       }
-
-      // Return the next decoded value from the cache
-      return valueCache.get(cacheIndex++);
+      return valueCache[cacheIndex++];
     } catch (IOException e) {
       throw new TsFileDecodingException(e.getMessage());
     }
@@ -194,21 +185,27 @@ public class CamelDecoder extends Decoder {
     return gorillaDecoder;
   }
 
-  /** Read all values until stream is exhausted. */
-  public List<Double> getValues() throws IOException {
-    List<Double> list = new LinkedList<>();
-    Double val;
-    while ((val = next()) != null) {
-      list.add(val);
+  /** Read all values until the stream is exhausted. */
+  public double[] getValues() throws IOException {
+    // Dynamically expanding array, initial capacity set to 16
+    double[] arr = new double[16];
+    int count = 0;
+    while (in.availableBits() > 0) {
+      double val = next();
+      if (count == arr.length) {
+        // Double the capacity when full
+        arr = Arrays.copyOf(arr, arr.length * 2);
+      }
+      arr[count++] = val;
     }
-    return list;
+    // Copy only the valid portion to a new array
+    double[] result = new double[count];
+    System.arraycopy(arr, 0, result, 0, count);
+    return result;
   }
 
   /** Decode next available value, return null if no more bits. */
-  private Double next() throws IOException {
-    if (in.availableBits() <= 0) {
-      return null;
-    }
+  private double next() throws IOException {
     double result;
     if (isFirst) {
       isFirst = false;

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/Decoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/Decoder.java
@@ -177,6 +177,13 @@ public abstract class Decoder {
           default:
             throw new TsFileDecodingException(String.format(ERROR_MSG, encoding, dataType));
         }
+      case CAMEL:
+        switch (dataType) {
+          case DOUBLE:
+            return new CamelDecoder();
+          default:
+            throw new TsFileDecodingException(String.format(ERROR_MSG, encoding, dataType));
+        }
       default:
         throw new TsFileDecodingException(String.format(ERROR_MSG, encoding, dataType));
     }

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
@@ -27,199 +27,202 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class CamelEncoder {
-    private final GorillaEncoder gorillaEncoder;
+  private final GorillaEncoder gorillaEncoder;
 
-    // === Constants for encoding ===
-    private static final int BITS_FOR_SIGN = 1;
-    private static final int BITS_FOR_TYPE = 1;
-    private static final int BITS_FOR_FIRST_VALUE = 64;
-    private static final int BITS_FOR_LEADING_ZEROS = 6;
-    private static final int BITS_FOR_SIGNIFICANT_BITS = 6;
-    private static final int BITS_FOR_DECIMAL_COUNT = 4;
-    private static final int DOUBLE_TOTAL_BITS = 64;
-    private static final int DOUBLE_MANTISSA_BITS = 52;
-    private static final int DECIMAL_MAX_COUNT = 15;
+  // === Constants for encoding ===
+  private static final int BITS_FOR_SIGN = 1;
+  private static final int BITS_FOR_TYPE = 1;
+  private static final int BITS_FOR_FIRST_VALUE = 64;
+  private static final int BITS_FOR_LEADING_ZEROS = 6;
+  private static final int BITS_FOR_SIGNIFICANT_BITS = 6;
+  private static final int BITS_FOR_DECIMAL_COUNT = 4;
+  private static final int DOUBLE_TOTAL_BITS = 64;
+  private static final int DOUBLE_MANTISSA_BITS = 52;
+  private static final int DECIMAL_MAX_COUNT = 15;
 
-    // === Camel state ===
-    private long storedVal = 0;
-    private boolean isFirst = true;
-    private int decimalCount = 0;
-    long previousValue = 0;
+  // === Camel state ===
+  private long storedVal = 0;
+  private boolean isFirst = true;
+  private int decimalCount = 0;
+  long previousValue = 0;
 
-    // === Precomputed tables ===
-    public static final long[] powers = new long[DECIMAL_MAX_COUNT];
-    public static final long[] threshold = new long[DECIMAL_MAX_COUNT];
-    public static final int[] mValueBits = new int[DECIMAL_MAX_COUNT];
+  // === Precomputed tables ===
+  public static final long[] powers = new long[DECIMAL_MAX_COUNT];
+  public static final long[] threshold = new long[DECIMAL_MAX_COUNT];
+  public static final int[] mValueBits = new int[DECIMAL_MAX_COUNT];
 
-    public static Map<String, byte[]> compressVal = new HashMap<>();
+  public static Map<String, byte[]> compressVal = new HashMap<>();
 
-    private final BitOutputStream out;
-    private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+  private final BitOutputStream out;
+  private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-    public CamelEncoder() {
-        for (int l = 1; l <= DECIMAL_MAX_COUNT; l++) {
-            int idx = l - 1;
-            powers[idx] = (long) Math.pow(10, l);
-            long divisor = 1L << l;
-            threshold[idx] = powers[idx] / divisor;
-            mValueBits[idx] = (int) Math.ceil(Math.log(threshold[idx]) / Math.log(2));
-        }
-        out = new BitOutputStream(baos);
-        gorillaEncoder = new GorillaEncoder();
+  public CamelEncoder() {
+    for (int l = 1; l <= DECIMAL_MAX_COUNT; l++) {
+      int idx = l - 1;
+      powers[idx] = (long) Math.pow(10, l);
+      long divisor = 1L << l;
+      threshold[idx] = powers[idx] / divisor;
+      mValueBits[idx] = (int) Math.ceil(Math.log(threshold[idx]) / Math.log(2));
     }
+    out = new BitOutputStream(baos);
+    gorillaEncoder = new GorillaEncoder();
+  }
 
-    public class GorillaEncoder {
-        private int leadingZeros = Integer.MAX_VALUE;
-        private int trailingZeros = 0;
+  public class GorillaEncoder {
+    private int leadingZeros = Integer.MAX_VALUE;
+    private int trailingZeros = 0;
 
-        public void encode(double value, BitOutputStream out) throws IOException {
-            long curr = Double.doubleToLongBits(value);
-            if (isFirst) {
-                out.writeLong(curr, BITS_FOR_FIRST_VALUE);
-                previousValue = curr;
-                isFirst = false;
-                return;
-            }
-
-            long xor = curr ^ previousValue;
-            if (xor == 0) {
-                out.writeBit(false); // Control bit: same as previous
-            } else {
-                out.writeBit(true); // Control bit: value changed
-                int leading = Long.numberOfLeadingZeros(xor);
-                int trailing = Long.numberOfTrailingZeros(xor);
-                if (leading >= leadingZeros && trailing >= trailingZeros) {
-                    out.writeBit(false); // Reuse previous block info
-                    int significantBits = DOUBLE_TOTAL_BITS - leadingZeros - trailingZeros;
-                    out.writeLong(xor >>> trailingZeros, significantBits);
-                } else {
-                    out.writeBit(true); // Write new block info
-                    out.writeInt(leading, BITS_FOR_LEADING_ZEROS);
-                    int significantBits = DOUBLE_TOTAL_BITS - leading - trailing;
-                    out.writeInt(significantBits - 1, BITS_FOR_SIGNIFICANT_BITS);
-                    out.writeLong(xor >>> trailing, significantBits);
-                    leadingZeros = leading;
-                    trailingZeros = trailing;
-                }
-            }
-
-            previousValue = curr;
-        }
-
-        public void close(BitOutputStream out) throws IOException {
-            out.close();
-        }
-    }
-
-    public void addValue(double value) throws IOException {
-        if (isFirst) {
-            writeFirst(Double.doubleToRawLongBits(value));
-        } else {
-            compressValue(value);
-        }
-        previousValue = Double.doubleToLongBits(value);
-    }
-
-    private void writeFirst(long value) throws IOException {
+    public void encode(double value, BitOutputStream out) throws IOException {
+      long curr = Double.doubleToLongBits(value);
+      if (isFirst) {
+        out.writeLong(curr, BITS_FOR_FIRST_VALUE);
+        previousValue = curr;
         isFirst = false;
-        storedVal = (long) Double.longBitsToDouble(value);
-        out.writeLong(value, BITS_FOR_FIRST_VALUE);
-    }
+        return;
+      }
 
-    public long close() throws IOException {
-        out.close();
-        return out.getBitsWritten();
-    }
-
-    private void compressValue(double value) throws IOException {
-        int signBit = (int) ((Double.doubleToLongBits(value) >>> (DOUBLE_TOTAL_BITS - 1)) & 1);
-        out.writeInt(signBit, BITS_FOR_SIGN);
-
-        value = Math.abs(value);
-        if (value > Long.MAX_VALUE || value == 0 || Math.abs(Math.floor(Math.log10(value))) > DECIMAL_MAX_COUNT) {
-            out.writeInt(CamelInnerEncodingType.GORILLA.getCode(), BITS_FOR_TYPE);
-            gorillaEncoder.encode(value, out);
-            return;
-        }
-
-        long integerPart = (long) value;
-        int numDigits = integerPart == 0 ? 1 : (int) Math.log10(Math.abs(integerPart)) + 1;
-
-        double factor = 1;
-        while (Math.abs(value * factor - Math.round(value * factor)) > 0) {
-            factor *= 10.0;
-            decimalCount++;
-            if (decimalCount > DECIMAL_MAX_COUNT) {
-                break;
-            }
-        }
-
-        decimalCount = Math.max(1, decimalCount);
-        long decimalValue = 0;
-
-        if (decimalCount + numDigits <= DECIMAL_MAX_COUNT) {
-            long pow = powers[decimalCount - 1];
-            decimalValue = Math.round(value * pow) % pow;
-
-            out.writeInt(CamelInnerEncodingType.CAMEL.getCode(), BITS_FOR_TYPE);
-            compressIntegerValue(integerPart);
-            compressDecimalValue(decimalValue, decimalCount);
+      long xor = curr ^ previousValue;
+      if (xor == 0) {
+        out.writeBit(false); // Control bit: same as previous
+      } else {
+        out.writeBit(true); // Control bit: value changed
+        int leading = Long.numberOfLeadingZeros(xor);
+        int trailing = Long.numberOfTrailingZeros(xor);
+        if (leading >= leadingZeros && trailing >= trailingZeros) {
+          out.writeBit(false); // Reuse previous block info
+          int significantBits = DOUBLE_TOTAL_BITS - leadingZeros - trailingZeros;
+          out.writeLong(xor >>> trailingZeros, significantBits);
         } else {
-            out.writeInt(CamelInnerEncodingType.GORILLA.getCode(), BITS_FOR_TYPE);
-            gorillaEncoder.encode(value, out);
+          out.writeBit(true); // Write new block info
+          out.writeInt(leading, BITS_FOR_LEADING_ZEROS);
+          int significantBits = DOUBLE_TOTAL_BITS - leading - trailing;
+          out.writeInt(significantBits - 1, BITS_FOR_SIGNIFICANT_BITS);
+          out.writeLong(xor >>> trailing, significantBits);
+          leadingZeros = leading;
+          trailingZeros = trailing;
         }
+      }
+
+      previousValue = curr;
     }
 
-    private void compressIntegerValue(long value) throws IOException {
-        long diff = value - storedVal;
-        storedVal = value;
-        BitOutputStream.writeVarLong(diff, out);
+    public void close(BitOutputStream out) throws IOException {
+      out.close();
+    }
+  }
+
+  public void addValue(double value) throws IOException {
+    if (isFirst) {
+      writeFirst(Double.doubleToRawLongBits(value));
+    } else {
+      compressValue(value);
+    }
+    previousValue = Double.doubleToLongBits(value);
+  }
+
+  private void writeFirst(long value) throws IOException {
+    isFirst = false;
+    storedVal = (long) Double.longBitsToDouble(value);
+    out.writeLong(value, BITS_FOR_FIRST_VALUE);
+  }
+
+  public long close() throws IOException {
+    out.close();
+    return out.getBitsWritten();
+  }
+
+  private void compressValue(double value) throws IOException {
+    int signBit = (int) ((Double.doubleToLongBits(value) >>> (DOUBLE_TOTAL_BITS - 1)) & 1);
+    out.writeInt(signBit, BITS_FOR_SIGN);
+
+    value = Math.abs(value);
+    if (value > Long.MAX_VALUE
+        || value == 0
+        || Math.abs(Math.floor(Math.log10(value))) > DECIMAL_MAX_COUNT) {
+      out.writeInt(CamelInnerEncodingType.GORILLA.getCode(), BITS_FOR_TYPE);
+      gorillaEncoder.encode(value, out);
+      return;
     }
 
-    private void compressDecimalValue(long decimalValue, int decimalCount) throws IOException {
-        out.writeInt(decimalCount - 1, BITS_FOR_DECIMAL_COUNT);
-        long thresh = threshold[decimalCount - 1];
-        int m = (int) decimalValue;
+    long integerPart = (long) value;
+    int numDigits = integerPart == 0 ? 1 : (int) Math.log10(Math.abs(integerPart)) + 1;
 
-        if (decimalValue >= thresh) {
-            out.writeBit(true);
-            m = (int) (decimalValue % thresh);
-
-            long xor = Double.doubleToLongBits((double) decimalValue / powers[decimalCount - 1] + 1) ^
-                    Double.doubleToLongBits((double) m / powers[decimalCount - 1] + 1);
-
-            out.writeLong(xor >>> (DOUBLE_MANTISSA_BITS - decimalCount), decimalCount);
-        } else {
-            out.writeBit(false);
-        }
-
-        BitOutputStream.writeVarLong(m, out);
+    double factor = 1;
+    while (Math.abs(value * factor - Math.round(value * factor)) > 0) {
+      factor *= 10.0;
+      decimalCount++;
+      if (decimalCount > DECIMAL_MAX_COUNT) {
+        break;
+      }
     }
 
-    public int getWrittenBits() {
-        return out.getBitsWritten();
+    decimalCount = Math.max(1, decimalCount);
+    long decimalValue = 0;
+
+    if (decimalCount + numDigits <= DECIMAL_MAX_COUNT) {
+      long pow = powers[decimalCount - 1];
+      decimalValue = Math.round(value * pow) % pow;
+
+      out.writeInt(CamelInnerEncodingType.CAMEL.getCode(), BITS_FOR_TYPE);
+      compressIntegerValue(integerPart);
+      compressDecimalValue(decimalValue, decimalCount);
+    } else {
+      out.writeInt(CamelInnerEncodingType.GORILLA.getCode(), BITS_FOR_TYPE);
+      gorillaEncoder.encode(value, out);
+    }
+  }
+
+  private void compressIntegerValue(long value) throws IOException {
+    long diff = value - storedVal;
+    storedVal = value;
+    BitOutputStream.writeVarLong(diff, out);
+  }
+
+  private void compressDecimalValue(long decimalValue, int decimalCount) throws IOException {
+    out.writeInt(decimalCount - 1, BITS_FOR_DECIMAL_COUNT);
+    long thresh = threshold[decimalCount - 1];
+    int m = (int) decimalValue;
+
+    if (decimalValue >= thresh) {
+      out.writeBit(true);
+      m = (int) (decimalValue % thresh);
+
+      long xor =
+          Double.doubleToLongBits((double) decimalValue / powers[decimalCount - 1] + 1)
+              ^ Double.doubleToLongBits((double) m / powers[decimalCount - 1] + 1);
+
+      out.writeLong(xor >>> (DOUBLE_MANTISSA_BITS - decimalCount), decimalCount);
+    } else {
+      out.writeBit(false);
     }
 
-    public ByteArrayOutputStream getByteArrayOutputStream() {
-        return this.baos;
+    BitOutputStream.writeVarLong(m, out);
+  }
+
+  public int getWrittenBits() {
+    return out.getBitsWritten();
+  }
+
+  public ByteArrayOutputStream getByteArrayOutputStream() {
+    return this.baos;
+  }
+
+  public GorillaEncoder getGorillaEncoder() {
+    return gorillaEncoder;
+  }
+
+  public enum CamelInnerEncodingType {
+    GORILLA(0),
+    CAMEL(1);
+
+    private final int code;
+
+    CamelInnerEncodingType(int code) {
+      this.code = code;
     }
 
-    public GorillaEncoder getGorillaEncoder() {
-        return gorillaEncoder;
+    public int getCode() {
+      return code;
     }
-
-    public enum CamelInnerEncodingType {
-        GORILLA(0),
-        CAMEL(1);
-
-        private final int code;
-
-        CamelInnerEncodingType(int code) {
-            this.code = code;
-        }
-
-        public int getCode() {
-            return code;
-        }
-    }
+  }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
@@ -20,13 +20,13 @@
 package org.apache.tsfile.encoding.encoder;
 
 import org.apache.tsfile.common.bitStream.BitOutputStream;
+import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
-public class CamelEncoder {
+public class CamelEncoder extends Encoder {
   private final GorillaEncoder gorillaEncoder;
 
   // === Constants for encoding ===
@@ -38,25 +38,25 @@ public class CamelEncoder {
   private static final int BITS_FOR_DECIMAL_COUNT = 4;
   private static final int DOUBLE_TOTAL_BITS = 64;
   private static final int DOUBLE_MANTISSA_BITS = 52;
-  private static final int DECIMAL_MAX_COUNT = 15;
+  private static final int DECIMAL_MAX_COUNT = 10;
 
   // === Camel state ===
   private long storedVal = 0;
   private boolean isFirst = true;
   private int decimalCount = 0;
   long previousValue = 0;
+  private boolean hasPending = false; // guard for empty or duplicate flush
 
   // === Precomputed tables ===
   public static final long[] powers = new long[DECIMAL_MAX_COUNT];
   public static final long[] threshold = new long[DECIMAL_MAX_COUNT];
   public static final int[] mValueBits = new int[DECIMAL_MAX_COUNT];
 
-  public static Map<String, byte[]> compressVal = new HashMap<>();
-
   private final BitOutputStream out;
   private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
   public CamelEncoder() {
+    super(TSEncoding.CAMEL);
     for (int l = 1; l <= DECIMAL_MAX_COUNT; l++) {
       int idx = l - 1;
       powers[idx] = (long) Math.pow(10, l);
@@ -66,6 +66,70 @@ public class CamelEncoder {
     }
     out = new BitOutputStream(baos);
     gorillaEncoder = new GorillaEncoder();
+  }
+
+  /**
+   * Encode a double value and buffer bits for later flush. Marks that there is pending data to
+   * flush.
+   *
+   * @param value the double value to encode
+   * @param out unused here, uses internal buffer
+   */
+  @Override
+  public void encode(double value, ByteArrayOutputStream out) {
+    try {
+      this.addValue(value);
+      hasPending = true;
+    } catch (IOException ignored) {
+    }
+  }
+
+  /**
+   * Flush buffered encoded values to the provided stream. Writes a header indicating the number of
+   * bits written, followed by the buffered bit data. Resets internal buffers and state afterward.
+   * Consecutive calls without new data are no-ops.
+   *
+   * @param out the destination ByteArrayOutputStream to write flushed data
+   * @throws IOException if an I/O error occurs during flush
+   */
+  @Override
+  public void flush(ByteArrayOutputStream out) throws IOException {
+    if (!hasPending) {
+      return;
+    }
+    int writtenBits = close();
+    ReadWriteForEncodingUtils.writeVarInt(writtenBits, out);
+    this.baos.writeTo(out);
+    this.baos.reset();
+    this.out.reset(this.baos);
+    resetState();
+    hasPending = false;
+  }
+
+  /**
+   * Reset encoder state to initial conditions for a new block. Clears Camel and nested Gorilla
+   * state, and resets pending flag.
+   */
+  private void resetState() {
+    this.isFirst = true;
+    this.storedVal = 0L;
+    this.previousValue = 0L;
+    this.decimalCount = 0;
+    this.hasPending = false;
+    // reset Gorilla state
+    this.gorillaEncoder.leadingZeros = Integer.MAX_VALUE;
+    this.gorillaEncoder.trailingZeros = 0;
+  }
+
+  @Override
+  public int getOneItemMaxSize() {
+    return 8;
+  }
+
+  @Override
+  public long getMaxByteSize() {
+    // bitstream buffer | bytes buffer | storedVal | previousValue
+    return 1 + this.baos.size() + 8 + 8;
   }
 
   public class GorillaEncoder {
@@ -126,7 +190,7 @@ public class CamelEncoder {
     out.writeLong(value, BITS_FOR_FIRST_VALUE);
   }
 
-  public long close() throws IOException {
+  public int close() throws IOException {
     out.close();
     return out.getBitsWritten();
   }
@@ -151,7 +215,7 @@ public class CamelEncoder {
     while (Math.abs(value * factor - Math.round(value * factor)) > 0) {
       factor *= 10.0;
       decimalCount++;
-      if (decimalCount > DECIMAL_MAX_COUNT) {
+      if (numDigits + decimalCount > DECIMAL_MAX_COUNT) {
         break;
       }
     }

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.tsfile.encoding.encoder;
 
 import org.apache.tsfile.common.bitStream.BitOutputStream;
@@ -8,11 +27,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class CamelEncoder {
-    public static GorillaEncoder GorillaEncoder;
+    private GorillaEncoder gorillaEncoder;
 
     public enum CamelInnerEncodingType {
-        CAMEL(0),
-        Gorilla(1);
+        GORILLA(0),
+        CAMEL(1);
 
         private final int code;
 
@@ -34,16 +53,14 @@ public class CamelEncoder {
         }
     }
 
-    public static class GorillaEncoder {
-        private long previousValue = 0;
+    public class GorillaEncoder {
         private int leadingZeros = Integer.MAX_VALUE;
         private int trailingZeros = 0;
-        private boolean isFirst = true;
 
         public void encode(double value, BitOutputStream out) throws IOException {
             long curr = Double.doubleToLongBits(value);
-
             if (isFirst) {
+                size += 64;
                 out.writeLong(curr, 64);
                 previousValue = curr;
                 isFirst = false;
@@ -51,21 +68,27 @@ public class CamelEncoder {
             }
 
             long xor = curr ^ previousValue;
+            size += 1;
             if (xor == 0) {
                 out.writeBit(false); // Control bit
             } else {
                 out.writeBit(true); // Control bit
                 int leading = Long.numberOfLeadingZeros(xor);
                 int trailing = Long.numberOfTrailingZeros(xor);
+                size += 1;
                 if (leading >= leadingZeros && trailing >= trailingZeros) {
                     out.writeBit(false); // Reuse previous block
                     int significantBits = 64 - leadingZeros - trailingZeros;
+                    size += significantBits;
                     out.writeLong(xor >>> trailingZeros, significantBits);
                 } else {
                     out.writeBit(true); // Write new leading/trailing info
+                    size += 6;
                     out.writeInt(leading, 6);
                     int significantBits = 64 - leading - trailing;
+                    size += 6;
                     out.writeInt(significantBits - 1, 6);
+                    size += significantBits;
                     out.writeLong(xor >>> trailing, significantBits);
                     leadingZeros = leading;
                     trailingZeros = trailing;
@@ -83,17 +106,15 @@ public class CamelEncoder {
 
     private long storedVal = 0;
 
-    private boolean first = true;
+    private boolean isFirst = true;
 
     private int size;
 
     private final static int DECIMAL_MAX_COUNT = 15;
 
-    private  boolean decimalCountFlag = false;
-
     private  int decimalCount = 0;
 
-    double prevVal = 0;
+    long previousValue = 0;
 
     public static final long[] powers = new long[DECIMAL_MAX_COUNT];
 
@@ -118,6 +139,11 @@ public class CamelEncoder {
         }
         out = new BitOutputStream(baos);
         size = 0;
+        gorillaEncoder = new GorillaEncoder();
+    }
+
+    public GorillaEncoder getGorillaEncoder() {
+        return gorillaEncoder;
     }
 
     public ByteArrayOutputStream getByteArrayOutputStream() {
@@ -130,19 +156,20 @@ public class CamelEncoder {
      * @param value next floating point value in the series
      */
     public int addValue(double value) throws IOException {
-        prevVal = value;
-        if(first) {
-            return writeFirst(Double.doubleToRawLongBits(value));
+        if(isFirst) {
+            writeFirst(Double.doubleToRawLongBits(value));
         } else {
-            return compressValue(value);
+            compressValue(value);
         }
+        previousValue = Double.doubleToLongBits(value);
+        return size;
     }
 
     // 写入第一个数据
     private int writeFirst(long value) throws IOException {
-        first = false;
+        isFirst = false;
         // 保存第一个数字的整数进行差值计算
-        storedVal = (int) Double.longBitsToDouble(value);
+        storedVal = (long) Double.longBitsToDouble(value);
         out.writeLong(value, 64);
         size += 64;
         return size;
@@ -158,38 +185,55 @@ public class CamelEncoder {
 
     // 数据压缩
     private int compressValue(double value) throws IOException {
-        compressIntegerValue((long)value);
-        double factor = 1;
+        size += 1;
+        byte signBit = (byte) ((Double.doubleToLongBits(value) >>> 63) & 1);
+        out.writeBit(signBit == 1);
+
         value = Math.abs(value);
-        if (!decimalCountFlag) {
-            double epsilon = 0.0000001; // 设置一个很小的阈值
-            while (Math.abs(value * factor - Math.round(value * factor)) > epsilon) {
-                factor *= 10.0;
-                decimalCount++;
+        if (value > Long.MAX_VALUE || value == 0 || Math.abs(Math.floor(Math.log10(value))) > DECIMAL_MAX_COUNT) {
+            // gorilla
+            size += 1;
+            out.writeInt(CamelInnerEncodingType.GORILLA.getCode(), 1);
+            gorillaEncoder.encode(value, out);
+            return this.size;
+        }
+
+        // 计算整数部分的值和十进制位数
+        long integerPart = (long) value;
+        int numDigits = integerPart == 0 ? 1 : (int) Math.log10(Math.abs(integerPart)) + 1;
+        // 计算小数部分的位数和值
+        double factor = 1;
+        while (Math.abs(value * factor - Math.round(value * factor)) > 0) {
+            factor *= 10.0;
+            decimalCount++;
+            if (decimalCount > DECIMAL_MAX_COUNT) {
+                break;
             }
-            decimalCountFlag = true;
         }
-
-        long decimalValue;
-        if (decimalCount == 0) {
-            decimalCount = 1;
-        }
-
-        if (decimalCount > 0 && decimalCount <= DECIMAL_MAX_COUNT) {
+        decimalCount = Math.max(1, decimalCount);
+        long decimalValue = 0;
+        if (decimalCount + numDigits <= DECIMAL_MAX_COUNT) {
             long pow = powers[decimalCount - 1];
             decimalValue = Math.round(value * pow) % pow;
-        }else {
-            decimalValue = ((long) (value * powers[DECIMAL_MAX_COUNT]) % powers[DECIMAL_MAX_COUNT])/10;
-            decimalCount = DECIMAL_MAX_COUNT;
+            size += 1;
+            // camel
+            out.writeInt(CamelInnerEncodingType.CAMEL.getCode(), 1);
+            compressIntegerValue(integerPart);
+            compressDecimalValue(decimalValue, decimalCount);
+        } else {
+            // gorilla
+            size += 1;
+            out.writeInt(CamelInnerEncodingType.GORILLA.getCode(), 1);
+            gorillaEncoder.encode(value, out);
         }
-        compressDecimalValue(decimalValue, decimalCount);
+
         return this.size;
     }
 
     // 压缩小数部分
     private void compressDecimalValue(long decimal_value, int decimalCount) throws IOException {
-        out.writeInt(decimalCount-1, 2);
-        size += 2;
+        out.writeInt(decimalCount-1, 4);
+        size += 4;
         // 计算m的值
         long thread = threshold[decimalCount-1];
         int m = (int) decimal_value;
@@ -219,7 +263,7 @@ public class CamelEncoder {
     }
 
 
-    public int getSize() {
-        return size;
+    public int getWrittenBits() {
+        return out.getBitsWritten();
     }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
@@ -1,0 +1,277 @@
+package org.apache.tsfile.encoding.encoder;
+
+import org.apache.tsfile.common.bitStream.BitOutputStream;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CamelEncoder {
+
+    private long storedVal = 0;
+
+    // 默认10000 对应 block大小位1000
+    private final static int outStreamSize = 100000;
+    private boolean first = true;
+    private int size;
+    private final static long END_SIGN = Double.doubleToLongBits(Double.NaN);
+
+    private final static int DECIMAL_MAX_COUNT = 4;
+
+    private  boolean decimalCountFlag = false;
+
+    private  int decimal_count = 0;
+
+    // 按照寻找到的m的值进行保存
+    public final static int[] mValueBits = {3, 5, 7, 10, 12, 14};
+    //    public final static BigDecimal[]  threshold = {BigDecimal.valueOf(0.5), BigDecimal.valueOf(0.25), BigDecimal.valueOf(0.125), BigDecimal.valueOf(0.0625)};
+    public final static long[]  threshold = {5, 25, 125, 625, 3125, 15625};
+
+    private static final long[] powers = {10L, 100L, 1000L, 10000L, 10000L, 100000L, 1000000L};
+    public static Map<String, byte[]> compressVal = new HashMap<>();
+
+    private final BitOutputStream out;
+    private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+    // We should have access to the series?
+    public CamelEncoder() {
+        out = new BitOutputStream(baos);
+        size = 0;
+    }
+
+    public ByteArrayOutputStream getByteArrayOutputStream() {
+        return this.baos;
+    }
+
+    /**
+     * Adds a new long value to the series. Note, values must be inserted in order.
+     *
+     * @param value next floating point value in the series
+     */
+    public int addValue(long value) throws IOException {
+        if(first) {
+            return writeFirst(value);
+        } else {
+            return compressValue(value);
+        }
+    }
+
+    /**
+     * Adds a new double value to the series. Note, values must be inserted in order.
+     *
+     * @param value next floating point value in the series
+     */
+    public int addValue(double value) throws IOException {
+        if(first) {
+            return writeFirst(Double.doubleToRawLongBits(value));
+        } else {
+            return compressValue(value);
+        }
+    }
+
+    // 写入第一个数据
+    private int writeFirst(long value) throws IOException {
+        first = false;
+        // 保存第一个数字的整数进行差值计算
+        storedVal = (int) Double.longBitsToDouble(value);
+        out.writeLong(value, 64);
+        size += 64;
+//        compressVal.put("compressInt", convertToBinary((int) value, 64));
+        return size;
+    }
+
+    /**
+     * Closes the block and writes the remaining stuff to the BitOutput.
+     */
+    public long close() throws IOException {
+//        addValue(END_SIGN);
+        out.close();
+        long totalWrittenBits = out.getBitsWritten();
+        return totalWrittenBits;
+    }
+
+    // 数据压缩
+    private int compressValue(double value) throws IOException {
+        // 压缩小数位 默认小数位是1.**
+        size = compressIntegerValue((int)value);
+        double factor = 1;
+        value = Math.abs(value);
+        if (!decimalCountFlag) {
+            double epsilon = 0.0000001; // 设置一个很小的阈值
+            while (Math.abs(value * factor - Math.round(value * factor)) > epsilon) {
+                factor *= 10.0;
+                decimal_count++;
+            }
+            decimalCountFlag = true;
+        }
+
+        long decimal_value;
+        if (decimal_count == 0) {
+            decimal_count = 1;
+        }
+
+        if (decimal_count > 0 && decimal_count<= DECIMAL_MAX_COUNT) {
+            decimal_value =  ((long) (value * powers[decimal_count]) % powers[decimal_count])/10;
+        }else {
+            decimal_value = ((long) (value * powers[DECIMAL_MAX_COUNT]) % powers[DECIMAL_MAX_COUNT])/10;
+            decimal_count = DECIMAL_MAX_COUNT;
+        }
+        size = compressDecimalValue(decimal_value, decimal_count);
+
+
+        // 压缩整数位
+
+        return size;
+    }
+
+
+    public int countDecimalPlaces(BigDecimal value) {
+        String valueStr = value.toString();
+        int decimalPointIndex = valueStr.indexOf('.');
+
+        if (decimalPointIndex >= 0) {
+            return valueStr.length() - decimalPointIndex - 1;
+        } else {
+            // No decimal point, so there are no decimal places
+            return 0;
+        }
+    }
+
+
+    // 压缩小数部分
+    private int compressDecimalValue(long decimal_value, int decimal_count) throws IOException {
+        // 计算小数位数
+        out.writeInt(decimal_count-1, 2); // 保存字节数 00-1 01-2 10-3 11-4
+        size += 2;
+        // 计算m的值
+        long thread = threshold[decimal_count-1];
+        int m = (int) decimal_value;
+        size += 1;
+        if (decimal_value - thread >= 0) {  // 计算m的值
+            // 标志位：是否计算m的值
+            out.writeBit(true);
+            m = (int) (decimal_value % thread);
+            // 对于m进行XOR操作
+            long xor = (Double.doubleToLongBits((double)decimal_value/powers[decimal_count-1]+1)) ^ Double.doubleToLongBits(((double) m/powers[decimal_count-1]+1));
+            // 保存小数位数长度的centerBits 保存decimal_count （四位最多就是1000）
+            out.writeLong(xor >>> 52 - decimal_count, decimal_count);
+            size += decimal_count;// Store the meaningful bits of XOR
+
+        } else {  // m就为原来的值
+            out.writeBit(false);
+        }
+
+        // 保存m的值
+        if (decimal_count <= 1) { // 如果是1 直接往后读decimal_count+1位
+            out.writeInt(m, decimal_count + 1);
+            size += decimal_count + 1;
+            return this.size;
+        }
+        if (decimal_count ==2) {
+            if (m < 8) {
+                out.writeInt(0, 1);
+                out.writeInt(m, 3);
+                size += 4;
+                return this.size;
+            }  else {
+                out.writeInt(1, 1);
+                out.writeInt(m, 5);
+                size += 6;
+                return this.size;
+            }
+        }
+        if (decimal_count == 3) {
+            if (m < 2) {
+                out.writeInt(0, 2);
+                out.writeInt(m, 1);
+                size += 3;
+                return this.size;
+            }else if (m < 8){
+                out.writeInt(1, 2);
+                out.writeInt(m, 3);
+                size += 5;
+                return this.size;
+            }else if (m < 32) {
+                out.writeInt(2, 2);
+                out.writeInt(m, 5);
+                size += 7;
+                return this.size;
+            }else {
+                out.writeInt(3, 2);
+                out.writeInt(m, mValueBits[decimal_count-1]);
+                size += 2;
+                size += mValueBits[decimal_count-1];
+                return this.size;
+            }
+        }
+        if (decimal_count >= 4){
+            if (m < 16) {
+                out.writeInt(0, 2);
+                out.writeInt(m, 4);
+                size += 6;
+                return this.size;
+            }else if (m < 64){
+                out.writeInt(1, 2);
+                out.writeInt(m, 6);
+                size += 8;
+                return this.size;
+            }else if (m < 256) {
+                out.writeInt(2, 2);
+                out.writeInt(m, 8);
+                size += 10;
+                return this.size;
+            }else {
+                out.writeInt(3, 2);
+                out.writeInt(m, mValueBits[decimal_count-1]);
+                size += 2;
+                size += mValueBits[decimal_count-1];
+                return this.size;
+            }
+
+        }
+
+        return this.size;
+
+    }
+
+    // 压缩整数部分
+    private int compressIntegerValue(long int_value) throws IOException {
+
+        int diff = (int)(int_value - storedVal) ;
+        size += 2;
+        storedVal = int_value;
+        if (diff >= -1 && diff <= 1) {
+            out.writeInt((diff + 1), 2); // Map -1 to 0, 0 to 1, 1 to 2 respectively
+            return this.size;
+        } else{
+            out.writeInt(3, 2); // //11
+            if (diff < 0){
+                out.writeBit(false);
+                diff = -diff;
+            } else {
+                out.writeBit(true);
+
+            }
+            size += 1;
+            if (diff >=2 && diff < 8) { // [4,8)
+                out.writeInt(0, 1); // 0
+                out.writeInt(diff, 3);
+                size += 4;
+                return this.size;
+            } else {
+                out.writeInt(1, 1); //1  // [8,...)
+                out.writeInt(diff, 32); // 暂用16个bit表示
+                size += 17;
+                return this.size;
+            }
+        }
+//        return this.size;
+    }
+
+
+    public int getSize() {
+        return size;
+    }
+}

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
@@ -4,11 +4,82 @@ import org.apache.tsfile.common.bitStream.BitOutputStream;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 
 public class CamelEncoder {
+    public static GorillaEncoder GorillaEncoder;
+
+    public enum CamelInnerEncodingType {
+        CAMEL(0),
+        Gorilla(1);
+
+        private final int code;
+
+        CamelInnerEncodingType(int code) {
+            this.code = code;
+        }
+
+        public int getCode() {
+            return code;
+        }
+
+        public static CamelInnerEncodingType fromCode(int code) {
+            for (CamelInnerEncodingType type : CamelInnerEncodingType.values()) {
+                if (type.code == code) {
+                    return type;
+                }
+            }
+            throw new IllegalArgumentException("Invalid encoding type code: " + code);
+        }
+    }
+
+    public static class GorillaEncoder {
+        private long previousValue = 0;
+        private int leadingZeros = Integer.MAX_VALUE;
+        private int trailingZeros = 0;
+        private boolean isFirst = true;
+
+        public void encode(double value, BitOutputStream out) throws IOException {
+            long curr = Double.doubleToLongBits(value);
+
+            if (isFirst) {
+                out.writeLong(curr, 64);
+                previousValue = curr;
+                isFirst = false;
+                return;
+            }
+
+            long xor = curr ^ previousValue;
+            if (xor == 0) {
+                out.writeBit(false); // Control bit
+            } else {
+                out.writeBit(true); // Control bit
+                int leading = Long.numberOfLeadingZeros(xor);
+                int trailing = Long.numberOfTrailingZeros(xor);
+                if (leading >= leadingZeros && trailing >= trailingZeros) {
+                    out.writeBit(false); // Reuse previous block
+                    int significantBits = 64 - leadingZeros - trailingZeros;
+                    out.writeLong(xor >>> trailingZeros, significantBits);
+                } else {
+                    out.writeBit(true); // Write new leading/trailing info
+                    out.writeInt(leading, 6);
+                    int significantBits = 64 - leading - trailing;
+                    out.writeInt(significantBits - 1, 6);
+                    out.writeLong(xor >>> trailing, significantBits);
+                    leadingZeros = leading;
+                    trailingZeros = trailing;
+                }
+            }
+
+            previousValue = curr;
+        }
+
+        public void close (BitOutputStream out) throws IOException {
+            out.close();
+        }
+    }
+
 
     private long storedVal = 0;
 
@@ -16,25 +87,35 @@ public class CamelEncoder {
 
     private int size;
 
-    private final static int DECIMAL_MAX_COUNT = 4;
+    private final static int DECIMAL_MAX_COUNT = 15;
 
     private  boolean decimalCountFlag = false;
 
-    private  int decimal_count = 0;
+    private  int decimalCount = 0;
 
-    // 按照寻找到的m的值进行保存
-    public final static int[] mValueBits = {3, 5, 7, 10, 12, 14};
-    //    public final static BigDecimal[]  threshold = {BigDecimal.valueOf(0.5), BigDecimal.valueOf(0.25), BigDecimal.valueOf(0.125), BigDecimal.valueOf(0.0625)};
-    public final static long[]  threshold = {5, 25, 125, 625, 3125, 15625, 78125, 390625, 1953125};
+    double prevVal = 0;
 
-    private static final long[] powers = {10L, 100L, 1000L, 10000L, 10000L, 100000L, 1000000L};
+    public static final long[] powers = new long[DECIMAL_MAX_COUNT];
+
+    // threshold[l-1] = 10^l / 2^l
+    public static final long[] threshold = new long[DECIMAL_MAX_COUNT];
+
+    // mValueBits[l-1] = ceil(log2(threshold[l-1]))
+    public static final int[] mValueBits = new int[DECIMAL_MAX_COUNT];
+
     public static Map<String, byte[]> compressVal = new HashMap<>();
 
     private final BitOutputStream out;
     private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-    // We should have access to the series?
     public CamelEncoder() {
+        for (int l = 1; l <= DECIMAL_MAX_COUNT; l++) {
+            int idx = l - 1;
+            powers[idx] = (long) Math.pow(10, l);
+            long divisor = 1L << l;  // 2^l
+            threshold[idx] = powers[idx] / divisor;
+            mValueBits[idx] = (int) Math.ceil(Math.log(threshold[idx]) / Math.log(2));
+        }
         out = new BitOutputStream(baos);
         size = 0;
     }
@@ -44,24 +125,12 @@ public class CamelEncoder {
     }
 
     /**
-     * Adds a new long value to the series. Note, values must be inserted in order.
-     *
-     * @param value next floating point value in the series
-     */
-    public int addValue(long value) throws IOException {
-        if(first) {
-            return writeFirst(value);
-        } else {
-            return compressValue(value);
-        }
-    }
-
-    /**
      * Adds a new double value to the series. Note, values must be inserted in order.
      *
      * @param value next floating point value in the series
      */
     public int addValue(double value) throws IOException {
+        prevVal = value;
         if(first) {
             return writeFirst(Double.doubleToRawLongBits(value));
         } else {
@@ -76,7 +145,6 @@ public class CamelEncoder {
         storedVal = (int) Double.longBitsToDouble(value);
         out.writeLong(value, 64);
         size += 64;
-//        compressVal.put("compressInt", convertToBinary((int) value, 64));
         return size;
     }
 
@@ -84,69 +152,46 @@ public class CamelEncoder {
      * Closes the block and writes the remaining stuff to the BitOutput.
      */
     public long close() throws IOException {
-//        addValue(END_SIGN);
         out.close();
-        long totalWrittenBits = out.getBitsWritten();
-        return totalWrittenBits;
+        return out.getBitsWritten();
     }
 
     // 数据压缩
     private int compressValue(double value) throws IOException {
-        // 压缩小数位 默认小数位是1.**
-        size = compressIntegerValue((int)value);
+        compressIntegerValue((long)value);
         double factor = 1;
         value = Math.abs(value);
         if (!decimalCountFlag) {
             double epsilon = 0.0000001; // 设置一个很小的阈值
             while (Math.abs(value * factor - Math.round(value * factor)) > epsilon) {
                 factor *= 10.0;
-                decimal_count++;
+                decimalCount++;
             }
             decimalCountFlag = true;
         }
 
-        long decimal_value;
-        if (decimal_count == 0) {
-            decimal_count = 1;
+        long decimalValue;
+        if (decimalCount == 0) {
+            decimalCount = 1;
         }
 
-        if (decimal_count > 0 && decimal_count<= DECIMAL_MAX_COUNT) {
-            //decimal_value =  ((long) (value * powers[decimal_count]) % powers[decimal_count])/10;
-            long pow = powers[decimal_count - 1];  // 如 100L
-            decimal_value = Math.round(value * pow) % pow;
+        if (decimalCount > 0 && decimalCount <= DECIMAL_MAX_COUNT) {
+            long pow = powers[decimalCount - 1];
+            decimalValue = Math.round(value * pow) % pow;
         }else {
-            decimal_value = ((long) (value * powers[DECIMAL_MAX_COUNT]) % powers[DECIMAL_MAX_COUNT])/10;
-            decimal_count = DECIMAL_MAX_COUNT;
+            decimalValue = ((long) (value * powers[DECIMAL_MAX_COUNT]) % powers[DECIMAL_MAX_COUNT])/10;
+            decimalCount = DECIMAL_MAX_COUNT;
         }
-        size = compressDecimalValue(decimal_value, decimal_count);
-
-
-        // 压缩整数位
-
-        return size;
+        compressDecimalValue(decimalValue, decimalCount);
+        return this.size;
     }
-
-
-    public int countDecimalPlaces(BigDecimal value) {
-        String valueStr = value.toString();
-        int decimalPointIndex = valueStr.indexOf('.');
-
-        if (decimalPointIndex >= 0) {
-            return valueStr.length() - decimalPointIndex - 1;
-        } else {
-            // No decimal point, so there are no decimal places
-            return 0;
-        }
-    }
-
 
     // 压缩小数部分
-    private int compressDecimalValue(long decimal_value, int decimal_count) throws IOException {
-        // 计算小数位数
-        out.writeInt(decimal_count-1, 2); // 保存字节数 00-1 01-2 10-3 11-4
+    private void compressDecimalValue(long decimal_value, int decimalCount) throws IOException {
+        out.writeInt(decimalCount-1, 2);
         size += 2;
         // 计算m的值
-        long thread = threshold[decimal_count-1];
+        long thread = threshold[decimalCount-1];
         int m = (int) decimal_value;
         size += 1;
         if (decimal_value - thread >= 0) {  // 计算m的值
@@ -154,120 +199,23 @@ public class CamelEncoder {
             out.writeBit(true);
             m = (int) (decimal_value % thread);
             // 对于m进行XOR操作
-            long xor = (Double.doubleToLongBits((double)decimal_value/powers[decimal_count-1]+1)) ^ Double.doubleToLongBits(((double) m/powers[decimal_count-1]+1));
-            // 保存小数位数长度的centerBits 保存decimal_count （四位最多就是1000）
-            out.writeLong(xor >>> 52 - decimal_count, decimal_count);
-            size += decimal_count;// Store the meaningful bits of XOR
+            long xor = (Double.doubleToLongBits((double)decimal_value/powers[decimalCount-1]+1)) ^ Double.doubleToLongBits(((double) m/powers[decimalCount-1]+1));
+            // 保存小数位数长度的centerBits
+            out.writeLong(xor >>> 52 - decimalCount, decimalCount);
+            size += decimalCount;// Store the meaningful bits of XOR
 
-        } else {  // m就为原来的值
+        } else {
             out.writeBit(false);
         }
-
-        // 保存m的值
-        if (decimal_count <= 1) { // 如果是1 直接往后读decimal_count+1位
-            out.writeInt(m, decimal_count + 1);
-            size += decimal_count + 1;
-            return this.size;
-        }
-        if (decimal_count ==2) {
-            if (m < 8) {
-                out.writeInt(0, 1);
-                out.writeInt(m, 3);
-                size += 4;
-                return this.size;
-            }  else {
-                out.writeInt(1, 1);
-                out.writeInt(m, 5);
-                size += 6;
-                return this.size;
-            }
-        }
-        if (decimal_count == 3) {
-            if (m < 2) {
-                out.writeInt(0, 2);
-                out.writeInt(m, 1);
-                size += 3;
-                return this.size;
-            }else if (m < 8){
-                out.writeInt(1, 2);
-                out.writeInt(m, 3);
-                size += 5;
-                return this.size;
-            }else if (m < 32) {
-                out.writeInt(2, 2);
-                out.writeInt(m, 5);
-                size += 7;
-                return this.size;
-            }else {
-                out.writeInt(3, 2);
-                out.writeInt(m, mValueBits[decimal_count-1]);
-                size += 2;
-                size += mValueBits[decimal_count-1];
-                return this.size;
-            }
-        }
-        if (decimal_count >= 4){
-            if (m < 16) {
-                out.writeInt(0, 2);
-                out.writeInt(m, 4);
-                size += 6;
-                return this.size;
-            }else if (m < 64){
-                out.writeInt(1, 2);
-                out.writeInt(m, 6);
-                size += 8;
-                return this.size;
-            }else if (m < 256) {
-                out.writeInt(2, 2);
-                out.writeInt(m, 8);
-                size += 10;
-                return this.size;
-            }else {
-                out.writeInt(3, 2);
-                out.writeInt(m, mValueBits[decimal_count-1]);
-                size += 2;
-                size += mValueBits[decimal_count-1];
-                return this.size;
-            }
-
-        }
-
-        return this.size;
-
+        this.size += BitOutputStream.writeVarLong(m, out);
     }
 
     // 压缩整数部分
-    private int compressIntegerValue(long int_value) throws IOException {
-
-        int diff = (int)(int_value - storedVal) ;
-        size += 2;
-        storedVal = int_value;
-        if (diff >= -1 && diff <= 1) {
-            out.writeInt((diff + 1), 2); // Map -1 to 0, 0 to 1, 1 to 2 respectively
-            return this.size;
-        } else{
-            out.writeInt(3, 2); // //11
-            if (diff < 0){
-                out.writeBit(false);
-                diff = -diff;
-            } else {
-                out.writeBit(true);
-
-            }
-            size += 1;
-            if (diff >=2 && diff < 8) { // [4,8)
-                out.writeInt(0, 1); // 0
-                out.writeInt(diff, 3);
-                size += 4;
-                return this.size;
-            } else {
-                out.writeInt(1, 1); //1  // [8,...)
-                out.writeInt(diff, 32); // 暂用16个bit表示
-                size += 17;
-                return this.size;
-            }
-        }
-//        return this.size;
+    private void compressIntegerValue(long value) throws IOException {
+        long diff = value - storedVal;
+        storedVal = value;
+        int bitsWritten = BitOutputStream.writeVarLong(diff, out);
+        this.size += bitsWritten;
     }
 
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
@@ -43,7 +43,6 @@ public class CamelEncoder extends Encoder {
   // === Camel state ===
   private long storedVal = 0;
   private boolean isFirst = true;
-  private int decimalCount = 0;
   long previousValue = 0;
   private boolean hasPending = false; // guard for empty or duplicate flush
 
@@ -114,7 +113,6 @@ public class CamelEncoder extends Encoder {
     this.isFirst = true;
     this.storedVal = 0L;
     this.previousValue = 0L;
-    this.decimalCount = 0;
     this.hasPending = false;
     // reset Gorilla state
     this.gorillaEncoder.leadingZeros = Integer.MAX_VALUE;
@@ -217,6 +215,7 @@ public class CamelEncoder extends Encoder {
     }
 
     double factor = 1;
+    int decimalCount = 0;
     while (Math.abs(value * factor - Math.round(value * factor)) > 0) {
       factor *= 10.0;
       decimalCount++;
@@ -226,7 +225,7 @@ public class CamelEncoder extends Encoder {
     }
 
     decimalCount = Math.max(1, decimalCount);
-    long decimalValue = 0;
+    long decimalValue;
 
     if (decimalCount + numDigits <= DECIMAL_MAX_COUNT) {
       long pow = powers[decimalCount - 1];

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
@@ -27,7 +27,186 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class CamelEncoder {
-    private GorillaEncoder gorillaEncoder;
+    private final GorillaEncoder gorillaEncoder;
+
+    // === Constants for encoding ===
+    private static final int BITS_FOR_SIGN = 1;
+    private static final int BITS_FOR_TYPE = 1;
+    private static final int BITS_FOR_FIRST_VALUE = 64;
+    private static final int BITS_FOR_LEADING_ZEROS = 6;
+    private static final int BITS_FOR_SIGNIFICANT_BITS = 6;
+    private static final int BITS_FOR_DECIMAL_COUNT = 4;
+    private static final int DOUBLE_TOTAL_BITS = 64;
+    private static final int DOUBLE_MANTISSA_BITS = 52;
+    private static final int DECIMAL_MAX_COUNT = 15;
+
+    // === Camel state ===
+    private long storedVal = 0;
+    private boolean isFirst = true;
+    private int decimalCount = 0;
+    long previousValue = 0;
+
+    // === Precomputed tables ===
+    public static final long[] powers = new long[DECIMAL_MAX_COUNT];
+    public static final long[] threshold = new long[DECIMAL_MAX_COUNT];
+    public static final int[] mValueBits = new int[DECIMAL_MAX_COUNT];
+
+    public static Map<String, byte[]> compressVal = new HashMap<>();
+
+    private final BitOutputStream out;
+    private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+    public CamelEncoder() {
+        for (int l = 1; l <= DECIMAL_MAX_COUNT; l++) {
+            int idx = l - 1;
+            powers[idx] = (long) Math.pow(10, l);
+            long divisor = 1L << l;
+            threshold[idx] = powers[idx] / divisor;
+            mValueBits[idx] = (int) Math.ceil(Math.log(threshold[idx]) / Math.log(2));
+        }
+        out = new BitOutputStream(baos);
+        gorillaEncoder = new GorillaEncoder();
+    }
+
+    public class GorillaEncoder {
+        private int leadingZeros = Integer.MAX_VALUE;
+        private int trailingZeros = 0;
+
+        public void encode(double value, BitOutputStream out) throws IOException {
+            long curr = Double.doubleToLongBits(value);
+            if (isFirst) {
+                out.writeLong(curr, BITS_FOR_FIRST_VALUE);
+                previousValue = curr;
+                isFirst = false;
+                return;
+            }
+
+            long xor = curr ^ previousValue;
+            if (xor == 0) {
+                out.writeBit(false); // Control bit: same as previous
+            } else {
+                out.writeBit(true); // Control bit: value changed
+                int leading = Long.numberOfLeadingZeros(xor);
+                int trailing = Long.numberOfTrailingZeros(xor);
+                if (leading >= leadingZeros && trailing >= trailingZeros) {
+                    out.writeBit(false); // Reuse previous block info
+                    int significantBits = DOUBLE_TOTAL_BITS - leadingZeros - trailingZeros;
+                    out.writeLong(xor >>> trailingZeros, significantBits);
+                } else {
+                    out.writeBit(true); // Write new block info
+                    out.writeInt(leading, BITS_FOR_LEADING_ZEROS);
+                    int significantBits = DOUBLE_TOTAL_BITS - leading - trailing;
+                    out.writeInt(significantBits - 1, BITS_FOR_SIGNIFICANT_BITS);
+                    out.writeLong(xor >>> trailing, significantBits);
+                    leadingZeros = leading;
+                    trailingZeros = trailing;
+                }
+            }
+
+            previousValue = curr;
+        }
+
+        public void close(BitOutputStream out) throws IOException {
+            out.close();
+        }
+    }
+
+    public void addValue(double value) throws IOException {
+        if (isFirst) {
+            writeFirst(Double.doubleToRawLongBits(value));
+        } else {
+            compressValue(value);
+        }
+        previousValue = Double.doubleToLongBits(value);
+    }
+
+    private void writeFirst(long value) throws IOException {
+        isFirst = false;
+        storedVal = (long) Double.longBitsToDouble(value);
+        out.writeLong(value, BITS_FOR_FIRST_VALUE);
+    }
+
+    public long close() throws IOException {
+        out.close();
+        return out.getBitsWritten();
+    }
+
+    private void compressValue(double value) throws IOException {
+        int signBit = (int) ((Double.doubleToLongBits(value) >>> (DOUBLE_TOTAL_BITS - 1)) & 1);
+        out.writeInt(signBit, BITS_FOR_SIGN);
+
+        value = Math.abs(value);
+        if (value > Long.MAX_VALUE || value == 0 || Math.abs(Math.floor(Math.log10(value))) > DECIMAL_MAX_COUNT) {
+            out.writeInt(CamelInnerEncodingType.GORILLA.getCode(), BITS_FOR_TYPE);
+            gorillaEncoder.encode(value, out);
+            return;
+        }
+
+        long integerPart = (long) value;
+        int numDigits = integerPart == 0 ? 1 : (int) Math.log10(Math.abs(integerPart)) + 1;
+
+        double factor = 1;
+        while (Math.abs(value * factor - Math.round(value * factor)) > 0) {
+            factor *= 10.0;
+            decimalCount++;
+            if (decimalCount > DECIMAL_MAX_COUNT) {
+                break;
+            }
+        }
+
+        decimalCount = Math.max(1, decimalCount);
+        long decimalValue = 0;
+
+        if (decimalCount + numDigits <= DECIMAL_MAX_COUNT) {
+            long pow = powers[decimalCount - 1];
+            decimalValue = Math.round(value * pow) % pow;
+
+            out.writeInt(CamelInnerEncodingType.CAMEL.getCode(), BITS_FOR_TYPE);
+            compressIntegerValue(integerPart);
+            compressDecimalValue(decimalValue, decimalCount);
+        } else {
+            out.writeInt(CamelInnerEncodingType.GORILLA.getCode(), BITS_FOR_TYPE);
+            gorillaEncoder.encode(value, out);
+        }
+    }
+
+    private void compressIntegerValue(long value) throws IOException {
+        long diff = value - storedVal;
+        storedVal = value;
+        BitOutputStream.writeVarLong(diff, out);
+    }
+
+    private void compressDecimalValue(long decimalValue, int decimalCount) throws IOException {
+        out.writeInt(decimalCount - 1, BITS_FOR_DECIMAL_COUNT);
+        long thresh = threshold[decimalCount - 1];
+        int m = (int) decimalValue;
+
+        if (decimalValue >= thresh) {
+            out.writeBit(true);
+            m = (int) (decimalValue % thresh);
+
+            long xor = Double.doubleToLongBits((double) decimalValue / powers[decimalCount - 1] + 1) ^
+                    Double.doubleToLongBits((double) m / powers[decimalCount - 1] + 1);
+
+            out.writeLong(xor >>> (DOUBLE_MANTISSA_BITS - decimalCount), decimalCount);
+        } else {
+            out.writeBit(false);
+        }
+
+        BitOutputStream.writeVarLong(m, out);
+    }
+
+    public int getWrittenBits() {
+        return out.getBitsWritten();
+    }
+
+    public ByteArrayOutputStream getByteArrayOutputStream() {
+        return this.baos;
+    }
+
+    public GorillaEncoder getGorillaEncoder() {
+        return gorillaEncoder;
+    }
 
     public enum CamelInnerEncodingType {
         GORILLA(0),
@@ -42,228 +221,5 @@ public class CamelEncoder {
         public int getCode() {
             return code;
         }
-
-        public static CamelInnerEncodingType fromCode(int code) {
-            for (CamelInnerEncodingType type : CamelInnerEncodingType.values()) {
-                if (type.code == code) {
-                    return type;
-                }
-            }
-            throw new IllegalArgumentException("Invalid encoding type code: " + code);
-        }
-    }
-
-    public class GorillaEncoder {
-        private int leadingZeros = Integer.MAX_VALUE;
-        private int trailingZeros = 0;
-
-        public void encode(double value, BitOutputStream out) throws IOException {
-            long curr = Double.doubleToLongBits(value);
-            if (isFirst) {
-                size += 64;
-                out.writeLong(curr, 64);
-                previousValue = curr;
-                isFirst = false;
-                return;
-            }
-
-            long xor = curr ^ previousValue;
-            size += 1;
-            if (xor == 0) {
-                out.writeBit(false); // Control bit
-            } else {
-                out.writeBit(true); // Control bit
-                int leading = Long.numberOfLeadingZeros(xor);
-                int trailing = Long.numberOfTrailingZeros(xor);
-                size += 1;
-                if (leading >= leadingZeros && trailing >= trailingZeros) {
-                    out.writeBit(false); // Reuse previous block
-                    int significantBits = 64 - leadingZeros - trailingZeros;
-                    size += significantBits;
-                    out.writeLong(xor >>> trailingZeros, significantBits);
-                } else {
-                    out.writeBit(true); // Write new leading/trailing info
-                    size += 6;
-                    out.writeInt(leading, 6);
-                    int significantBits = 64 - leading - trailing;
-                    size += 6;
-                    out.writeInt(significantBits - 1, 6);
-                    size += significantBits;
-                    out.writeLong(xor >>> trailing, significantBits);
-                    leadingZeros = leading;
-                    trailingZeros = trailing;
-                }
-            }
-
-            previousValue = curr;
-        }
-
-        public void close (BitOutputStream out) throws IOException {
-            out.close();
-        }
-    }
-
-
-    private long storedVal = 0;
-
-    private boolean isFirst = true;
-
-    private int size;
-
-    private final static int DECIMAL_MAX_COUNT = 15;
-
-    private  int decimalCount = 0;
-
-    long previousValue = 0;
-
-    public static final long[] powers = new long[DECIMAL_MAX_COUNT];
-
-    // threshold[l-1] = 10^l / 2^l
-    public static final long[] threshold = new long[DECIMAL_MAX_COUNT];
-
-    // mValueBits[l-1] = ceil(log2(threshold[l-1]))
-    public static final int[] mValueBits = new int[DECIMAL_MAX_COUNT];
-
-    public static Map<String, byte[]> compressVal = new HashMap<>();
-
-    private final BitOutputStream out;
-    private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-    public CamelEncoder() {
-        for (int l = 1; l <= DECIMAL_MAX_COUNT; l++) {
-            int idx = l - 1;
-            powers[idx] = (long) Math.pow(10, l);
-            long divisor = 1L << l;  // 2^l
-            threshold[idx] = powers[idx] / divisor;
-            mValueBits[idx] = (int) Math.ceil(Math.log(threshold[idx]) / Math.log(2));
-        }
-        out = new BitOutputStream(baos);
-        size = 0;
-        gorillaEncoder = new GorillaEncoder();
-    }
-
-    public GorillaEncoder getGorillaEncoder() {
-        return gorillaEncoder;
-    }
-
-    public ByteArrayOutputStream getByteArrayOutputStream() {
-        return this.baos;
-    }
-
-    /**
-     * Adds a new double value to the series. Note, values must be inserted in order.
-     *
-     * @param value next floating point value in the series
-     */
-    public int addValue(double value) throws IOException {
-        if(isFirst) {
-            writeFirst(Double.doubleToRawLongBits(value));
-        } else {
-            compressValue(value);
-        }
-        previousValue = Double.doubleToLongBits(value);
-        return size;
-    }
-
-    // 写入第一个数据
-    private int writeFirst(long value) throws IOException {
-        isFirst = false;
-        // 保存第一个数字的整数进行差值计算
-        storedVal = (long) Double.longBitsToDouble(value);
-        out.writeLong(value, 64);
-        size += 64;
-        return size;
-    }
-
-    /**
-     * Closes the block and writes the remaining stuff to the BitOutput.
-     */
-    public long close() throws IOException {
-        out.close();
-        return out.getBitsWritten();
-    }
-
-    // 数据压缩
-    private int compressValue(double value) throws IOException {
-        size += 1;
-        byte signBit = (byte) ((Double.doubleToLongBits(value) >>> 63) & 1);
-        out.writeBit(signBit == 1);
-
-        value = Math.abs(value);
-        if (value > Long.MAX_VALUE || value == 0 || Math.abs(Math.floor(Math.log10(value))) > DECIMAL_MAX_COUNT) {
-            // gorilla
-            size += 1;
-            out.writeInt(CamelInnerEncodingType.GORILLA.getCode(), 1);
-            gorillaEncoder.encode(value, out);
-            return this.size;
-        }
-
-        // 计算整数部分的值和十进制位数
-        long integerPart = (long) value;
-        int numDigits = integerPart == 0 ? 1 : (int) Math.log10(Math.abs(integerPart)) + 1;
-        // 计算小数部分的位数和值
-        double factor = 1;
-        while (Math.abs(value * factor - Math.round(value * factor)) > 0) {
-            factor *= 10.0;
-            decimalCount++;
-            if (decimalCount > DECIMAL_MAX_COUNT) {
-                break;
-            }
-        }
-        decimalCount = Math.max(1, decimalCount);
-        long decimalValue = 0;
-        if (decimalCount + numDigits <= DECIMAL_MAX_COUNT) {
-            long pow = powers[decimalCount - 1];
-            decimalValue = Math.round(value * pow) % pow;
-            size += 1;
-            // camel
-            out.writeInt(CamelInnerEncodingType.CAMEL.getCode(), 1);
-            compressIntegerValue(integerPart);
-            compressDecimalValue(decimalValue, decimalCount);
-        } else {
-            // gorilla
-            size += 1;
-            out.writeInt(CamelInnerEncodingType.GORILLA.getCode(), 1);
-            gorillaEncoder.encode(value, out);
-        }
-
-        return this.size;
-    }
-
-    // 压缩小数部分
-    private void compressDecimalValue(long decimal_value, int decimalCount) throws IOException {
-        out.writeInt(decimalCount-1, 4);
-        size += 4;
-        // 计算m的值
-        long thread = threshold[decimalCount-1];
-        int m = (int) decimal_value;
-        size += 1;
-        if (decimal_value - thread >= 0) {  // 计算m的值
-            // 标志位：是否计算m的值
-            out.writeBit(true);
-            m = (int) (decimal_value % thread);
-            // 对于m进行XOR操作
-            long xor = (Double.doubleToLongBits((double)decimal_value/powers[decimalCount-1]+1)) ^ Double.doubleToLongBits(((double) m/powers[decimalCount-1]+1));
-            // 保存小数位数长度的centerBits
-            out.writeLong(xor >>> 52 - decimalCount, decimalCount);
-            size += decimalCount;// Store the meaningful bits of XOR
-
-        } else {
-            out.writeBit(false);
-        }
-        this.size += BitOutputStream.writeVarLong(m, out);
-    }
-
-    // 压缩整数部分
-    private void compressIntegerValue(long value) throws IOException {
-        long diff = value - storedVal;
-        storedVal = value;
-        int bitsWritten = BitOutputStream.writeVarLong(diff, out);
-        this.size += bitsWritten;
-    }
-
-
-    public int getWrittenBits() {
-        return out.getBitsWritten();
     }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
@@ -49,20 +49,21 @@ public class CamelEncoder extends Encoder {
   // === Precomputed tables ===
   public static final long[] powers = new long[DECIMAL_MAX_COUNT];
   public static final long[] threshold = new long[DECIMAL_MAX_COUNT];
-  public static final int[] mValueBits = new int[DECIMAL_MAX_COUNT];
 
   private final BitOutputStream out;
   private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-  public CamelEncoder() {
-    super(TSEncoding.CAMEL);
+  static {
     for (int l = 1; l <= DECIMAL_MAX_COUNT; l++) {
       int idx = l - 1;
       powers[idx] = (long) Math.pow(10, l);
       long divisor = 1L << l;
       threshold[idx] = powers[idx] / divisor;
-      mValueBits[idx] = (int) Math.ceil(Math.log(threshold[idx]) / Math.log(2));
     }
+  }
+
+  public CamelEncoder() {
+    super(TSEncoding.CAMEL);
     out = new BitOutputStream(baos);
     gorillaEncoder = new GorillaEncoder();
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
@@ -12,11 +12,9 @@ public class CamelEncoder {
 
     private long storedVal = 0;
 
-    // 默认10000 对应 block大小位1000
-    private final static int outStreamSize = 100000;
     private boolean first = true;
+
     private int size;
-    private final static long END_SIGN = Double.doubleToLongBits(Double.NaN);
 
     private final static int DECIMAL_MAX_COUNT = 4;
 
@@ -27,7 +25,7 @@ public class CamelEncoder {
     // 按照寻找到的m的值进行保存
     public final static int[] mValueBits = {3, 5, 7, 10, 12, 14};
     //    public final static BigDecimal[]  threshold = {BigDecimal.valueOf(0.5), BigDecimal.valueOf(0.25), BigDecimal.valueOf(0.125), BigDecimal.valueOf(0.0625)};
-    public final static long[]  threshold = {5, 25, 125, 625, 3125, 15625};
+    public final static long[]  threshold = {5, 25, 125, 625, 3125, 15625, 78125, 390625, 1953125};
 
     private static final long[] powers = {10L, 100L, 1000L, 10000L, 10000L, 100000L, 1000000L};
     public static Map<String, byte[]> compressVal = new HashMap<>();
@@ -113,7 +111,9 @@ public class CamelEncoder {
         }
 
         if (decimal_count > 0 && decimal_count<= DECIMAL_MAX_COUNT) {
-            decimal_value =  ((long) (value * powers[decimal_count]) % powers[decimal_count])/10;
+            //decimal_value =  ((long) (value * powers[decimal_count]) % powers[decimal_count])/10;
+            long pow = powers[decimal_count - 1];  // 如 100L
+            decimal_value = Math.round(value * pow) % pow;
         }else {
             decimal_value = ((long) (value * powers[DECIMAL_MAX_COUNT]) % powers[DECIMAL_MAX_COUNT])/10;
             decimal_count = DECIMAL_MAX_COUNT;

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/CamelEncoder.java
@@ -209,7 +209,12 @@ public class CamelEncoder extends Encoder {
     }
 
     long integerPart = (long) value;
-    int numDigits = integerPart == 0 ? 1 : (int) Math.log10(Math.abs(integerPart)) + 1;
+    int numDigits = 1;
+    long absInt = Math.abs(integerPart);
+    while (absInt >= 10) {
+      absInt /= 10;
+      numDigits++;
+    }
 
     double factor = 1;
     while (Math.abs(value * factor - Math.round(value * factor)) > 0) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/TSEncodingBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/TSEncodingBuilder.java
@@ -78,6 +78,8 @@ public abstract class TSEncodingBuilder {
         return new Sprintz();
       case RLBE:
         return new RLBE();
+      case CAMEL:
+        return new Camel();
       default:
         throw new UnsupportedOperationException(type.toString());
     }
@@ -254,6 +256,25 @@ public abstract class TSEncodingBuilder {
           return new SinglePrecisionEncoderV1();
         case DOUBLE:
           return new DoublePrecisionEncoderV1();
+        default:
+          throw new UnSupportedDataTypeException("GORILLA_V1 doesn't support data type: " + type);
+      }
+    }
+
+    @Override
+    public void initFromProps(Map<String, String> props) {
+      // allowed do nothing
+    }
+  }
+
+  /** for DOUBLE. */
+  public static class Camel extends TSEncodingBuilder {
+
+    @Override
+    public Encoder getEncoder(TSDataType type) {
+      switch (type) {
+        case DOUBLE:
+          return new CamelEncoder();
         default:
           throw new UnSupportedDataTypeException("GORILLA_V1 doesn't support data type: " + type);
       }

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/enums/TSEncoding.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/enums/TSEncoding.java
@@ -41,7 +41,8 @@ public enum TSEncoding {
   FREQ((byte) 10),
   CHIMP((byte) 11),
   SPRINTZ((byte) 12),
-  RLBE((byte) 13);
+  RLBE((byte) 13),
+  CAMEL((byte) 14);
   private final byte type;
 
   @SuppressWarnings("java:S2386") // used by other projects

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/enums/TSEncoding.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/enums/TSEncoding.java
@@ -79,6 +79,7 @@ public enum TSEncoding {
     floatSet.add(TSEncoding.CHIMP);
     floatSet.add(TSEncoding.SPRINTZ);
     floatSet.add(TSEncoding.RLBE);
+    floatSet.add(TSEncoding.CAMEL);
 
     TYPE_SUPPORTED_ENCODINGS.put(TSDataType.FLOAT, floatSet);
     TYPE_SUPPORTED_ENCODINGS.put(TSDataType.DOUBLE, floatSet);
@@ -136,6 +137,8 @@ public enum TSEncoding {
         return TSEncoding.SPRINTZ;
       case 13:
         return TSEncoding.RLBE;
+      case 14:
+        return TSEncoding.CAMEL;
       default:
         throw new IllegalArgumentException("Invalid input: " + encoding);
     }

--- a/java/tsfile/src/test/java/org/apache/tsfile/common/bitStream/TestBitStream.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/common/bitStream/TestBitStream.java
@@ -5,6 +5,11 @@ import org.junit.Test;
 
 import java.io.*;
 
+import static org.apache.tsfile.common.bitStream.BitInputStream.readVarLong;
+import static org.apache.tsfile.common.bitStream.BitOutputStream.writeVarInt;
+import static org.apache.tsfile.common.bitStream.BitOutputStream.writeVarLong;
+import static org.apache.tsfile.utils.ReadWriteForEncodingUtils.readVarInt;
+
 /**
  * Unit tests for BitInputStream and BitOutputStream (Big Endian Bit Stream).
  */
@@ -215,5 +220,131 @@ public class TestBitStream {
         Assert.assertTrue(in.readBit());
 
         in.close();
+    }
+
+    // ------------------------------------------------------------------------
+    // 对称性测试
+    // ------------------------------------------------------------------------
+    @Test
+    public void testVarLongSymmetry() throws IOException {
+        long[] testValues = new long[]{
+                0, 1, -1, 63, -63, 64, -64,
+                128, -128, 1024, -1024,
+                Long.MAX_VALUE, Long.MIN_VALUE
+        };
+
+        for (long original : testValues) {
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            BitOutputStream out = new BitOutputStream(bout);
+            writeVarLong(original, out);
+            out.close();
+            BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+            long decoded = readVarLong(in);
+            in.close();
+
+            Assert.assertEquals("Mismatch for value: " + original, original, decoded);
+        }
+    }
+
+
+    // ------------------------------------------------------------------------
+    // 连续范围测试：-10000 ~ 10000
+    // ------------------------------------------------------------------------
+    @Test
+    public void testVarLongContinuousRange() throws IOException {
+        for (int value = -10000; value <= 10000; value++) {
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            BitOutputStream out = new BitOutputStream(bout);
+            writeVarLong(value, out);
+            out.close();
+
+            BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+            long decoded = readVarLong(in);
+            in.close();
+
+            Assert.assertEquals("Mismatch in range test for: " + value, value, decoded);
+        }
+    }
+
+
+    // ------------------------------------------------------------------------
+    // 验证写入位数随值增长而递增
+    // ------------------------------------------------------------------------
+    @Test
+    public void testVarLongBitLengthGrowth() throws IOException {
+        long[] values = {0, 1, 2, 64, 128, 8192, 1 << 20, Long.MAX_VALUE / 2};
+        int lastBits = 0;
+
+        for (long value : values) {
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            BitOutputStream out = new BitOutputStream(bout);
+            int bits = writeVarLong(value, out);
+            out.close();
+
+            Assert.assertTrue("Bit length didn't increase for " + value, bits >= lastBits);
+            lastBits = bits;
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // 对称性测试：常用 int 值
+    // ------------------------------------------------------------------------
+    @Test
+    public void testVarIntSymmetry() throws IOException {
+        int[] values = {
+                0, 1, -1, 63, -63, 127, -128, 255, -256,
+                1023, -1023, 16384, -16384, Integer.MAX_VALUE, Integer.MIN_VALUE
+        };
+
+        for (int value : values) {
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            BitOutputStream out = new BitOutputStream(bout);
+            writeVarInt(value, out);
+            out.close();
+
+            BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+            int decoded = in.readVarInt(in);
+            in.close();
+
+            Assert.assertEquals("Mismatch for value: " + value, value, decoded);
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // 范围测试：-10000 到 10000
+    // ------------------------------------------------------------------------
+    @Test
+    public void testVarIntRange() throws IOException {
+        for (int value = -10000; value <= 10000; value++) {
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            BitOutputStream out = new BitOutputStream(bout);
+            writeVarInt(value, out);
+            out.close();
+
+            BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+            int decoded = in.readVarInt(in);
+            in.close();
+
+            Assert.assertEquals("Mismatch in range for value: " + value, value, decoded);
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // 测试写入 bit 长度是否随值递增
+    // ------------------------------------------------------------------------
+    @Test
+    public void testBitLengthGrowth() throws IOException {
+        int[] values = {0, 1, 2, 64, 128, 1024, 16384, 1 << 20};
+        int lastBits = 0;
+
+        for (int value : values) {
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            BitOutputStream out = new BitOutputStream(bout);
+            int bits = writeVarInt(value, out);
+            out.close();
+
+            Assert.assertTrue("Bit length not increasing for value: " + value, bits >= lastBits);
+            lastBits = bits;
+        }
     }
 }

--- a/java/tsfile/src/test/java/org/apache/tsfile/common/bitStream/TestBitStream.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/common/bitStream/TestBitStream.java
@@ -1,0 +1,219 @@
+package org.apache.tsfile.common.bitStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.*;
+
+/**
+ * Unit tests for BitInputStream and BitOutputStream (Big Endian Bit Stream).
+ */
+public class TestBitStream {
+
+    // ------------------------------------------------------------------------
+    // Basic int read/write test (verifies bit layout and order correctness)
+    // ------------------------------------------------------------------------
+    @Test
+    public void testWriteAndReadInt() throws IOException {
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        BitOutputStream out = new BitOutputStream(bout);
+
+        out.writeInt(0, 0);                // No-op write
+        out.writeInt(0x78563412, 32);      // Full int
+        out.writeInt(2, 4);                // Partial int
+        out.writeInt(3, 3);
+        out.writeInt(0, 1);
+        out.writeInt(0xA8, 8);             // One byte
+        out.writeInt(0x11, 6);             // 6 bits
+        out.close();
+
+        byte[] expected = new byte[]{0x78, 0x56, 0x34, 0x12, 0x26, (byte) 0xA8, 0x44};
+        Assert.assertArrayEquals(expected, bout.toByteArray());
+    }
+
+    // ------------------------------------------------------------------------
+    // Full read test with mark/reset and EOF handling
+    // ------------------------------------------------------------------------
+    @Test
+    public void testBitInputWithMarkAndEOF() throws IOException {
+        byte[] data = new byte[]{0x12, 0x34, 0x56, 0x78, 0x32, (byte) 0xA8, 0x11};
+        BitInputStream in = new BitInputStream(new ByteArrayInputStream(data), data.length * 8);
+
+        Assert.assertTrue(in.markSupported());
+        Assert.assertEquals(56, in.availableBits());
+        Assert.assertEquals(0, in.readInt(0));
+        Assert.assertEquals(0x12345678, in.readInt(32));
+        Assert.assertEquals(3, in.readInt(4));
+
+        in.mark(200);
+        Assert.assertEquals(1, in.readInt(3));
+        Assert.assertEquals(0, in.readInt(1));
+        Assert.assertEquals(0xA8, in.readInt(8));
+
+        in.reset();
+        Assert.assertEquals(2, in.readInt(4));
+        Assert.assertEquals(0xA8, in.readInt(8));
+
+        Assert.assertEquals(8, in.availableBits());
+        Assert.assertEquals(0x110, in.readInt(12));
+
+        try {
+            in.readInt(1);
+            Assert.fail("Expected EOFException");
+        } catch (EOFException ignored) {
+        }
+
+        in.close();
+    }
+
+    // ------------------------------------------------------------------------
+    // Writing and reading various long values with specified bit widths
+    // ------------------------------------------------------------------------
+    @Test
+    public void testWriteAndReadLong() throws IOException {
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        BitOutputStream out = new BitOutputStream(bout);
+
+        long[] values = {
+                0L,
+                1L,
+                0xFFFFFFFFL,
+                0x123456789ABCDEFL,
+                Long.MAX_VALUE,
+                Long.MIN_VALUE
+        };
+        int[] bits = {
+                1, 2, 32, 60, 64, 64
+        };
+
+        for (int i = 0; i < values.length; i++) {
+            out.writeLong(values[i], bits[i]);
+        }
+        out.close();
+
+        BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+        for (int i = 0; i < values.length; i++) {
+            long actual = in.readLong(bits[i]);
+            Assert.assertEquals("Mismatch at index " + i, values[i], actual);
+        }
+        in.close();
+    }
+
+    // ------------------------------------------------------------------------
+    // Writing and reading individual bits
+    // ------------------------------------------------------------------------
+    @Test
+    public void testWriteAndReadBits() throws IOException {
+        boolean[] bits = {
+                true, false, true, true, false, false, false, true,
+                false, true
+        };
+
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        BitOutputStream out = new BitOutputStream(bout);
+        for (boolean b : bits) {
+            out.writeBit(b);
+        }
+        out.close();
+
+        BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+        for (int i = 0; i < bits.length; i++) {
+            boolean actual = in.readBit();
+            Assert.assertEquals("Bit mismatch at index " + i, bits[i], actual);
+        }
+
+        try {
+            in.readBit();
+            Assert.fail("Expected EOFException");
+        } catch (EOFException ignored) {
+        }
+
+        in.close();
+    }
+
+    // ------------------------------------------------------------------------
+    // Validates writeLong and readLong for all bit widths from 1 to 64
+    // ------------------------------------------------------------------------
+    @Test
+    public void testLongBitWidths() throws IOException {
+        for (int bits = 1; bits <= 64; bits++) {
+            long value = (1L << (bits - 1)) | 1L;
+
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            BitOutputStream out = new BitOutputStream(bout);
+            out.writeLong(value, bits);
+            out.close();
+
+            BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+            long result = in.readLong(bits);
+            Assert.assertEquals("Failed at bit width = " + bits, value, result);
+            in.close();
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // Special case: writing all-zeros and all-ones long values
+    // ------------------------------------------------------------------------
+    @Test
+    public void testAllZerosAndAllOnesLong() throws IOException {
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        BitOutputStream out = new BitOutputStream(bout);
+
+        out.writeLong(0L, 64);
+        out.writeLong(-1L, 64);
+        out.close();
+
+        BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+        Assert.assertEquals(0L, in.readLong(64));
+        Assert.assertEquals(-1L, in.readLong(64));
+        in.close();
+    }
+
+    // ------------------------------------------------------------------------
+    // Test that bit write/read works correctly across byte boundaries
+    // ------------------------------------------------------------------------
+    @Test
+    public void testBitBoundaryCrossing() throws IOException {
+        boolean[] bits = {
+                false, true, true, false, true, false, false, true, // first byte
+                true, true, false, true, false, true, true          // crosses byte
+        };
+
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        BitOutputStream out = new BitOutputStream(bout);
+        for (boolean b : bits) {
+            out.writeBit(b);
+        }
+        out.close();
+
+        BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+        for (int i = 0; i < bits.length; i++) {
+            Assert.assertEquals("Mismatch at bit index " + i, bits[i], in.readBit());
+        }
+        in.close();
+    }
+
+    // ------------------------------------------------------------------------
+    // Mix writeLong and writeBit and verify bit alignment
+    // ------------------------------------------------------------------------
+    @Test
+    public void testMixedLongAndBit() throws IOException {
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        BitOutputStream out = new BitOutputStream(bout);
+
+        out.writeLong(0x1FL, 5); // 11111
+        out.writeBit(true);      // 1
+        out.writeBit(false);     // 0
+        out.writeBit(true);      // 1
+        out.close();
+
+        BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+
+        Assert.assertEquals(0x1F, in.readLong(5));
+        Assert.assertTrue(in.readBit());
+        Assert.assertFalse(in.readBit());
+        Assert.assertTrue(in.readBit());
+
+        in.close();
+    }
+}

--- a/java/tsfile/src/test/java/org/apache/tsfile/common/bitStream/TestBitStream.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/common/bitStream/TestBitStream.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.tsfile.common.bitStream;
 
 import org.junit.Assert;

--- a/java/tsfile/src/test/java/org/apache/tsfile/common/bitStream/TestBitStream.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/common/bitStream/TestBitStream.java
@@ -29,14 +29,8 @@ import static org.apache.tsfile.common.bitStream.BitOutputStream.writeVarInt;
 import static org.apache.tsfile.common.bitStream.BitOutputStream.writeVarLong;
 import static org.apache.tsfile.utils.ReadWriteForEncodingUtils.readVarInt;
 
-/**
- * Unit tests for BitInputStream and BitOutputStream (Big Endian Bit Stream).
- */
 public class TestBitStream {
 
-    // ------------------------------------------------------------------------
-    // Basic int read/write test (verifies bit layout and order correctness)
-    // ------------------------------------------------------------------------
     @Test
     public void testWriteAndReadInt() throws IOException {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
@@ -55,9 +49,6 @@ public class TestBitStream {
         Assert.assertArrayEquals(expected, bout.toByteArray());
     }
 
-    // ------------------------------------------------------------------------
-    // Full read test with mark/reset and EOF handling
-    // ------------------------------------------------------------------------
     @Test
     public void testBitInputWithMarkAndEOF() throws IOException {
         byte[] data = new byte[]{0x12, 0x34, 0x56, 0x78, 0x32, (byte) 0xA8, 0x11};
@@ -90,25 +81,13 @@ public class TestBitStream {
         in.close();
     }
 
-    // ------------------------------------------------------------------------
-    // Writing and reading various long values with specified bit widths
-    // ------------------------------------------------------------------------
     @Test
     public void testWriteAndReadLong() throws IOException {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         BitOutputStream out = new BitOutputStream(bout);
 
-        long[] values = {
-                0L,
-                1L,
-                0xFFFFFFFFL,
-                0x123456789ABCDEFL,
-                Long.MAX_VALUE,
-                Long.MIN_VALUE
-        };
-        int[] bits = {
-                1, 2, 32, 60, 64, 64
-        };
+        long[] values = {0L, 1L, 0xFFFFFFFFL, 0x123456789ABCDEFL, Long.MAX_VALUE, Long.MIN_VALUE};
+        int[] bits = {1, 2, 32, 60, 64, 64};
 
         for (int i = 0; i < values.length; i++) {
             out.writeLong(values[i], bits[i]);
@@ -123,15 +102,9 @@ public class TestBitStream {
         in.close();
     }
 
-    // ------------------------------------------------------------------------
-    // Writing and reading individual bits
-    // ------------------------------------------------------------------------
     @Test
     public void testWriteAndReadBits() throws IOException {
-        boolean[] bits = {
-                true, false, true, true, false, false, false, true,
-                false, true
-        };
+        boolean[] bits = {true, false, true, true, false, false, false, true, false, true};
 
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         BitOutputStream out = new BitOutputStream(bout);
@@ -155,9 +128,6 @@ public class TestBitStream {
         in.close();
     }
 
-    // ------------------------------------------------------------------------
-    // Validates writeLong and readLong for all bit widths from 1 to 64
-    // ------------------------------------------------------------------------
     @Test
     public void testLongBitWidths() throws IOException {
         for (int bits = 1; bits <= 64; bits++) {
@@ -175,9 +145,6 @@ public class TestBitStream {
         }
     }
 
-    // ------------------------------------------------------------------------
-    // Special case: writing all-zeros and all-ones long values
-    // ------------------------------------------------------------------------
     @Test
     public void testAllZerosAndAllOnesLong() throws IOException {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
@@ -193,9 +160,6 @@ public class TestBitStream {
         in.close();
     }
 
-    // ------------------------------------------------------------------------
-    // Test that bit write/read works correctly across byte boundaries
-    // ------------------------------------------------------------------------
     @Test
     public void testBitBoundaryCrossing() throws IOException {
         boolean[] bits = {
@@ -217,9 +181,6 @@ public class TestBitStream {
         in.close();
     }
 
-    // ------------------------------------------------------------------------
-    // Mix writeLong and writeBit and verify bit alignment
-    // ------------------------------------------------------------------------
     @Test
     public void testMixedLongAndBit() throws IOException {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
@@ -241,16 +202,10 @@ public class TestBitStream {
         in.close();
     }
 
-    // ------------------------------------------------------------------------
-    // 对称性测试
-    // ------------------------------------------------------------------------
     @Test
     public void testVarLongSymmetry() throws IOException {
-        long[] testValues = new long[]{
-                0, 1, -1, 63, -63, 64, -64,
-                128, -128, 1024, -1024,
-                Long.MAX_VALUE, Long.MIN_VALUE
-        };
+        long[] testValues = {0, 1, -1, 63, -63, 64, -64, 128, -128, 1024, -1024,
+                Long.MAX_VALUE, Long.MIN_VALUE};
 
         for (long original : testValues) {
             ByteArrayOutputStream bout = new ByteArrayOutputStream();
@@ -265,10 +220,6 @@ public class TestBitStream {
         }
     }
 
-
-    // ------------------------------------------------------------------------
-    // 连续范围测试：-10000 ~ 10000
-    // ------------------------------------------------------------------------
     @Test
     public void testVarLongContinuousRange() throws IOException {
         for (int value = -10000; value <= 10000; value++) {
@@ -285,10 +236,6 @@ public class TestBitStream {
         }
     }
 
-
-    // ------------------------------------------------------------------------
-    // 验证写入位数随值增长而递增
-    // ------------------------------------------------------------------------
     @Test
     public void testVarLongBitLengthGrowth() throws IOException {
         long[] values = {0, 1, 2, 64, 128, 8192, 1 << 20, Long.MAX_VALUE / 2};
@@ -305,15 +252,10 @@ public class TestBitStream {
         }
     }
 
-    // ------------------------------------------------------------------------
-    // 对称性测试：常用 int 值
-    // ------------------------------------------------------------------------
     @Test
     public void testVarIntSymmetry() throws IOException {
-        int[] values = {
-                0, 1, -1, 63, -63, 127, -128, 255, -256,
-                1023, -1023, 16384, -16384, Integer.MAX_VALUE, Integer.MIN_VALUE
-        };
+        int[] values = {0, 1, -1, 63, -63, 127, -128, 255, -256,
+                1023, -1023, 16384, -16384, Integer.MAX_VALUE, Integer.MIN_VALUE};
 
         for (int value : values) {
             ByteArrayOutputStream bout = new ByteArrayOutputStream();
@@ -322,16 +264,13 @@ public class TestBitStream {
             out.close();
 
             BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
-            int decoded = in.readVarInt(in);
+            int decoded = BitInputStream.readVarInt(in);
             in.close();
 
             Assert.assertEquals("Mismatch for value: " + value, value, decoded);
         }
     }
 
-    // ------------------------------------------------------------------------
-    // 范围测试：-10000 到 10000
-    // ------------------------------------------------------------------------
     @Test
     public void testVarIntRange() throws IOException {
         for (int value = -10000; value <= 10000; value++) {
@@ -348,9 +287,6 @@ public class TestBitStream {
         }
     }
 
-    // ------------------------------------------------------------------------
-    // 测试写入 bit 长度是否随值递增
-    // ------------------------------------------------------------------------
     @Test
     public void testBitLengthGrowth() throws IOException {
         int[] values = {0, 1, 2, 64, 128, 1024, 16384, 1 << 20};

--- a/java/tsfile/src/test/java/org/apache/tsfile/common/bitStream/TestBitStream.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/common/bitStream/TestBitStream.java
@@ -22,284 +22,325 @@ package org.apache.tsfile.common.bitStream;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
 
 import static org.apache.tsfile.common.bitStream.BitInputStream.readVarLong;
 import static org.apache.tsfile.common.bitStream.BitOutputStream.writeVarInt;
 import static org.apache.tsfile.common.bitStream.BitOutputStream.writeVarLong;
-import static org.apache.tsfile.utils.ReadWriteForEncodingUtils.readVarInt;
 
 public class TestBitStream {
 
-    @Test
-    public void testWriteAndReadInt() throws IOException {
-        ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        BitOutputStream out = new BitOutputStream(bout);
+  @Test
+  public void testWriteAndReadInt() throws IOException {
+    ByteArrayOutputStream bout = new ByteArrayOutputStream();
+    BitOutputStream out = new BitOutputStream(bout);
 
-        out.writeInt(0, 0);                // No-op write
-        out.writeInt(0x78563412, 32);      // Full int
-        out.writeInt(2, 4);                // Partial int
-        out.writeInt(3, 3);
-        out.writeInt(0, 1);
-        out.writeInt(0xA8, 8);             // One byte
-        out.writeInt(0x11, 6);             // 6 bits
-        out.close();
+    out.writeInt(0, 0); // No-op write
+    out.writeInt(0x78563412, 32); // Full int
+    out.writeInt(2, 4); // Partial int
+    out.writeInt(3, 3);
+    out.writeInt(0, 1);
+    out.writeInt(0xA8, 8); // One byte
+    out.writeInt(0x11, 6); // 6 bits
+    out.close();
 
-        byte[] expected = new byte[]{0x78, 0x56, 0x34, 0x12, 0x26, (byte) 0xA8, 0x44};
-        Assert.assertArrayEquals(expected, bout.toByteArray());
+    byte[] expected = new byte[] {0x78, 0x56, 0x34, 0x12, 0x26, (byte) 0xA8, 0x44};
+    Assert.assertArrayEquals(expected, bout.toByteArray());
+  }
+
+  @Test
+  public void testBitInputWithMarkAndEOF() throws IOException {
+    byte[] data = new byte[] {0x12, 0x34, 0x56, 0x78, 0x32, (byte) 0xA8, 0x11};
+    BitInputStream in = new BitInputStream(new ByteArrayInputStream(data), data.length * 8);
+
+    Assert.assertTrue(in.markSupported());
+    Assert.assertEquals(56, in.availableBits());
+    Assert.assertEquals(0, in.readInt(0));
+    Assert.assertEquals(0x12345678, in.readInt(32));
+    Assert.assertEquals(3, in.readInt(4));
+
+    in.mark(200);
+    Assert.assertEquals(1, in.readInt(3));
+    Assert.assertEquals(0, in.readInt(1));
+    Assert.assertEquals(0xA8, in.readInt(8));
+
+    in.reset();
+    Assert.assertEquals(2, in.readInt(4));
+    Assert.assertEquals(0xA8, in.readInt(8));
+
+    Assert.assertEquals(8, in.availableBits());
+    Assert.assertEquals(0x110, in.readInt(12));
+
+    try {
+      in.readInt(1);
+      Assert.fail("Expected EOFException");
+    } catch (EOFException ignored) {
     }
 
-    @Test
-    public void testBitInputWithMarkAndEOF() throws IOException {
-        byte[] data = new byte[]{0x12, 0x34, 0x56, 0x78, 0x32, (byte) 0xA8, 0x11};
-        BitInputStream in = new BitInputStream(new ByteArrayInputStream(data), data.length * 8);
+    in.close();
+  }
 
-        Assert.assertTrue(in.markSupported());
-        Assert.assertEquals(56, in.availableBits());
-        Assert.assertEquals(0, in.readInt(0));
-        Assert.assertEquals(0x12345678, in.readInt(32));
-        Assert.assertEquals(3, in.readInt(4));
+  @Test
+  public void testWriteAndReadLong() throws IOException {
+    ByteArrayOutputStream bout = new ByteArrayOutputStream();
+    BitOutputStream out = new BitOutputStream(bout);
 
-        in.mark(200);
-        Assert.assertEquals(1, in.readInt(3));
-        Assert.assertEquals(0, in.readInt(1));
-        Assert.assertEquals(0xA8, in.readInt(8));
+    long[] values = {0L, 1L, 0xFFFFFFFFL, 0x123456789ABCDEFL, Long.MAX_VALUE, Long.MIN_VALUE};
+    int[] bits = {1, 2, 32, 60, 64, 64};
 
-        in.reset();
-        Assert.assertEquals(2, in.readInt(4));
-        Assert.assertEquals(0xA8, in.readInt(8));
+    for (int i = 0; i < values.length; i++) {
+      out.writeLong(values[i], bits[i]);
+    }
+    out.close();
 
-        Assert.assertEquals(8, in.availableBits());
-        Assert.assertEquals(0x110, in.readInt(12));
+    BitInputStream in =
+        new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+    for (int i = 0; i < values.length; i++) {
+      long actual = in.readLong(bits[i]);
+      Assert.assertEquals("Mismatch at index " + i, values[i], actual);
+    }
+    in.close();
+  }
 
-        try {
-            in.readInt(1);
-            Assert.fail("Expected EOFException");
-        } catch (EOFException ignored) {
-        }
+  @Test
+  public void testWriteAndReadBits() throws IOException {
+    boolean[] bits = {true, false, true, true, false, false, false, true, false, true};
 
-        in.close();
+    ByteArrayOutputStream bout = new ByteArrayOutputStream();
+    BitOutputStream out = new BitOutputStream(bout);
+    for (boolean b : bits) {
+      out.writeBit(b);
+    }
+    out.close();
+
+    BitInputStream in =
+        new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+    for (int i = 0; i < bits.length; i++) {
+      boolean actual = in.readBit();
+      Assert.assertEquals("Bit mismatch at index " + i, bits[i], actual);
     }
 
-    @Test
-    public void testWriteAndReadLong() throws IOException {
-        ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        BitOutputStream out = new BitOutputStream(bout);
-
-        long[] values = {0L, 1L, 0xFFFFFFFFL, 0x123456789ABCDEFL, Long.MAX_VALUE, Long.MIN_VALUE};
-        int[] bits = {1, 2, 32, 60, 64, 64};
-
-        for (int i = 0; i < values.length; i++) {
-            out.writeLong(values[i], bits[i]);
-        }
-        out.close();
-
-        BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
-        for (int i = 0; i < values.length; i++) {
-            long actual = in.readLong(bits[i]);
-            Assert.assertEquals("Mismatch at index " + i, values[i], actual);
-        }
-        in.close();
+    try {
+      in.readBit();
+      Assert.fail("Expected EOFException");
+    } catch (EOFException ignored) {
     }
 
-    @Test
-    public void testWriteAndReadBits() throws IOException {
-        boolean[] bits = {true, false, true, true, false, false, false, true, false, true};
+    in.close();
+  }
 
-        ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        BitOutputStream out = new BitOutputStream(bout);
-        for (boolean b : bits) {
-            out.writeBit(b);
-        }
-        out.close();
+  @Test
+  public void testLongBitWidths() throws IOException {
+    for (int bits = 1; bits <= 64; bits++) {
+      long value = (1L << (bits - 1)) | 1L;
 
-        BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
-        for (int i = 0; i < bits.length; i++) {
-            boolean actual = in.readBit();
-            Assert.assertEquals("Bit mismatch at index " + i, bits[i], actual);
-        }
+      ByteArrayOutputStream bout = new ByteArrayOutputStream();
+      BitOutputStream out = new BitOutputStream(bout);
+      out.writeLong(value, bits);
+      out.close();
 
-        try {
-            in.readBit();
-            Assert.fail("Expected EOFException");
-        } catch (EOFException ignored) {
-        }
-
-        in.close();
+      BitInputStream in =
+          new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+      long result = in.readLong(bits);
+      Assert.assertEquals("Failed at bit width = " + bits, value, result);
+      in.close();
     }
+  }
 
-    @Test
-    public void testLongBitWidths() throws IOException {
-        for (int bits = 1; bits <= 64; bits++) {
-            long value = (1L << (bits - 1)) | 1L;
+  @Test
+  public void testAllZerosAndAllOnesLong() throws IOException {
+    ByteArrayOutputStream bout = new ByteArrayOutputStream();
+    BitOutputStream out = new BitOutputStream(bout);
 
-            ByteArrayOutputStream bout = new ByteArrayOutputStream();
-            BitOutputStream out = new BitOutputStream(bout);
-            out.writeLong(value, bits);
-            out.close();
+    out.writeLong(0L, 64);
+    out.writeLong(-1L, 64);
+    out.close();
 
-            BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
-            long result = in.readLong(bits);
-            Assert.assertEquals("Failed at bit width = " + bits, value, result);
-            in.close();
-        }
+    BitInputStream in =
+        new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+    Assert.assertEquals(0L, in.readLong(64));
+    Assert.assertEquals(-1L, in.readLong(64));
+    in.close();
+  }
+
+  @Test
+  public void testBitBoundaryCrossing() throws IOException {
+    boolean[] bits = {
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      true, // first byte
+      true,
+      true,
+      false,
+      true,
+      false,
+      true,
+      true // crosses byte
+    };
+
+    ByteArrayOutputStream bout = new ByteArrayOutputStream();
+    BitOutputStream out = new BitOutputStream(bout);
+    for (boolean b : bits) {
+      out.writeBit(b);
     }
+    out.close();
 
-    @Test
-    public void testAllZerosAndAllOnesLong() throws IOException {
-        ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        BitOutputStream out = new BitOutputStream(bout);
-
-        out.writeLong(0L, 64);
-        out.writeLong(-1L, 64);
-        out.close();
-
-        BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
-        Assert.assertEquals(0L, in.readLong(64));
-        Assert.assertEquals(-1L, in.readLong(64));
-        in.close();
+    BitInputStream in =
+        new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+    for (int i = 0; i < bits.length; i++) {
+      Assert.assertEquals("Mismatch at bit index " + i, bits[i], in.readBit());
     }
+    in.close();
+  }
 
-    @Test
-    public void testBitBoundaryCrossing() throws IOException {
-        boolean[] bits = {
-                false, true, true, false, true, false, false, true, // first byte
-                true, true, false, true, false, true, true          // crosses byte
-        };
+  @Test
+  public void testMixedLongAndBit() throws IOException {
+    ByteArrayOutputStream bout = new ByteArrayOutputStream();
+    BitOutputStream out = new BitOutputStream(bout);
 
-        ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        BitOutputStream out = new BitOutputStream(bout);
-        for (boolean b : bits) {
-            out.writeBit(b);
-        }
-        out.close();
+    out.writeLong(0x1FL, 5); // 11111
+    out.writeBit(true); // 1
+    out.writeBit(false); // 0
+    out.writeBit(true); // 1
+    out.close();
 
-        BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
-        for (int i = 0; i < bits.length; i++) {
-            Assert.assertEquals("Mismatch at bit index " + i, bits[i], in.readBit());
-        }
-        in.close();
+    BitInputStream in =
+        new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+
+    Assert.assertEquals(0x1F, in.readLong(5));
+    Assert.assertTrue(in.readBit());
+    Assert.assertFalse(in.readBit());
+    Assert.assertTrue(in.readBit());
+
+    in.close();
+  }
+
+  @Test
+  public void testVarLongSymmetry() throws IOException {
+    long[] testValues = {
+      0, 1, -1, 63, -63, 64, -64, 128, -128, 1024, -1024, Long.MAX_VALUE, Long.MIN_VALUE
+    };
+
+    for (long original : testValues) {
+      ByteArrayOutputStream bout = new ByteArrayOutputStream();
+      BitOutputStream out = new BitOutputStream(bout);
+      writeVarLong(original, out);
+      out.close();
+      BitInputStream in =
+          new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+      long decoded = readVarLong(in);
+      in.close();
+
+      Assert.assertEquals("Mismatch for value: " + original, original, decoded);
     }
+  }
 
-    @Test
-    public void testMixedLongAndBit() throws IOException {
-        ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        BitOutputStream out = new BitOutputStream(bout);
+  @Test
+  public void testVarLongContinuousRange() throws IOException {
+    for (int value = -10000; value <= 10000; value++) {
+      ByteArrayOutputStream bout = new ByteArrayOutputStream();
+      BitOutputStream out = new BitOutputStream(bout);
+      writeVarLong(value, out);
+      out.close();
 
-        out.writeLong(0x1FL, 5); // 11111
-        out.writeBit(true);      // 1
-        out.writeBit(false);     // 0
-        out.writeBit(true);      // 1
-        out.close();
+      BitInputStream in =
+          new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+      long decoded = readVarLong(in);
+      in.close();
 
-        BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
-
-        Assert.assertEquals(0x1F, in.readLong(5));
-        Assert.assertTrue(in.readBit());
-        Assert.assertFalse(in.readBit());
-        Assert.assertTrue(in.readBit());
-
-        in.close();
+      Assert.assertEquals("Mismatch in range test for: " + value, value, decoded);
     }
+  }
 
-    @Test
-    public void testVarLongSymmetry() throws IOException {
-        long[] testValues = {0, 1, -1, 63, -63, 64, -64, 128, -128, 1024, -1024,
-                Long.MAX_VALUE, Long.MIN_VALUE};
+  @Test
+  public void testVarLongBitLengthGrowth() throws IOException {
+    long[] values = {0, 1, 2, 64, 128, 8192, 1 << 20, Long.MAX_VALUE / 2};
+    int lastBits = 0;
 
-        for (long original : testValues) {
-            ByteArrayOutputStream bout = new ByteArrayOutputStream();
-            BitOutputStream out = new BitOutputStream(bout);
-            writeVarLong(original, out);
-            out.close();
-            BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
-            long decoded = readVarLong(in);
-            in.close();
+    for (long value : values) {
+      ByteArrayOutputStream bout = new ByteArrayOutputStream();
+      BitOutputStream out = new BitOutputStream(bout);
+      int bits = writeVarLong(value, out);
+      out.close();
 
-            Assert.assertEquals("Mismatch for value: " + original, original, decoded);
-        }
+      Assert.assertTrue("Bit length didn't increase for " + value, bits >= lastBits);
+      lastBits = bits;
     }
+  }
 
-    @Test
-    public void testVarLongContinuousRange() throws IOException {
-        for (int value = -10000; value <= 10000; value++) {
-            ByteArrayOutputStream bout = new ByteArrayOutputStream();
-            BitOutputStream out = new BitOutputStream(bout);
-            writeVarLong(value, out);
-            out.close();
+  @Test
+  public void testVarIntSymmetry() throws IOException {
+    int[] values = {
+      0,
+      1,
+      -1,
+      63,
+      -63,
+      127,
+      -128,
+      255,
+      -256,
+      1023,
+      -1023,
+      16384,
+      -16384,
+      Integer.MAX_VALUE,
+      Integer.MIN_VALUE
+    };
 
-            BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
-            long decoded = readVarLong(in);
-            in.close();
+    for (int value : values) {
+      ByteArrayOutputStream bout = new ByteArrayOutputStream();
+      BitOutputStream out = new BitOutputStream(bout);
+      writeVarInt(value, out);
+      out.close();
 
-            Assert.assertEquals("Mismatch in range test for: " + value, value, decoded);
-        }
+      BitInputStream in =
+          new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+      int decoded = BitInputStream.readVarInt(in);
+      in.close();
+
+      Assert.assertEquals("Mismatch for value: " + value, value, decoded);
     }
+  }
 
-    @Test
-    public void testVarLongBitLengthGrowth() throws IOException {
-        long[] values = {0, 1, 2, 64, 128, 8192, 1 << 20, Long.MAX_VALUE / 2};
-        int lastBits = 0;
+  @Test
+  public void testVarIntRange() throws IOException {
+    for (int value = -10000; value <= 10000; value++) {
+      ByteArrayOutputStream bout = new ByteArrayOutputStream();
+      BitOutputStream out = new BitOutputStream(bout);
+      writeVarInt(value, out);
+      out.close();
 
-        for (long value : values) {
-            ByteArrayOutputStream bout = new ByteArrayOutputStream();
-            BitOutputStream out = new BitOutputStream(bout);
-            int bits = writeVarLong(value, out);
-            out.close();
+      BitInputStream in =
+          new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
+      int decoded = in.readVarInt(in);
+      in.close();
 
-            Assert.assertTrue("Bit length didn't increase for " + value, bits >= lastBits);
-            lastBits = bits;
-        }
+      Assert.assertEquals("Mismatch in range for value: " + value, value, decoded);
     }
+  }
 
-    @Test
-    public void testVarIntSymmetry() throws IOException {
-        int[] values = {0, 1, -1, 63, -63, 127, -128, 255, -256,
-                1023, -1023, 16384, -16384, Integer.MAX_VALUE, Integer.MIN_VALUE};
+  @Test
+  public void testBitLengthGrowth() throws IOException {
+    int[] values = {0, 1, 2, 64, 128, 1024, 16384, 1 << 20};
+    int lastBits = 0;
 
-        for (int value : values) {
-            ByteArrayOutputStream bout = new ByteArrayOutputStream();
-            BitOutputStream out = new BitOutputStream(bout);
-            writeVarInt(value, out);
-            out.close();
+    for (int value : values) {
+      ByteArrayOutputStream bout = new ByteArrayOutputStream();
+      BitOutputStream out = new BitOutputStream(bout);
+      int bits = writeVarInt(value, out);
+      out.close();
 
-            BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
-            int decoded = BitInputStream.readVarInt(in);
-            in.close();
-
-            Assert.assertEquals("Mismatch for value: " + value, value, decoded);
-        }
+      Assert.assertTrue("Bit length not increasing for value: " + value, bits >= lastBits);
+      lastBits = bits;
     }
-
-    @Test
-    public void testVarIntRange() throws IOException {
-        for (int value = -10000; value <= 10000; value++) {
-            ByteArrayOutputStream bout = new ByteArrayOutputStream();
-            BitOutputStream out = new BitOutputStream(bout);
-            writeVarInt(value, out);
-            out.close();
-
-            BitInputStream in = new BitInputStream(new ByteArrayInputStream(bout.toByteArray()), out.getBitsWritten());
-            int decoded = in.readVarInt(in);
-            in.close();
-
-            Assert.assertEquals("Mismatch in range for value: " + value, value, decoded);
-        }
-    }
-
-    @Test
-    public void testBitLengthGrowth() throws IOException {
-        int[] values = {0, 1, 2, 64, 128, 1024, 16384, 1 << 20};
-        int lastBits = 0;
-
-        for (int value : values) {
-            ByteArrayOutputStream bout = new ByteArrayOutputStream();
-            BitOutputStream out = new BitOutputStream(bout);
-            int bits = writeVarInt(value, out);
-            out.close();
-
-            Assert.assertTrue("Bit length not increasing for value: " + value, bits >= lastBits);
-            lastBits = bits;
-        }
-    }
+  }
 }

--- a/java/tsfile/src/test/java/org/apache/tsfile/encoding/decoder/CamelDecoderTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/encoding/decoder/CamelDecoderTest.java
@@ -1,20 +1,29 @@
 package org.apache.tsfile.encoding.decoder;
 
 import org.apache.tsfile.encoding.encoder.CamelEncoder;
+import org.apache.tsfile.encoding.encoder.DoublePrecisionEncoderV2;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 
 public class CamelDecoderTest {
     @Test
     public void testSimpleCaseForDebug() throws Exception {
-        double[] original = new double[] { -536641.84,  -536641.83 };
+        System.out.println("Double.MIN=" + Double.MIN_VALUE);
+        double[] original = new double[] { 0.1, 0.12345 };
         CamelEncoder compressor = new CamelEncoder();
         // 压缩所有数据点
         for (double v : original) {
@@ -30,8 +39,243 @@ public class CamelDecoderTest {
         assertEquals(original.length, result.size());
         for (int i = 0; i < original.length; i++) {
             // 允许很小的浮点误差，例如 1e-9
-            assertEquals(original[i], result.get(i), 1e-4);
+            assertEquals(original[i], result.get(i), 0);
         }
+    }
+
+    @Test
+    public void testCityTempCompression() throws Exception {
+        // 1. 读取CSV文件
+        String filePath = "D:/workspace/camel/src/test/resources/ElfTestData/City-temp.csv";
+        List<Double> originalData = Files.lines(Paths.get(filePath))
+                .map(Double::parseDouble)
+                .collect(Collectors.toList());
+        System.out.println("Read " + originalData.size() + " data points");
+
+        // 2. 压缩
+        long startTime = System.nanoTime();
+        CamelEncoder compressor = new CamelEncoder();
+        for (Double value : originalData) {  // 改用传统for循环处理异常
+            compressor.addValue(value);
+        }
+        long totalBits = compressor.close();
+        ByteArrayOutputStream compressedStream = compressor.getByteArrayOutputStream();
+        long compressTime = System.nanoTime() - startTime;
+
+        // 3. 解压缩
+        startTime = System.nanoTime();
+        InputStream inputStream = new ByteArrayInputStream(compressedStream.toByteArray());
+        List<Double> decompressedData = new CamelDecoder(inputStream, totalBits).getValues();
+        long decompressTime = System.nanoTime() - startTime;
+
+        // 4. 计算统计信息
+        double originalSize = originalData.size() * 8.0;
+        double compressedSize = compressedStream.size();
+        double compressionRatio = originalSize / compressedSize;
+
+        System.out.println("\nCompression Results:");
+        System.out.printf("Original size: %.2f bytes\n", originalSize);
+        System.out.printf("Compressed size: %.2f bytes\n", compressedSize);
+        System.out.printf("Compression ratio: %.2f:1\n", compressionRatio);
+        System.out.printf("Compression time: %.3f ms\n", compressTime / 1e6);
+        System.out.printf("Decompression time: %.3f ms\n", decompressTime / 1e6);
+
+        assertEquals(originalData.size(), decompressedData.size());
+    }
+
+    @Test
+    public void testGorillaCompression() throws Exception {
+        // 1. 读取CSV文件
+        String filePath = "D:/workspace/camel/src/test/resources/ElfTestData/City-temp.csv";
+        List<Double> originalData = Files.lines(Paths.get(filePath))
+                .map(Double::parseDouble)
+                .collect(Collectors.toList());
+        System.out.println("Read " + originalData.size() + " data points");
+
+        // 2. Gorilla压缩
+        long startTime = System.nanoTime();
+        ByteArrayOutputStream compressedStream = new ByteArrayOutputStream();
+        DoublePrecisionEncoderV2 encoder = new DoublePrecisionEncoderV2();
+        for (Double value : originalData) {
+            encoder.encode(value, compressedStream);
+        }
+        encoder.flush(compressedStream); // 结束编码
+        long compressTime = System.nanoTime() - startTime;
+
+        // 3. Gorilla解压缩
+        startTime = System.nanoTime();
+        ByteBuffer buffer = ByteBuffer.wrap(compressedStream.toByteArray());
+        DoublePrecisionDecoderV2 decoder = new DoublePrecisionDecoderV2();
+        List<Double> decompressedData = new ArrayList<>();
+        while (decoder.hasNext(buffer)) { // 假设Decoder有hasNext()方法
+            decompressedData.add(decoder.readDouble(buffer));
+        }
+        long decompressTime = System.nanoTime() - startTime;
+
+        // 4. 计算统计信息
+        double originalSize = originalData.size() * 8.0; // 每个double 8字节
+        double compressedSize = compressedStream.size();
+        double compressionRatio = originalSize / compressedSize;
+
+        System.out.println("\nGorilla Compression Results:");
+        System.out.printf("Original size: %.2f bytes\n", originalSize);
+        System.out.printf("Compressed size: %.2f bytes\n", compressedSize);
+        System.out.printf("Compression ratio: %.2f:1\n", compressionRatio);
+        System.out.printf("Compression time: %.3f ms\n", compressTime / 1e6);
+        System.out.printf("Decompression time: %.3f ms\n", decompressTime / 1e6);
+
+        assertEquals(originalData.size(), decompressedData.size());
+    }
+
+    // 要处理的目录路径
+    private static final String INPUT_DIR = "D:/workspace/camel/src/test/resources/ElfTestData/";
+
+    @Test
+    public void testAllCsvFilesCompression() throws Exception {
+        // 1. 获取目录下所有CSV文件
+        List<Path> csvFiles = Files.list(Paths.get(INPUT_DIR))
+                .filter(path -> path.toString().endsWith(".csv"))
+                .collect(Collectors.toList());
+
+        if (csvFiles.isEmpty()) {
+            System.out.println("No CSV files found in directory: " + INPUT_DIR);
+            return;
+        }
+
+        System.out.println("Found " + csvFiles.size() + " CSV files to camel process:");
+        csvFiles.forEach(path -> System.out.println("  - " + path.getFileName()));
+
+        // 2. 处理每个文件
+        for (Path csvFile : csvFiles) {
+            System.out.println("\n=== Processing: " + csvFile.getFileName() + " ===");
+            processSingleFile(csvFile);
+        }
+    }
+
+    private void processSingleFile(Path csvFile) throws Exception {
+        // 1. 读取CSV文件
+        List<Double> originalData;
+        try {
+            originalData = Files.lines(csvFile)
+                    .map(String::trim)
+                    .filter(line -> !line.isEmpty())
+                    .map(Double::parseDouble)
+                    .collect(Collectors.toList());
+        } catch (NumberFormatException e) {
+            System.err.println("Skipping file due to parsing error: " + csvFile);
+            return;
+        }
+
+        System.out.println("Read " + originalData.size() + " data points");
+
+        // 2. 压缩
+        long startTime = System.nanoTime();
+        CamelEncoder compressor = new CamelEncoder();
+        for (Double value : originalData) {
+            try {
+                compressor.addValue(value);
+            } catch (IOException e) {
+                throw new RuntimeException("Compression failed", e);
+            }
+        }
+        long totalBits = compressor.close();
+        ByteArrayOutputStream compressedStream = compressor.getByteArrayOutputStream();
+        long compressTime = System.nanoTime() - startTime;
+
+        // 3. 解压缩
+        startTime = System.nanoTime();
+        InputStream inputStream = new ByteArrayInputStream(compressedStream.toByteArray());
+        List<Double> decompressedData = new CamelDecoder(inputStream, totalBits).getValues();
+        long decompressTime = System.nanoTime() - startTime;
+
+        // 4. 计算统计信息
+        double originalSize = originalData.size() * 8.0;
+        double compressedSize = compressedStream.size();
+        double compressionRatio = originalSize / compressedSize;
+
+        System.out.println("\nCompression Results:");
+        System.out.printf("Original size: %.2f bytes\n", originalSize);
+        System.out.printf("Compressed size: %.2f bytes\n", compressedSize);
+        System.out.printf("Compression ratio: %.2f:1\n", compressionRatio);
+        System.out.printf("Compression time: %.3f ms\n", compressTime / 1e6);
+        System.out.printf("Decompression time: %.3f ms\n", decompressTime / 1e6);
+
+        // 5. 验证数据完整性
+        assertEquals(originalData.size(), decompressedData.size());
+    }
+
+    @Test
+    public void testAllCsvFilesWithGorilla() throws Exception {
+        // 1. 获取目录下所有CSV文件
+        List<Path> csvFiles = Files.list(Paths.get(INPUT_DIR))
+                .filter(path -> path.toString().endsWith(".csv"))
+                .collect(Collectors.toList());
+
+        if (csvFiles.isEmpty()) {
+            System.out.println("No CSV files found in directory: " + INPUT_DIR);
+            return;
+        }
+
+        System.out.println("Found " + csvFiles.size() + " CSV files for Gorilla compression:");
+        csvFiles.forEach(path -> System.out.println("  - " + path.getFileName()));
+
+        // 2. 处理每个文件
+        for (Path csvFile : csvFiles) {
+            System.out.println("\n=== Processing with Gorilla: " + csvFile.getFileName() + " ===");
+            processSingleFileWithGorilla(csvFile);
+        }
+    }
+
+    private void processSingleFileWithGorilla(Path csvFile) throws Exception {
+        // 1. 读取CSV文件
+        List<Double> originalData;
+        try {
+            originalData = Files.lines(csvFile)
+                    .map(String::trim)
+                    .filter(line -> !line.isEmpty())
+                    .map(Double::parseDouble)
+                    .collect(Collectors.toList());
+        } catch (NumberFormatException e) {
+            System.err.println("Skipping file due to parsing error: " + csvFile);
+            return;
+        }
+
+        System.out.println("Read " + originalData.size() + " data points");
+
+        // 2. Gorilla压缩
+        long startTime = System.nanoTime();
+        ByteArrayOutputStream compressedStream = new ByteArrayOutputStream();
+        DoublePrecisionEncoderV2 encoder = new DoublePrecisionEncoderV2();
+        for (Double value : originalData) {
+            encoder.encode(value, compressedStream);
+        }
+        encoder.flush(compressedStream); // 结束编码
+        long compressTime = System.nanoTime() - startTime;
+
+        // 3. Gorilla解压缩
+        startTime = System.nanoTime();
+        ByteBuffer buffer = ByteBuffer.wrap(compressedStream.toByteArray());
+        DoublePrecisionDecoderV2 decoder = new DoublePrecisionDecoderV2();
+        List<Double> decompressedData = new ArrayList<>();
+        while (decoder.hasNext(buffer)) { // 假设Decoder有hasNext(ByteBuffer)方法
+            decompressedData.add(decoder.readDouble(buffer));
+        }
+        long decompressTime = System.nanoTime() - startTime;
+
+        // 4. 计算统计信息
+        double originalSize = originalData.size() * 8.0;
+        double compressedSize = compressedStream.size();
+        double compressionRatio = originalSize / compressedSize;
+
+        System.out.println("\nGorilla Compression Results:");
+        System.out.printf("Original size: %.2f bytes\n", originalSize);
+        System.out.printf("Compressed size: %.2f bytes\n", compressedSize);
+        System.out.printf("Compression ratio: %.2f:1\n", compressionRatio);
+        System.out.printf("Compression time: %.3f ms\n", compressTime / 1e6);
+        System.out.printf("Decompression time: %.3f ms\n", decompressTime / 1e6);
+
+        // 5. 验证数据完整性
+        assertEquals(originalData.size(), decompressedData.size());
     }
 
     @Test
@@ -77,15 +321,15 @@ public class CamelDecoderTest {
     public void testRandomizedCompressDecompress() throws Exception {
         // 初始化随机数生成器
         Random random = new Random();
-        int sampleSize = 1000;  // 恢复为100,000组测试数据
+        int sampleSize = 100000;  // 恢复为100,000组测试数据
         double[] original = new double[sampleSize];
 
         // 生成随机测试数据
         for (int i = 0; i < sampleSize; i++) {
-            // 随机整数部分：-1,000,000 ~ 1,000,000
-            int intPart = random.nextInt(2_000_001) - 1_000_000;
-            // 随机小数部分：0.01 ~ 0.99（保留两位小数）
-            double decimalPart = 0.01 + random.nextInt(99) * 0.01;
+            // 随机整数部分：INT32_MIN >> 1 ~ INT32_MAX >> 1
+            int intPart = random.nextInt(Integer.MAX_VALUE) - (Integer.MAX_VALUE >> 1);
+            // 随机小数部分：0.0001 ~ 0.9999（保留四位小数）
+            double decimalPart = 0.0001 + random.nextInt(9999) * 0.0001;
             // 组合为完整浮点数
             original[i] = intPart + decimalPart;
         }

--- a/java/tsfile/src/test/java/org/apache/tsfile/encoding/decoder/CamelDecoderTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/encoding/decoder/CamelDecoderTest.java
@@ -32,35 +32,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class CamelDecoderTest {
-
-  @Test
-  public void testSimpleCaseForDebug() throws Exception {
-    double[] original = new double[] {Double.MIN_VALUE, -7048.1184028651805};
-
-    CamelEncoder encoder = new CamelEncoder();
-    // Compress all values
-    for (double v : original) {
-      encoder.addValue(v);
-    }
-    long totalWrittenBits = encoder.close();
-    ByteArrayOutputStream compressed = encoder.getByteArrayOutputStream();
-
-    // Decompress and verify
-    InputStream inputStream = new ByteArrayInputStream(compressed.toByteArray());
-    CamelDecoder decoder = new CamelDecoder(inputStream, totalWrittenBits);
-    List<Double> result = decoder.getValues();
-    assertEquals(original.length, result.size());
-    for (int i = 0; i < original.length; i++) {
-      assertEquals(original[i], result.get(i), 0);
-    }
-  }
 
   @Test
   public void testRandomizedCompressDecompress() throws Exception {
@@ -83,26 +60,27 @@ public class CamelDecoderTest {
 
   private void compressDecompressAndAssert(double[] original, double tolerance) throws Exception {
     CamelEncoder encoder = new CamelEncoder();
+    ByteArrayOutputStream bout = new ByteArrayOutputStream();
     for (double v : original) {
-      encoder.addValue(v);
+      encoder.encode(v, bout);
     }
-    long totalBits = encoder.close();
-    ByteArrayOutputStream compressed = encoder.getByteArrayOutputStream();
+    encoder.flush(bout);
+    // Decode and verify
+    CamelDecoder decoder = new CamelDecoder();
+    ByteBuffer buffer = ByteBuffer.wrap(bout.toByteArray());
 
-    InputStream input = new ByteArrayInputStream(compressed.toByteArray());
-    CamelDecoder decoder = new CamelDecoder(input, totalBits);
-    List<Double> result = decoder.getValues();
-
-    assertEquals(original.length, result.size());
-    for (int i = 0; i < original.length; i++) {
+    int i = 0;
+    while (decoder.hasNext(buffer)) {
+      double actual = decoder.readDouble(buffer);
       double expected = original[i];
-      double actual = result.get(i);
       if (Double.isNaN(expected)) {
         assertTrue("Expected NaN at index " + i, Double.isNaN(actual));
       } else {
         assertEquals("Mismatch at index " + i, expected, actual, tolerance);
       }
+      i++;
     }
+    assertEquals(original.length, i);
   }
 
   @Test

--- a/java/tsfile/src/test/java/org/apache/tsfile/encoding/decoder/CamelDecoderTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/encoding/decoder/CamelDecoderTest.java
@@ -22,13 +22,16 @@ package org.apache.tsfile.encoding.decoder;
 import org.apache.tsfile.common.bitStream.BitInputStream;
 import org.apache.tsfile.common.bitStream.BitOutputStream;
 import org.apache.tsfile.encoding.encoder.CamelEncoder;
+import org.apache.tsfile.encoding.encoder.Encoder;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
@@ -40,10 +43,7 @@ public class CamelDecoderTest {
 
   @Test
   public void testSimpleCaseForDebug() throws Exception {
-    double[] original =
-        new double[] {
-          Double.MIN_VALUE, Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MIN_VALUE, 0.0, -0.0
-        };
+    double[] original = new double[] {Double.MIN_VALUE, -7048.1184028651805};
 
     CamelEncoder encoder = new CamelEncoder();
     // Compress all values
@@ -255,5 +255,70 @@ public class CamelDecoderTest {
       values[i] = Math.sin(i / 10.0);
     }
     testGorillaValues(values);
+  }
+
+  @Test
+  public void testCamelMultiFlush() throws IOException {
+    Encoder encoder = new CamelEncoder();
+    ByteArrayOutputStream bout = new ByteArrayOutputStream();
+    for (int i = 0; i < 10; i++) {
+      for (int j = 0; j < 10; j++) {
+        encoder.encode((double) i, bout);
+      }
+      encoder.flush(bout);
+    }
+
+    Decoder decoder = new CamelDecoder();
+    ByteBuffer buffer = ByteBuffer.wrap(bout.toByteArray());
+    while (decoder.hasNext(buffer)) {
+      double val = decoder.readDouble(buffer);
+      System.out.println(val);
+      // Assert.assertEquals(1.0, val, 0.0);
+    }
+  }
+
+  private static final int[] FLUSH_SIZES = {32, 64, 128, 256, 512, 1000};
+  private static final int TOTAL_VALUES = 10_000;
+
+  @Test
+  public void testBatchFlushForVariousBlockSizes() throws IOException {
+    Random random = new Random(42);
+    for (int blockSize : FLUSH_SIZES) {
+      // Prepare encoder and output buffer
+      CamelEncoder encoder = new CamelEncoder();
+      ByteArrayOutputStream bout = new ByteArrayOutputStream();
+      double[] original = new double[TOTAL_VALUES];
+
+      // Generate random data and flush every blockSize values
+      for (int i = 0; i < TOTAL_VALUES; i++) {
+        double v;
+        do {
+          long bits = random.nextLong();
+          v = Double.longBitsToDouble(bits);
+        } while (Double.isNaN(v) || Double.isInfinite(v));
+        original[i] = v;
+        encoder.encode(v, bout);
+        if ((i + 1) % blockSize == 0) {
+          encoder.flush(bout);
+        }
+      }
+      // Final flush to cover trailing values
+      encoder.flush(bout);
+
+      // Decode and verify
+      CamelDecoder decoder = new CamelDecoder();
+      ByteBuffer buffer = ByteBuffer.wrap(bout.toByteArray());
+      for (int i = 0; i < TOTAL_VALUES; i++) {
+        Assert.assertTrue(
+            "Decoder should have next for blockSize=" + blockSize, decoder.hasNext(buffer));
+        double decoded = decoder.readDouble(buffer);
+
+        Assert.assertEquals(
+            "Mismatch at index " + i + " for blockSize=" + blockSize, original[i], decoded, 0);
+      }
+      Assert.assertFalse(
+          "Decoder should be exhausted after reading all values for blockSize=" + blockSize,
+          decoder.hasNext(buffer));
+    }
   }
 }

--- a/java/tsfile/src/test/java/org/apache/tsfile/encoding/decoder/CamelDecoderTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/encoding/decoder/CamelDecoderTest.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.encoding.decoder;
 import org.apache.tsfile.common.bitStream.BitInputStream;
 import org.apache.tsfile.common.bitStream.BitOutputStream;
 import org.apache.tsfile.encoding.encoder.CamelEncoder;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,226 +38,222 @@ import static org.junit.Assert.assertTrue;
 
 public class CamelDecoderTest {
 
-    @Test
-    public void testSimpleCaseForDebug() throws Exception {
-        double[] original = new double[]{
-                Double.MIN_VALUE,
-                Double.MAX_VALUE,
-                -Double.MAX_VALUE,
-                -Double.MIN_VALUE,
-                0.0, -0.0
+  @Test
+  public void testSimpleCaseForDebug() throws Exception {
+    double[] original =
+        new double[] {
+          Double.MIN_VALUE, Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MIN_VALUE, 0.0, -0.0
         };
 
-        CamelEncoder encoder = new CamelEncoder();
-        // Compress all values
-        for (double v : original) {
-            encoder.addValue(v);
-        }
-        long totalWrittenBits = encoder.close();
-        ByteArrayOutputStream compressed = encoder.getByteArrayOutputStream();
+    CamelEncoder encoder = new CamelEncoder();
+    // Compress all values
+    for (double v : original) {
+      encoder.addValue(v);
+    }
+    long totalWrittenBits = encoder.close();
+    ByteArrayOutputStream compressed = encoder.getByteArrayOutputStream();
 
-        // Decompress and verify
-        InputStream inputStream = new ByteArrayInputStream(compressed.toByteArray());
-        CamelDecoder decoder = new CamelDecoder(inputStream, totalWrittenBits);
-        List<Double> result = decoder.getValues();
-        assertEquals(original.length, result.size());
-        for (int i = 0; i < original.length; i++) {
-            assertEquals(original[i], result.get(i), 0);
-        }
+    // Decompress and verify
+    InputStream inputStream = new ByteArrayInputStream(compressed.toByteArray());
+    CamelDecoder decoder = new CamelDecoder(inputStream, totalWrittenBits);
+    List<Double> result = decoder.getValues();
+    assertEquals(original.length, result.size());
+    for (int i = 0; i < original.length; i++) {
+      assertEquals(original[i], result.get(i), 0);
+    }
+  }
+
+  @Test
+  public void testRandomizedCompressDecompress() throws Exception {
+    Random random = new Random();
+    int sampleSize = 10_000;
+    double[] original = new double[sampleSize];
+
+    // Generate random test data (excluding NaN and ±Infinity)
+    for (int i = 0; i < sampleSize; i++) {
+      double v;
+      do {
+        long bits = random.nextLong();
+        v = Double.longBitsToDouble(bits);
+      } while (Double.isNaN(v) || Double.isInfinite(v));
+      original[i] = v;
     }
 
-    @Test
-    public void testRandomizedCompressDecompress() throws Exception {
-        Random random = new Random();
-        int sampleSize = 10_000;
-        double[] original = new double[sampleSize];
+    compressDecompressAndAssert(original, 0);
+  }
 
-        // Generate random test data (excluding NaN and ±Infinity)
-        for (int i = 0; i < sampleSize; i++) {
-            double v;
-            do {
-                long bits = random.nextLong();
-                v = Double.longBitsToDouble(bits);
-            } while (Double.isNaN(v) || Double.isInfinite(v));
-            original[i] = v;
-        }
-
-        compressDecompressAndAssert(original, 0);
+  private void compressDecompressAndAssert(double[] original, double tolerance) throws Exception {
+    CamelEncoder encoder = new CamelEncoder();
+    for (double v : original) {
+      encoder.addValue(v);
     }
+    long totalBits = encoder.close();
+    ByteArrayOutputStream compressed = encoder.getByteArrayOutputStream();
 
-    private void compressDecompressAndAssert(double[] original, double tolerance) throws Exception {
-        CamelEncoder encoder = new CamelEncoder();
-        for (double v : original) {
-            encoder.addValue(v);
-        }
-        long totalBits = encoder.close();
-        ByteArrayOutputStream compressed = encoder.getByteArrayOutputStream();
+    InputStream input = new ByteArrayInputStream(compressed.toByteArray());
+    CamelDecoder decoder = new CamelDecoder(input, totalBits);
+    List<Double> result = decoder.getValues();
 
-        InputStream input = new ByteArrayInputStream(compressed.toByteArray());
-        CamelDecoder decoder = new CamelDecoder(input, totalBits);
-        List<Double> result = decoder.getValues();
-
-        assertEquals(original.length, result.size());
-        for (int i = 0; i < original.length; i++) {
-            double expected = original[i];
-            double actual = result.get(i);
-            if (Double.isNaN(expected)) {
-                assertTrue("Expected NaN at index " + i, Double.isNaN(actual));
-            } else {
-                assertEquals("Mismatch at index " + i, expected, actual, tolerance);
-            }
-        }
+    assertEquals(original.length, result.size());
+    for (int i = 0; i < original.length; i++) {
+      double expected = original[i];
+      double actual = result.get(i);
+      if (Double.isNaN(expected)) {
+        assertTrue("Expected NaN at index " + i, Double.isNaN(actual));
+      } else {
+        assertEquals("Mismatch at index " + i, expected, actual, tolerance);
+      }
     }
+  }
 
-    @Test
-    public void testSpecialFloatingValues() throws Exception {
-        double[] original = new double[] {
-                Double.NaN,
-                Double.POSITIVE_INFINITY,
-                Double.NEGATIVE_INFINITY,
-                +0.0, -0.0,
-                Double.MIN_VALUE,
-                -Double.MIN_VALUE,
-                Double.MIN_NORMAL,
-                -Double.MIN_NORMAL,
-                Double.MAX_VALUE,
-                -Double.MAX_VALUE
+  @Test
+  public void testSpecialFloatingValues() throws Exception {
+    double[] original =
+        new double[] {
+          Double.NaN,
+          Double.POSITIVE_INFINITY,
+          Double.NEGATIVE_INFINITY,
+          +0.0,
+          -0.0,
+          Double.MIN_VALUE,
+          -Double.MIN_VALUE,
+          Double.MIN_NORMAL,
+          -Double.MIN_NORMAL,
+          Double.MAX_VALUE,
+          -Double.MAX_VALUE
         };
-        compressDecompressAndAssert(original, 0.0);
+    compressDecompressAndAssert(original, 0.0);
+  }
+
+  @Test
+  public void testMonotonicSequence() throws Exception {
+    double[] increasing = new double[500];
+    double[] decreasing = new double[500];
+    for (int i = 0; i < 500; i++) {
+      increasing[i] = 100.0 + i * 0.0001;
+      decreasing[i] = 100.0 - i * 0.0001;
     }
+    compressDecompressAndAssert(increasing, 0);
+    compressDecompressAndAssert(decreasing, 0);
+  }
 
-    @Test
-    public void testMonotonicSequence() throws Exception {
-        double[] increasing = new double[500];
-        double[] decreasing = new double[500];
-        for (int i = 0; i < 500; i++) {
-            increasing[i] = 100.0 + i * 0.0001;
-            decreasing[i] = 100.0 - i * 0.0001;
-        }
-        compressDecompressAndAssert(increasing, 0);
-        compressDecompressAndAssert(decreasing, 0);
+  @Test
+  public void testPrecisionEdgeCases() throws Exception {
+    double[] original = {
+      9007199254740991.0, // 2^53 - 1
+      9007199254740992.0, // 2^53
+      9007199254740993.0,
+      1.0000000000000001, // Precision loss (equals 1.0)
+      1.0000000000000002,
+      12345,
+      21332213
+    };
+    compressDecompressAndAssert(original, 0.0);
+  }
+
+  @Test
+  public void testAlternatingSignsAndDecimals() throws Exception {
+    double[] original = new double[2];
+    for (int i = 0; i < 2; i++) {
+      double base = i * 0.123456 % 1000;
+      original[i] = (i % 2 == 0) ? base : -base;
     }
+    compressDecompressAndAssert(original, 0.0);
+  }
 
-    @Test
-    public void testPrecisionEdgeCases() throws Exception {
-        double[] original = {
-                9007199254740991.0, // 2^53 - 1
-                9007199254740992.0, // 2^53
-                9007199254740993.0,
-                1.0000000000000001, // Precision loss (equals 1.0)
-                1.0000000000000002,
-                12345,
-                21332213
-        };
-        compressDecompressAndAssert(original, 0.0);
+  @Test
+  public void testMinimalDeltaSequence() throws Exception {
+    double[] original = new double[64];
+    double base = 100.0;
+    for (int i = 0; i < original.length; i++) {
+      original[i] = base + i * Math.ulp(base);
     }
+    compressDecompressAndAssert(original, 0.0);
+  }
 
-    @Test
-    public void testAlternatingSignsAndDecimals() throws Exception {
-        double[] original = new double[2];
-        for (int i = 0; i < 2; i++) {
-            double base = i * 0.123456 % 1000;
-            original[i] = (i % 2 == 0) ? base : -base;
-        }
-        compressDecompressAndAssert(original, 0.0);
+  @Test
+  public void testRepeatedValues() throws Exception {
+    double repeated = 123.456789;
+    double[] original = new double[1000];
+    Arrays.fill(original, repeated);
+    compressDecompressAndAssert(original, 0.0);
+  }
+
+  private void testGorillaValues(double[] values) throws Exception {
+    ByteArrayOutputStream bout = new ByteArrayOutputStream();
+    BitOutputStream out = new BitOutputStream(bout);
+
+    CamelEncoder.GorillaEncoder encoder = new CamelEncoder().getGorillaEncoder();
+    for (double v : values) {
+      encoder.encode(v, out);
     }
+    encoder.close(out);
 
-    @Test
-    public void testMinimalDeltaSequence() throws Exception {
-        double[] original = new double[64];
-        double base = 100.0;
-        for (int i = 0; i < original.length; i++) {
-            original[i] = base + i * Math.ulp(base);
-        }
-        compressDecompressAndAssert(original, 0.0);
+    byte[] encoded = bout.toByteArray();
+    BitInputStream in = new BitInputStream(new ByteArrayInputStream(encoded), out.getBitsWritten());
+    InputStream inputStream = new ByteArrayInputStream(encoded);
+    CamelDecoder.GorillaDecoder decoder =
+        new CamelDecoder(inputStream, out.getBitsWritten()).getGorillaDecoder();
+
+    int idx = 0;
+    for (double expected : values) {
+      double actual = decoder.decode(in);
+      Assert.assertEquals("Mismatch decoding: ", expected, actual, 0.0);
     }
+  }
 
-    @Test
-    public void testRepeatedValues() throws Exception {
-        double repeated = 123.456789;
-        double[] original = new double[1000];
-        Arrays.fill(original, repeated);
-        compressDecompressAndAssert(original, 0.0);
+  @Test
+  public void testGorillaAllZeros() throws Exception {
+    double[] values = new double[100];
+    Arrays.fill(values, 0.0);
+    testGorillaValues(values);
+  }
+
+  @Test
+  public void testGorillaConstantValue() throws Exception {
+    double[] values = new double[200];
+    Arrays.fill(values, 123456.789);
+    testGorillaValues(values);
+  }
+
+  @Test
+  public void testGorillaMinMaxValues() throws Exception {
+    double[] values = {
+      Double.MIN_VALUE, Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MIN_VALUE, 0.0, -0.0
+    };
+    testGorillaValues(values);
+  }
+
+  @Test
+  public void testGorillaMixedSigns() throws Exception {
+    double[] values = {-1.1, 2.2, -3.3, 4.4, -5.5, 6.6, -7.7};
+    testGorillaValues(values);
+  }
+
+  @Test
+  public void testGorillaHighPrecisionValues() throws Exception {
+    double[] values = {0.1, 0.2, 0.3, 0.1 + 0.2, 0.4 - 0.1};
+    testGorillaValues(values);
+  }
+
+  @Test
+  public void testGorillaXorEdgeTrigger() throws Exception {
+    double[] values = {
+      1.00000001,
+      1.00000002,
+      1.00000003,
+      1.00000001, // back to earlier value
+      1.00000009
+    };
+    testGorillaValues(values);
+  }
+
+  @Test
+  public void testLargeSeries() throws Exception {
+    double[] values = new double[1000];
+    for (int i = 0; i < values.length; i++) {
+      values[i] = Math.sin(i / 10.0);
     }
-
-    private void testGorillaValues(double[] values) throws Exception {
-        ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        BitOutputStream out = new BitOutputStream(bout);
-
-        CamelEncoder.GorillaEncoder encoder = new CamelEncoder().getGorillaEncoder();
-        for (double v : values) {
-            encoder.encode(v, out);
-        }
-        encoder.close(out);
-
-        byte[] encoded = bout.toByteArray();
-        BitInputStream in = new BitInputStream(new ByteArrayInputStream(encoded), out.getBitsWritten());
-        InputStream inputStream = new ByteArrayInputStream(encoded);
-        CamelDecoder.GorillaDecoder decoder = new CamelDecoder(inputStream, out.getBitsWritten()).getGorillaDecoder();
-
-        int idx = 0;
-        for (double expected : values) {
-            double actual = decoder.decode(in);
-            Assert.assertEquals("Mismatch decoding: ", expected, actual, 0.0);
-        }
-    }
-
-    @Test
-    public void testGorillaAllZeros() throws Exception {
-        double[] values = new double[100];
-        Arrays.fill(values, 0.0);
-        testGorillaValues(values);
-    }
-
-    @Test
-    public void testGorillaConstantValue() throws Exception {
-        double[] values = new double[200];
-        Arrays.fill(values, 123456.789);
-        testGorillaValues(values);
-    }
-
-    @Test
-    public void testGorillaMinMaxValues() throws Exception {
-        double[] values = {
-                Double.MIN_VALUE,
-                Double.MAX_VALUE,
-                -Double.MAX_VALUE,
-                -Double.MIN_VALUE,
-                0.0, -0.0
-        };
-        testGorillaValues(values);
-    }
-
-    @Test
-    public void testGorillaMixedSigns() throws Exception {
-        double[] values = {-1.1, 2.2, -3.3, 4.4, -5.5, 6.6, -7.7};
-        testGorillaValues(values);
-    }
-
-    @Test
-    public void testGorillaHighPrecisionValues() throws Exception {
-        double[] values = {0.1, 0.2, 0.3, 0.1 + 0.2, 0.4 - 0.1};
-        testGorillaValues(values);
-    }
-
-    @Test
-    public void testGorillaXorEdgeTrigger() throws Exception {
-        double[] values = {
-                1.00000001,
-                1.00000002,
-                1.00000003,
-                1.00000001,  // back to earlier value
-                1.00000009
-        };
-        testGorillaValues(values);
-    }
-
-    @Test
-    public void testLargeSeries() throws Exception {
-        double[] values = new double[1000];
-        for (int i = 0; i < values.length; i++) {
-            values[i] = Math.sin(i / 10.0);
-        }
-        testGorillaValues(values);
-    }
+    testGorillaValues(values);
+  }
 }

--- a/java/tsfile/src/test/java/org/apache/tsfile/encoding/decoder/CamelDecoderTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/encoding/decoder/CamelDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.tsfile.encoding.decoder;
 
 import org.apache.tsfile.common.bitStream.BitInputStream;
@@ -14,112 +33,157 @@ import java.util.List;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class CamelDecoderTest {
+
     @Test
     public void testSimpleCaseForDebug() throws Exception {
-        double[] original = new double[]{100.0, -100.52};
-        CamelEncoder compressor = new CamelEncoder();
-        // 压缩所有数据点
-        for (double v : original) {
-            compressor.addValue(v);
-        }
-        long totalWrittenBits = compressor.close();
-        ByteArrayOutputStream compressed = compressor.getByteArrayOutputStream();
-
-        // 解压并比对
-        InputStream inputStream = new ByteArrayInputStream(compressed.toByteArray());
-        CamelDecoder decompressor = new CamelDecoder(inputStream, totalWrittenBits);
-        List<Double> result = decompressor.getValues();
-        assertEquals(original.length, result.size());
-        for (int i = 0; i < original.length; i++) {
-            // 允许很小的浮点误差，例如 1e-9
-            assertEquals(original[i], result.get(i), 0);
-        }
-    }
-
-
-    @Test
-    public void testBasicCompressDecompress() throws Exception {
-        // 原始测试数据（保留原有测试用例）
-        double[] original = new double[] {
-                100.0, -100.52, 100.75, 100.23, 101.25, 100.25,
-                // 新增测试数据：覆盖 .01 ~ .99 的小数部分
-                100.01, 100.02, 100.03, 100.04, 100.05, 100.06, 100.07, 100.08, 100.09,
-                100.10, 100.11, 100.12, 100.13, 100.14, 100.15, 100.16, 100.17, 100.18, 100.19,
-                100.20, 100.21, 100.22, 100.23, 100.24, 100.25, 100.26, 100.27, 100.28, 100.29,
-                100.30, 100.31, 100.32, 100.33, 100.34, 100.35, 100.36, 100.37, 100.38, 100.39,
-                100.40, 100.41, 100.42, 100.43, 100.44, 100.45, 100.46, 100.47, 100.48, 100.49,
-                100.50, 100.51, 100.52, 100.53, 100.54, 100.55, 100.56, 100.57, 100.58, 100.59,
-                100.60, 100.61, 100.62, 100.63, 100.64, 100.65, 100.66, 100.67, 100.68, 100.69,
-                100.70, 100.71, 100.72, 100.73, 100.74, 100.75, 100.76, 100.77, 100.78, 100.79,
-                100.80, 100.81, 100.82, 100.83, 100.84, 100.85, 100.86, 100.87, 100.88, 100.89,
-                100.90, 100.91, 100.92, 100.93, 100.94, 100.95, 100.96, 100.97, 100.98, 100.99,
-                // 额外边界测试
-                -100.01, -100.99, 0.01, 0.99, 999.99, -999.99
+        double[] original = new double[]{
+                Double.MIN_VALUE,
+                Double.MAX_VALUE,
+                -Double.MAX_VALUE,
+                -Double.MIN_VALUE,
+                0.0, -0.0
         };
 
-        CamelEncoder compressor = new CamelEncoder();
-        // 压缩所有数据点
+        CamelEncoder encoder = new CamelEncoder();
+        // Compress all values
         for (double v : original) {
-            compressor.addValue(v);
+            encoder.addValue(v);
         }
-        long totalWrittenBits = compressor.close();
-        ByteArrayOutputStream compressed = compressor.getByteArrayOutputStream();
+        long totalWrittenBits = encoder.close();
+        ByteArrayOutputStream compressed = encoder.getByteArrayOutputStream();
 
-        // 解压并比对
+        // Decompress and verify
         InputStream inputStream = new ByteArrayInputStream(compressed.toByteArray());
-        CamelDecoder decompressor = new CamelDecoder(inputStream, totalWrittenBits);
-        List<Double> result = decompressor.getValues();
+        CamelDecoder decoder = new CamelDecoder(inputStream, totalWrittenBits);
+        List<Double> result = decoder.getValues();
         assertEquals(original.length, result.size());
         for (int i = 0; i < original.length; i++) {
-            // 允许很小的浮点误差，例如 1e-4
-            assertEquals(original[i], result.get(i), 1e-4);
+            assertEquals(original[i], result.get(i), 0);
         }
     }
 
     @Test
     public void testRandomizedCompressDecompress() throws Exception {
-        // 初始化随机数生成器
         Random random = new Random();
-        int sampleSize = 10000;  // 恢复为10,000组测试数据
+        int sampleSize = 10_000;
         double[] original = new double[sampleSize];
 
-        // 生成随机测试数据
+        // Generate random test data (excluding NaN and ±Infinity)
         for (int i = 0; i < sampleSize; i++) {
-            // 随机整数部分：INT32_MIN >> 1 ~ INT32_MAX >> 1
-            int intPart = random.nextInt(Integer.MAX_VALUE) - (Integer.MAX_VALUE >> 1);
-            // 随机小数部分：0.0001 ~ 0.9999（保留四位小数）
-            double decimalPart = 0.0001 + random.nextInt(9999) * 0.0001;
-            // 组合为完整浮点数
-            original[i] = intPart + decimalPart;
+            double v;
+            do {
+                long bits = random.nextLong();
+                v = Double.longBitsToDouble(bits);
+            } while (Double.isNaN(v) || Double.isInfinite(v));
+            original[i] = v;
         }
 
-        CamelEncoder compressor = new CamelEncoder();
-        // 压缩所有数据点
+        compressDecompressAndAssert(original, 0);
+    }
+
+    private void compressDecompressAndAssert(double[] original, double tolerance) throws Exception {
+        CamelEncoder encoder = new CamelEncoder();
         for (double v : original) {
-            compressor.addValue(v);
+            encoder.addValue(v);
         }
-        long totalWrittenBits = compressor.close();
-        ByteArrayOutputStream compressed = compressor.getByteArrayOutputStream();
+        long totalBits = encoder.close();
+        ByteArrayOutputStream compressed = encoder.getByteArrayOutputStream();
 
-        // 解压并比对
-        InputStream inputStream = new ByteArrayInputStream(compressed.toByteArray());
-        CamelDecoder decompressor = new CamelDecoder(inputStream, totalWrittenBits);
-        List<Double> result = decompressor.getValues();
+        InputStream input = new ByteArrayInputStream(compressed.toByteArray());
+        CamelDecoder decoder = new CamelDecoder(input, totalBits);
+        List<Double> result = decoder.getValues();
 
         assertEquals(original.length, result.size());
         for (int i = 0; i < original.length; i++) {
-            // 允许浮点误差（1e-4）
-            assertEquals(original[i], result.get(i), 1e-4);
+            double expected = original[i];
+            double actual = result.get(i);
+            if (Double.isNaN(expected)) {
+                assertTrue("Expected NaN at index " + i, Double.isNaN(actual));
+            } else {
+                assertEquals("Mismatch at index " + i, expected, actual, tolerance);
+            }
         }
+    }
+
+    @Test
+    public void testSpecialFloatingValues() throws Exception {
+        double[] original = new double[] {
+                Double.NaN,
+                Double.POSITIVE_INFINITY,
+                Double.NEGATIVE_INFINITY,
+                +0.0, -0.0,
+                Double.MIN_VALUE,
+                -Double.MIN_VALUE,
+                Double.MIN_NORMAL,
+                -Double.MIN_NORMAL,
+                Double.MAX_VALUE,
+                -Double.MAX_VALUE
+        };
+        compressDecompressAndAssert(original, 0.0);
+    }
+
+    @Test
+    public void testMonotonicSequence() throws Exception {
+        double[] increasing = new double[500];
+        double[] decreasing = new double[500];
+        for (int i = 0; i < 500; i++) {
+            increasing[i] = 100.0 + i * 0.0001;
+            decreasing[i] = 100.0 - i * 0.0001;
+        }
+        compressDecompressAndAssert(increasing, 0);
+        compressDecompressAndAssert(decreasing, 0);
+    }
+
+    @Test
+    public void testPrecisionEdgeCases() throws Exception {
+        double[] original = {
+                9007199254740991.0, // 2^53 - 1
+                9007199254740992.0, // 2^53
+                9007199254740993.0,
+                1.0000000000000001, // Precision loss (equals 1.0)
+                1.0000000000000002,
+                12345,
+                21332213
+        };
+        compressDecompressAndAssert(original, 0.0);
+    }
+
+    @Test
+    public void testAlternatingSignsAndDecimals() throws Exception {
+        double[] original = new double[2];
+        for (int i = 0; i < 2; i++) {
+            double base = i * 0.123456 % 1000;
+            original[i] = (i % 2 == 0) ? base : -base;
+        }
+        compressDecompressAndAssert(original, 0.0);
+    }
+
+    @Test
+    public void testMinimalDeltaSequence() throws Exception {
+        double[] original = new double[64];
+        double base = 100.0;
+        for (int i = 0; i < original.length; i++) {
+            original[i] = base + i * Math.ulp(base);
+        }
+        compressDecompressAndAssert(original, 0.0);
+    }
+
+    @Test
+    public void testRepeatedValues() throws Exception {
+        double repeated = 123.456789;
+        double[] original = new double[1000];
+        Arrays.fill(original, repeated);
+        compressDecompressAndAssert(original, 0.0);
     }
 
     private void testGorillaValues(double[] values) throws Exception {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         BitOutputStream out = new BitOutputStream(bout);
 
-        CamelEncoder.GorillaEncoder encoder = new CamelEncoder.GorillaEncoder();
+        CamelEncoder.GorillaEncoder encoder = new CamelEncoder().getGorillaEncoder();
         for (double v : values) {
             encoder.encode(v, out);
         }
@@ -127,7 +191,8 @@ public class CamelDecoderTest {
 
         byte[] encoded = bout.toByteArray();
         BitInputStream in = new BitInputStream(new ByteArrayInputStream(encoded), out.getBitsWritten());
-        CamelDecoder.GorillaDecoder decoder = new CamelDecoder.GorillaDecoder();
+        InputStream inputStream = new ByteArrayInputStream(encoded);
+        CamelDecoder.GorillaDecoder decoder = new CamelDecoder(inputStream, out.getBitsWritten()).getGorillaDecoder();
 
         int idx = 0;
         for (double expected : values) {
@@ -180,7 +245,7 @@ public class CamelDecoderTest {
                 1.00000001,
                 1.00000002,
                 1.00000003,
-                1.00000001,  // back to earlier
+                1.00000001,  // back to earlier value
                 1.00000009
         };
         testGorillaValues(values);
@@ -194,240 +259,4 @@ public class CamelDecoderTest {
         }
         testGorillaValues(values);
     }
-
-/*
-    @Test
-    public void testCityTempCompression() throws Exception {
-        // 1. 读取CSV文件
-        String filePath = "D:/workspace/camel/src/test/resources/ElfTestData/City-temp.csv";
-        List<Double> originalData = Files.lines(Paths.get(filePath))
-                .map(Double::parseDouble)
-                .collect(Collectors.toList());
-        System.out.println("Read " + originalData.size() + " data points");
-
-        // 2. 压缩
-        long startTime = System.nanoTime();
-        CamelEncoder compressor = new CamelEncoder();
-        for (Double value : originalData) {  // 改用传统for循环处理异常
-            compressor.addValue(value);
-        }
-        long totalBits = compressor.close();
-        ByteArrayOutputStream compressedStream = compressor.getByteArrayOutputStream();
-        long compressTime = System.nanoTime() - startTime;
-
-        // 3. 解压缩
-        startTime = System.nanoTime();
-        InputStream inputStream = new ByteArrayInputStream(compressedStream.toByteArray());
-        List<Double> decompressedData = new CamelDecoder(inputStream, totalBits).getValues();
-        long decompressTime = System.nanoTime() - startTime;
-
-        // 4. 计算统计信息
-        double originalSize = originalData.size() * 8.0;
-        double compressedSize = compressedStream.size();
-        double compressionRatio = originalSize / compressedSize;
-
-        System.out.println("\nCompression Results:");
-        System.out.printf("Original size: %.2f bytes\n", originalSize);
-        System.out.printf("Compressed size: %.2f bytes\n", compressedSize);
-        System.out.printf("Compression ratio: %.2f:1\n", compressionRatio);
-        System.out.printf("Compression time: %.3f ms\n", compressTime / 1e6);
-        System.out.printf("Decompression time: %.3f ms\n", decompressTime / 1e6);
-
-        assertEquals(originalData.size(), decompressedData.size());
-    }
-
-    @Test
-    public void testGorillaCompression() throws Exception {
-        // 1. 读取CSV文件
-        String filePath = "D:/workspace/camel/src/test/resources/ElfTestData/City-temp.csv";
-        List<Double> originalData = Files.lines(Paths.get(filePath))
-                .map(Double::parseDouble)
-                .collect(Collectors.toList());
-        System.out.println("Read " + originalData.size() + " data points");
-
-        // 2. Gorilla压缩
-        long startTime = System.nanoTime();
-        ByteArrayOutputStream compressedStream = new ByteArrayOutputStream();
-        DoublePrecisionEncoderV2 encoder = new DoublePrecisionEncoderV2();
-        for (Double value : originalData) {
-            encoder.encode(value, compressedStream);
-        }
-        encoder.flush(compressedStream); // 结束编码
-        long compressTime = System.nanoTime() - startTime;
-
-        // 3. Gorilla解压缩
-        startTime = System.nanoTime();
-        ByteBuffer buffer = ByteBuffer.wrap(compressedStream.toByteArray());
-        DoublePrecisionDecoderV2 decoder = new DoublePrecisionDecoderV2();
-        List<Double> decompressedData = new ArrayList<>();
-        while (decoder.hasNext(buffer)) { // 假设Decoder有hasNext()方法
-            decompressedData.add(decoder.readDouble(buffer));
-        }
-        long decompressTime = System.nanoTime() - startTime;
-
-        // 4. 计算统计信息
-        double originalSize = originalData.size() * 8.0; // 每个double 8字节
-        double compressedSize = compressedStream.size();
-        double compressionRatio = originalSize / compressedSize;
-
-        System.out.println("\nGorilla Compression Results:");
-        System.out.printf("Original size: %.2f bytes\n", originalSize);
-        System.out.printf("Compressed size: %.2f bytes\n", compressedSize);
-        System.out.printf("Compression ratio: %.2f:1\n", compressionRatio);
-        System.out.printf("Compression time: %.3f ms\n", compressTime / 1e6);
-        System.out.printf("Decompression time: %.3f ms\n", decompressTime / 1e6);
-
-        assertEquals(originalData.size(), decompressedData.size());
-    }
-
-    // 要处理的目录路径
-    private static final String INPUT_DIR = "D:/workspace/camel/src/test/resources/ElfTestData/";
-
-    @Test
-    public void testAllCsvFilesCompression() throws Exception {
-        // 1. 获取目录下所有CSV文件
-        List<Path> csvFiles = Files.list(Paths.get(INPUT_DIR))
-                .filter(path -> path.toString().endsWith(".csv"))
-                .collect(Collectors.toList());
-
-        if (csvFiles.isEmpty()) {
-            System.out.println("No CSV files found in directory: " + INPUT_DIR);
-            return;
-        }
-
-        System.out.println("Found " + csvFiles.size() + " CSV files to camel process:");
-        csvFiles.forEach(path -> System.out.println("  - " + path.getFileName()));
-
-        // 2. 处理每个文件
-        for (Path csvFile : csvFiles) {
-            System.out.println("\n=== Processing: " + csvFile.getFileName() + " ===");
-            processSingleFile(csvFile);
-        }
-    }
-
-    private void processSingleFile(Path csvFile) throws Exception {
-        // 1. 读取CSV文件
-        List<Double> originalData;
-        try {
-            originalData = Files.lines(csvFile)
-                    .map(String::trim)
-                    .filter(line -> !line.isEmpty())
-                    .map(Double::parseDouble)
-                    .collect(Collectors.toList());
-        } catch (NumberFormatException e) {
-            System.err.println("Skipping file due to parsing error: " + csvFile);
-            return;
-        }
-
-        System.out.println("Read " + originalData.size() + " data points");
-
-        // 2. 压缩
-        long startTime = System.nanoTime();
-        CamelEncoder compressor = new CamelEncoder();
-        for (Double value : originalData) {
-            try {
-                compressor.addValue(value);
-            } catch (IOException e) {
-                throw new RuntimeException("Compression failed", e);
-            }
-        }
-        long totalBits = compressor.close();
-        ByteArrayOutputStream compressedStream = compressor.getByteArrayOutputStream();
-        long compressTime = System.nanoTime() - startTime;
-
-        // 3. 解压缩
-        startTime = System.nanoTime();
-        InputStream inputStream = new ByteArrayInputStream(compressedStream.toByteArray());
-        List<Double> decompressedData = new CamelDecoder(inputStream, totalBits).getValues();
-        long decompressTime = System.nanoTime() - startTime;
-
-        // 4. 计算统计信息
-        double originalSize = originalData.size() * 8.0;
-        double compressedSize = compressedStream.size();
-        double compressionRatio = originalSize / compressedSize;
-
-        System.out.println("\nCompression Results:");
-        System.out.printf("Original size: %.2f bytes\n", originalSize);
-        System.out.printf("Compressed size: %.2f bytes\n", compressedSize);
-        System.out.printf("Compression ratio: %.2f:1\n", compressionRatio);
-        System.out.printf("Compression time: %.3f ms\n", compressTime / 1e6);
-        System.out.printf("Decompression time: %.3f ms\n", decompressTime / 1e6);
-
-        // 5. 验证数据完整性
-        assertEquals(originalData.size(), decompressedData.size());
-    }
-
-    @Test
-    public void testAllCsvFilesWithGorilla() throws Exception {
-        // 1. 获取目录下所有CSV文件
-        List<Path> csvFiles = Files.list(Paths.get(INPUT_DIR))
-                .filter(path -> path.toString().endsWith(".csv"))
-                .collect(Collectors.toList());
-
-        if (csvFiles.isEmpty()) {
-            System.out.println("No CSV files found in directory: " + INPUT_DIR);
-            return;
-        }
-
-        System.out.println("Found " + csvFiles.size() + " CSV files for Gorilla compression:");
-        csvFiles.forEach(path -> System.out.println("  - " + path.getFileName()));
-
-        // 2. 处理每个文件
-        for (Path csvFile : csvFiles) {
-            System.out.println("\n=== Processing with Gorilla: " + csvFile.getFileName() + " ===");
-            processSingleFileWithGorilla(csvFile);
-        }
-    }
-
-    private void processSingleFileWithGorilla(Path csvFile) throws Exception {
-        // 1. 读取CSV文件
-        List<Double> originalData;
-        try {
-            originalData = Files.lines(csvFile)
-                    .map(String::trim)
-                    .filter(line -> !line.isEmpty())
-                    .map(Double::parseDouble)
-                    .collect(Collectors.toList());
-        } catch (NumberFormatException e) {
-            System.err.println("Skipping file due to parsing error: " + csvFile);
-            return;
-        }
-
-        System.out.println("Read " + originalData.size() + " data points");
-
-        // 2. Gorilla压缩
-        long startTime = System.nanoTime();
-        ByteArrayOutputStream compressedStream = new ByteArrayOutputStream();
-        DoublePrecisionEncoderV2 encoder = new DoublePrecisionEncoderV2();
-        for (Double value : originalData) {
-            encoder.encode(value, compressedStream);
-        }
-        encoder.flush(compressedStream); // 结束编码
-        long compressTime = System.nanoTime() - startTime;
-
-        // 3. Gorilla解压缩
-        startTime = System.nanoTime();
-        ByteBuffer buffer = ByteBuffer.wrap(compressedStream.toByteArray());
-        DoublePrecisionDecoderV2 decoder = new DoublePrecisionDecoderV2();
-        List<Double> decompressedData = new ArrayList<>();
-        while (decoder.hasNext(buffer)) { // 假设Decoder有hasNext(ByteBuffer)方法
-            decompressedData.add(decoder.readDouble(buffer));
-        }
-        long decompressTime = System.nanoTime() - startTime;
-
-        // 4. 计算统计信息
-        double originalSize = originalData.size() * 8.0;
-        double compressedSize = compressedStream.size();
-        double compressionRatio = originalSize / compressedSize;
-
-        System.out.println("\nGorilla Compression Results:");
-        System.out.printf("Original size: %.2f bytes\n", originalSize);
-        System.out.printf("Compressed size: %.2f bytes\n", compressedSize);
-        System.out.printf("Compression ratio: %.2f:1\n", compressionRatio);
-        System.out.printf("Compression time: %.3f ms\n", compressTime / 1e6);
-        System.out.printf("Decompression time: %.3f ms\n", decompressTime / 1e6);
-
-        // 5. 验证数据完整性
-        assertEquals(originalData.size(), decompressedData.size());
-    }*/
 }

--- a/java/tsfile/src/test/java/org/apache/tsfile/encoding/decoder/CamelDecoderTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/encoding/decoder/CamelDecoderTest.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.encoding.decoder;
 import org.apache.tsfile.common.bitStream.BitInputStream;
 import org.apache.tsfile.common.bitStream.BitOutputStream;
 import org.apache.tsfile.encoding.encoder.CamelEncoder;
+import org.apache.tsfile.encoding.encoder.DoublePrecisionEncoderV2;
 import org.apache.tsfile.encoding.encoder.Encoder;
 
 import org.junit.Assert;
@@ -278,7 +279,7 @@ public class CamelDecoderTest {
   }
 
   private static final int[] FLUSH_SIZES = {32, 64, 128, 256, 512, 1000};
-  private static final int TOTAL_VALUES = 10_000;
+  private static final int TOTAL_VALUES = 1_000_000;
 
   @Test
   public void testBatchFlushForVariousBlockSizes() throws IOException {
@@ -321,4 +322,74 @@ public class CamelDecoderTest {
           decoder.hasNext(buffer));
     }
   }
+
+  private void testCodecPerformance(String label, Encoder encoder, Decoder decoder)
+          throws Exception {
+
+    System.out.printf("==== Testing %s Encoder/Decoder ====%n", label);
+
+    Random random = new Random(123);
+
+    for (int blockSize : FLUSH_SIZES) {
+      double[] input = new double[TOTAL_VALUES];
+
+      // Generate reproducible random double values (excluding NaN/Inf)
+      for (int i = 0; i < TOTAL_VALUES; i++) {
+        double v;
+        do {
+          v = Double.longBitsToDouble(random.nextLong());
+        } while (Double.isNaN(v) || Double.isInfinite(v));
+        input[i] = v;
+      }
+
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+      // Encode and time it
+      long encodeStart = System.nanoTime();
+      for (int i = 0; i < TOTAL_VALUES; i++) {
+        encoder.encode(input[i], out);
+        if ((i + 1) % blockSize == 0) {
+          encoder.flush(out);
+        }
+      }
+      encoder.flush(out);
+      long encodeEnd = System.nanoTime();
+
+      byte[] encodedBytes = out.toByteArray();
+      double encodeTimeMs = (encodeEnd - encodeStart) / 1_000_000.0;
+      double encodeThroughput = TOTAL_VALUES / encodeTimeMs;
+
+      // Decode and time it
+      ByteBuffer buffer = ByteBuffer.wrap(encodedBytes);
+      long decodeStart = System.nanoTime();
+      int count = 0;
+      while (decoder.hasNext(buffer)) {
+        decoder.readDouble(buffer);
+        count++;
+      }
+      long decodeEnd = System.nanoTime();
+
+      double decodeTimeMs = (decodeEnd - decodeStart) / 1_000_000.0;
+      double decodeThroughput = count / decodeTimeMs;
+
+      System.out.printf(
+              "%s | BlockSize=%3d | EncodedSize=%.2f KB | Encode=%.2f ms | Decode=%.2f ms | Enc=%.2f M/s | Dec=%.2f M/s%n",
+              label,
+              blockSize,
+              encodedBytes.length / 1024.0,
+              encodeTimeMs,
+              decodeTimeMs,
+              encodeThroughput / 1_000_000,
+              decodeThroughput / 1_000_000);
+    }
+
+    System.out.println();
+  }
+
+  @Test
+  public void testCamelCodecPerformanceWithDerivedClasses() throws Exception {
+    testCodecPerformance("Camel", new CamelEncoder(), new CamelDecoder());
+    testCodecPerformance("DoubleV2", new DoublePrecisionEncoderV2(), new DoublePrecisionDecoderV2());
+  }
+
 }

--- a/java/tsfile/src/test/java/org/apache/tsfile/encoding/decoder/CamelDecoderTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/encoding/decoder/CamelDecoderTest.java
@@ -1,0 +1,112 @@
+package org.apache.tsfile.encoding.decoder;
+
+import org.apache.tsfile.encoding.encoder.CamelEncoder;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+
+public class CamelDecoderTest {
+    @Test
+    public void testSimpleCaseForDebug() throws Exception {
+        double[] original = new double[] { -536641.84,  -536641.83 };
+        CamelEncoder compressor = new CamelEncoder();
+        // 压缩所有数据点
+        for (double v : original) {
+            compressor.addValue(v);
+        }
+        long totalWrittenBits = compressor.close();
+        ByteArrayOutputStream compressed = compressor.getByteArrayOutputStream();
+
+        // 解压并比对
+        InputStream inputStream = new ByteArrayInputStream(compressed.toByteArray());
+        CamelDecoder decompressor = new CamelDecoder(inputStream, totalWrittenBits);
+        List<Double> result = decompressor.getValues();
+        assertEquals(original.length, result.size());
+        for (int i = 0; i < original.length; i++) {
+            // 允许很小的浮点误差，例如 1e-9
+            assertEquals(original[i], result.get(i), 1e-4);
+        }
+    }
+
+    @Test
+    public void testBasicCompressDecompress() throws Exception {
+        // 原始测试数据（保留原有测试用例）
+        double[] original = new double[] {
+                100.0, -100.52, 100.75, 100.23, 101.25, 100.25,
+                // 新增测试数据：覆盖 .01 ~ .99 的小数部分
+                100.01, 100.02, 100.03, 100.04, 100.05, 100.06, 100.07, 100.08, 100.09,
+                100.10, 100.11, 100.12, 100.13, 100.14, 100.15, 100.16, 100.17, 100.18, 100.19,
+                100.20, 100.21, 100.22, 100.23, 100.24, 100.25, 100.26, 100.27, 100.28, 100.29,
+                100.30, 100.31, 100.32, 100.33, 100.34, 100.35, 100.36, 100.37, 100.38, 100.39,
+                100.40, 100.41, 100.42, 100.43, 100.44, 100.45, 100.46, 100.47, 100.48, 100.49,
+                100.50, 100.51, 100.52, 100.53, 100.54, 100.55, 100.56, 100.57, 100.58, 100.59,
+                100.60, 100.61, 100.62, 100.63, 100.64, 100.65, 100.66, 100.67, 100.68, 100.69,
+                100.70, 100.71, 100.72, 100.73, 100.74, 100.75, 100.76, 100.77, 100.78, 100.79,
+                100.80, 100.81, 100.82, 100.83, 100.84, 100.85, 100.86, 100.87, 100.88, 100.89,
+                100.90, 100.91, 100.92, 100.93, 100.94, 100.95, 100.96, 100.97, 100.98, 100.99,
+                // 额外边界测试
+                -100.01, -100.99, 0.01, 0.99, 999.99, -999.99
+        };
+
+        CamelEncoder compressor = new CamelEncoder();
+        // 压缩所有数据点
+        for (double v : original) {
+            compressor.addValue(v);
+        }
+        long totalWrittenBits = compressor.close();
+        ByteArrayOutputStream compressed = compressor.getByteArrayOutputStream();
+
+        // 解压并比对
+        InputStream inputStream = new ByteArrayInputStream(compressed.toByteArray());
+        CamelDecoder decompressor = new CamelDecoder(inputStream, totalWrittenBits);
+        List<Double> result = decompressor.getValues();
+        assertEquals(original.length, result.size());
+        for (int i = 0; i < original.length; i++) {
+            // 允许很小的浮点误差，例如 1e-4
+            assertEquals(original[i], result.get(i), 1e-4);
+        }
+    }
+
+    @Test
+    public void testRandomizedCompressDecompress() throws Exception {
+        // 初始化随机数生成器
+        Random random = new Random();
+        int sampleSize = 1000;  // 恢复为100,000组测试数据
+        double[] original = new double[sampleSize];
+
+        // 生成随机测试数据
+        for (int i = 0; i < sampleSize; i++) {
+            // 随机整数部分：-1,000,000 ~ 1,000,000
+            int intPart = random.nextInt(2_000_001) - 1_000_000;
+            // 随机小数部分：0.01 ~ 0.99（保留两位小数）
+            double decimalPart = 0.01 + random.nextInt(99) * 0.01;
+            // 组合为完整浮点数
+            original[i] = intPart + decimalPart;
+        }
+
+        CamelEncoder compressor = new CamelEncoder();
+        // 压缩所有数据点
+        for (double v : original) {
+            compressor.addValue(v);
+        }
+        long totalWrittenBits = compressor.close();
+        ByteArrayOutputStream compressed = compressor.getByteArrayOutputStream();
+
+        // 解压并比对
+        InputStream inputStream = new ByteArrayInputStream(compressed.toByteArray());
+        CamelDecoder decompressor = new CamelDecoder(inputStream, totalWrittenBits);
+        List<Double> result = decompressor.getValues();
+
+        assertEquals(original.length, result.size());
+        for (int i = 0; i < original.length; i++) {
+            // 允许浮点误差（1e-4）
+            assertEquals(original[i], result.get(i), 1e-4);
+        }
+    }
+}

--- a/java/tsfile/src/test/java/org/apache/tsfile/encoding/decoder/CamelDecoderTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/encoding/decoder/CamelDecoderTest.java
@@ -1,29 +1,24 @@
 package org.apache.tsfile.encoding.decoder;
 
+import org.apache.tsfile.common.bitStream.BitInputStream;
+import org.apache.tsfile.common.bitStream.BitOutputStream;
 import org.apache.tsfile.encoding.encoder.CamelEncoder;
-import org.apache.tsfile.encoding.encoder.DoublePrecisionEncoderV2;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 
 public class CamelDecoderTest {
     @Test
     public void testSimpleCaseForDebug() throws Exception {
-        System.out.println("Double.MIN=" + Double.MIN_VALUE);
-        double[] original = new double[] { 0.1, 0.12345 };
+        double[] original = new double[]{100.0, -100.52};
         CamelEncoder compressor = new CamelEncoder();
         // 压缩所有数据点
         for (double v : original) {
@@ -43,6 +38,164 @@ public class CamelDecoderTest {
         }
     }
 
+
+    @Test
+    public void testBasicCompressDecompress() throws Exception {
+        // 原始测试数据（保留原有测试用例）
+        double[] original = new double[] {
+                100.0, -100.52, 100.75, 100.23, 101.25, 100.25,
+                // 新增测试数据：覆盖 .01 ~ .99 的小数部分
+                100.01, 100.02, 100.03, 100.04, 100.05, 100.06, 100.07, 100.08, 100.09,
+                100.10, 100.11, 100.12, 100.13, 100.14, 100.15, 100.16, 100.17, 100.18, 100.19,
+                100.20, 100.21, 100.22, 100.23, 100.24, 100.25, 100.26, 100.27, 100.28, 100.29,
+                100.30, 100.31, 100.32, 100.33, 100.34, 100.35, 100.36, 100.37, 100.38, 100.39,
+                100.40, 100.41, 100.42, 100.43, 100.44, 100.45, 100.46, 100.47, 100.48, 100.49,
+                100.50, 100.51, 100.52, 100.53, 100.54, 100.55, 100.56, 100.57, 100.58, 100.59,
+                100.60, 100.61, 100.62, 100.63, 100.64, 100.65, 100.66, 100.67, 100.68, 100.69,
+                100.70, 100.71, 100.72, 100.73, 100.74, 100.75, 100.76, 100.77, 100.78, 100.79,
+                100.80, 100.81, 100.82, 100.83, 100.84, 100.85, 100.86, 100.87, 100.88, 100.89,
+                100.90, 100.91, 100.92, 100.93, 100.94, 100.95, 100.96, 100.97, 100.98, 100.99,
+                // 额外边界测试
+                -100.01, -100.99, 0.01, 0.99, 999.99, -999.99
+        };
+
+        CamelEncoder compressor = new CamelEncoder();
+        // 压缩所有数据点
+        for (double v : original) {
+            compressor.addValue(v);
+        }
+        long totalWrittenBits = compressor.close();
+        ByteArrayOutputStream compressed = compressor.getByteArrayOutputStream();
+
+        // 解压并比对
+        InputStream inputStream = new ByteArrayInputStream(compressed.toByteArray());
+        CamelDecoder decompressor = new CamelDecoder(inputStream, totalWrittenBits);
+        List<Double> result = decompressor.getValues();
+        assertEquals(original.length, result.size());
+        for (int i = 0; i < original.length; i++) {
+            // 允许很小的浮点误差，例如 1e-4
+            assertEquals(original[i], result.get(i), 1e-4);
+        }
+    }
+
+    @Test
+    public void testRandomizedCompressDecompress() throws Exception {
+        // 初始化随机数生成器
+        Random random = new Random();
+        int sampleSize = 10000;  // 恢复为10,000组测试数据
+        double[] original = new double[sampleSize];
+
+        // 生成随机测试数据
+        for (int i = 0; i < sampleSize; i++) {
+            // 随机整数部分：INT32_MIN >> 1 ~ INT32_MAX >> 1
+            int intPart = random.nextInt(Integer.MAX_VALUE) - (Integer.MAX_VALUE >> 1);
+            // 随机小数部分：0.0001 ~ 0.9999（保留四位小数）
+            double decimalPart = 0.0001 + random.nextInt(9999) * 0.0001;
+            // 组合为完整浮点数
+            original[i] = intPart + decimalPart;
+        }
+
+        CamelEncoder compressor = new CamelEncoder();
+        // 压缩所有数据点
+        for (double v : original) {
+            compressor.addValue(v);
+        }
+        long totalWrittenBits = compressor.close();
+        ByteArrayOutputStream compressed = compressor.getByteArrayOutputStream();
+
+        // 解压并比对
+        InputStream inputStream = new ByteArrayInputStream(compressed.toByteArray());
+        CamelDecoder decompressor = new CamelDecoder(inputStream, totalWrittenBits);
+        List<Double> result = decompressor.getValues();
+
+        assertEquals(original.length, result.size());
+        for (int i = 0; i < original.length; i++) {
+            // 允许浮点误差（1e-4）
+            assertEquals(original[i], result.get(i), 1e-4);
+        }
+    }
+
+    private void testGorillaValues(double[] values) throws Exception {
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        BitOutputStream out = new BitOutputStream(bout);
+
+        CamelEncoder.GorillaEncoder encoder = new CamelEncoder.GorillaEncoder();
+        for (double v : values) {
+            encoder.encode(v, out);
+        }
+        encoder.close(out);
+
+        byte[] encoded = bout.toByteArray();
+        BitInputStream in = new BitInputStream(new ByteArrayInputStream(encoded), out.getBitsWritten());
+        CamelDecoder.GorillaDecoder decoder = new CamelDecoder.GorillaDecoder();
+
+        int idx = 0;
+        for (double expected : values) {
+            double actual = decoder.decode(in);
+            Assert.assertEquals("Mismatch decoding: ", expected, actual, 0.0);
+        }
+    }
+
+    @Test
+    public void testGorillaAllZeros() throws Exception {
+        double[] values = new double[100];
+        Arrays.fill(values, 0.0);
+        testGorillaValues(values);
+    }
+
+    @Test
+    public void testGorillaConstantValue() throws Exception {
+        double[] values = new double[200];
+        Arrays.fill(values, 123456.789);
+        testGorillaValues(values);
+    }
+
+    @Test
+    public void testGorillaMinMaxValues() throws Exception {
+        double[] values = {
+                Double.MIN_VALUE,
+                Double.MAX_VALUE,
+                -Double.MAX_VALUE,
+                -Double.MIN_VALUE,
+                0.0, -0.0
+        };
+        testGorillaValues(values);
+    }
+
+    @Test
+    public void testGorillaMixedSigns() throws Exception {
+        double[] values = {-1.1, 2.2, -3.3, 4.4, -5.5, 6.6, -7.7};
+        testGorillaValues(values);
+    }
+
+    @Test
+    public void testGorillaHighPrecisionValues() throws Exception {
+        double[] values = {0.1, 0.2, 0.3, 0.1 + 0.2, 0.4 - 0.1};
+        testGorillaValues(values);
+    }
+
+    @Test
+    public void testGorillaXorEdgeTrigger() throws Exception {
+        double[] values = {
+                1.00000001,
+                1.00000002,
+                1.00000003,
+                1.00000001,  // back to earlier
+                1.00000009
+        };
+        testGorillaValues(values);
+    }
+
+    @Test
+    public void testLargeSeries() throws Exception {
+        double[] values = new double[1000];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = Math.sin(i / 10.0);
+        }
+        testGorillaValues(values);
+    }
+
+/*
     @Test
     public void testCityTempCompression() throws Exception {
         // 1. 读取CSV文件
@@ -276,81 +429,5 @@ public class CamelDecoderTest {
 
         // 5. 验证数据完整性
         assertEquals(originalData.size(), decompressedData.size());
-    }
-
-    @Test
-    public void testBasicCompressDecompress() throws Exception {
-        // 原始测试数据（保留原有测试用例）
-        double[] original = new double[] {
-                100.0, -100.52, 100.75, 100.23, 101.25, 100.25,
-                // 新增测试数据：覆盖 .01 ~ .99 的小数部分
-                100.01, 100.02, 100.03, 100.04, 100.05, 100.06, 100.07, 100.08, 100.09,
-                100.10, 100.11, 100.12, 100.13, 100.14, 100.15, 100.16, 100.17, 100.18, 100.19,
-                100.20, 100.21, 100.22, 100.23, 100.24, 100.25, 100.26, 100.27, 100.28, 100.29,
-                100.30, 100.31, 100.32, 100.33, 100.34, 100.35, 100.36, 100.37, 100.38, 100.39,
-                100.40, 100.41, 100.42, 100.43, 100.44, 100.45, 100.46, 100.47, 100.48, 100.49,
-                100.50, 100.51, 100.52, 100.53, 100.54, 100.55, 100.56, 100.57, 100.58, 100.59,
-                100.60, 100.61, 100.62, 100.63, 100.64, 100.65, 100.66, 100.67, 100.68, 100.69,
-                100.70, 100.71, 100.72, 100.73, 100.74, 100.75, 100.76, 100.77, 100.78, 100.79,
-                100.80, 100.81, 100.82, 100.83, 100.84, 100.85, 100.86, 100.87, 100.88, 100.89,
-                100.90, 100.91, 100.92, 100.93, 100.94, 100.95, 100.96, 100.97, 100.98, 100.99,
-                // 额外边界测试
-                -100.01, -100.99, 0.01, 0.99, 999.99, -999.99
-        };
-
-        CamelEncoder compressor = new CamelEncoder();
-        // 压缩所有数据点
-        for (double v : original) {
-            compressor.addValue(v);
-        }
-        long totalWrittenBits = compressor.close();
-        ByteArrayOutputStream compressed = compressor.getByteArrayOutputStream();
-
-        // 解压并比对
-        InputStream inputStream = new ByteArrayInputStream(compressed.toByteArray());
-        CamelDecoder decompressor = new CamelDecoder(inputStream, totalWrittenBits);
-        List<Double> result = decompressor.getValues();
-        assertEquals(original.length, result.size());
-        for (int i = 0; i < original.length; i++) {
-            // 允许很小的浮点误差，例如 1e-4
-            assertEquals(original[i], result.get(i), 1e-4);
-        }
-    }
-
-    @Test
-    public void testRandomizedCompressDecompress() throws Exception {
-        // 初始化随机数生成器
-        Random random = new Random();
-        int sampleSize = 100000;  // 恢复为100,000组测试数据
-        double[] original = new double[sampleSize];
-
-        // 生成随机测试数据
-        for (int i = 0; i < sampleSize; i++) {
-            // 随机整数部分：INT32_MIN >> 1 ~ INT32_MAX >> 1
-            int intPart = random.nextInt(Integer.MAX_VALUE) - (Integer.MAX_VALUE >> 1);
-            // 随机小数部分：0.0001 ~ 0.9999（保留四位小数）
-            double decimalPart = 0.0001 + random.nextInt(9999) * 0.0001;
-            // 组合为完整浮点数
-            original[i] = intPart + decimalPart;
-        }
-
-        CamelEncoder compressor = new CamelEncoder();
-        // 压缩所有数据点
-        for (double v : original) {
-            compressor.addValue(v);
-        }
-        long totalWrittenBits = compressor.close();
-        ByteArrayOutputStream compressed = compressor.getByteArrayOutputStream();
-
-        // 解压并比对
-        InputStream inputStream = new ByteArrayInputStream(compressed.toByteArray());
-        CamelDecoder decompressor = new CamelDecoder(inputStream, totalWrittenBits);
-        List<Double> result = decompressor.getValues();
-
-        assertEquals(original.length, result.size());
-        for (int i = 0; i < original.length; i++) {
-            // 允许浮点误差（1e-4）
-            assertEquals(original[i], result.get(i), 1e-4);
-        }
-    }
+    }*/
 }

--- a/java/tsfile/src/test/java/org/apache/tsfile/encoding/decoder/CamelDecoderTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/encoding/decoder/CamelDecoderTest.java
@@ -22,8 +22,6 @@ package org.apache.tsfile.encoding.decoder;
 import org.apache.tsfile.common.bitStream.BitInputStream;
 import org.apache.tsfile.common.bitStream.BitOutputStream;
 import org.apache.tsfile.encoding.encoder.CamelEncoder;
-import org.apache.tsfile.encoding.encoder.DoublePrecisionEncoderV2;
-import org.apache.tsfile.encoding.encoder.Encoder;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -258,26 +256,6 @@ public class CamelDecoderTest {
     testGorillaValues(values);
   }
 
-  @Test
-  public void testCamelMultiFlush() throws IOException {
-    Encoder encoder = new CamelEncoder();
-    ByteArrayOutputStream bout = new ByteArrayOutputStream();
-    for (int i = 0; i < 10; i++) {
-      for (int j = 0; j < 10; j++) {
-        encoder.encode((double) i, bout);
-      }
-      encoder.flush(bout);
-    }
-
-    Decoder decoder = new CamelDecoder();
-    ByteBuffer buffer = ByteBuffer.wrap(bout.toByteArray());
-    while (decoder.hasNext(buffer)) {
-      double val = decoder.readDouble(buffer);
-      System.out.println(val);
-      // Assert.assertEquals(1.0, val, 0.0);
-    }
-  }
-
   private static final int[] FLUSH_SIZES = {32, 64, 128, 256, 512, 1000};
   private static final int TOTAL_VALUES = 1_000_000;
 
@@ -322,74 +300,4 @@ public class CamelDecoderTest {
           decoder.hasNext(buffer));
     }
   }
-
-  private void testCodecPerformance(String label, Encoder encoder, Decoder decoder)
-          throws Exception {
-
-    System.out.printf("==== Testing %s Encoder/Decoder ====%n", label);
-
-    Random random = new Random(123);
-
-    for (int blockSize : FLUSH_SIZES) {
-      double[] input = new double[TOTAL_VALUES];
-
-      // Generate reproducible random double values (excluding NaN/Inf)
-      for (int i = 0; i < TOTAL_VALUES; i++) {
-        double v;
-        do {
-          v = Double.longBitsToDouble(random.nextLong());
-        } while (Double.isNaN(v) || Double.isInfinite(v));
-        input[i] = v;
-      }
-
-      ByteArrayOutputStream out = new ByteArrayOutputStream();
-
-      // Encode and time it
-      long encodeStart = System.nanoTime();
-      for (int i = 0; i < TOTAL_VALUES; i++) {
-        encoder.encode(input[i], out);
-        if ((i + 1) % blockSize == 0) {
-          encoder.flush(out);
-        }
-      }
-      encoder.flush(out);
-      long encodeEnd = System.nanoTime();
-
-      byte[] encodedBytes = out.toByteArray();
-      double encodeTimeMs = (encodeEnd - encodeStart) / 1_000_000.0;
-      double encodeThroughput = TOTAL_VALUES / encodeTimeMs;
-
-      // Decode and time it
-      ByteBuffer buffer = ByteBuffer.wrap(encodedBytes);
-      long decodeStart = System.nanoTime();
-      int count = 0;
-      while (decoder.hasNext(buffer)) {
-        decoder.readDouble(buffer);
-        count++;
-      }
-      long decodeEnd = System.nanoTime();
-
-      double decodeTimeMs = (decodeEnd - decodeStart) / 1_000_000.0;
-      double decodeThroughput = count / decodeTimeMs;
-
-      System.out.printf(
-              "%s | BlockSize=%3d | EncodedSize=%.2f KB | Encode=%.2f ms | Decode=%.2f ms | Enc=%.2f M/s | Dec=%.2f M/s%n",
-              label,
-              blockSize,
-              encodedBytes.length / 1024.0,
-              encodeTimeMs,
-              decodeTimeMs,
-              encodeThroughput / 1_000_000,
-              decodeThroughput / 1_000_000);
-    }
-
-    System.out.println();
-  }
-
-  @Test
-  public void testCamelCodecPerformanceWithDerivedClasses() throws Exception {
-    testCodecPerformance("Camel", new CamelEncoder(), new CamelDecoder());
-    testCodecPerformance("DoubleV2", new DoublePrecisionEncoderV2(), new DoublePrecisionDecoderV2());
-  }
-
 }

--- a/java/tsfile/src/test/java/org/apache/tsfile/write/TsFileReadWriteTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/write/TsFileReadWriteTest.java
@@ -151,7 +151,8 @@ public class TsFileReadWriteTest {
             TSEncoding.RLE,
             TSEncoding.TS_2DIFF,
             TSEncoding.GORILLA_V1,
-            TSEncoding.GORILLA);
+            TSEncoding.GORILLA,
+            TSEncoding.CAMEL);
     for (TSEncoding encoding : encodings) {
       doubleTest(encoding);
     }


### PR DESCRIPTION
### Camel Algorithm Implementation
#### Core Strategy
Splits double-precision floats into integer and decimal components:

- Integer part: Stable differences → Differential encoding
- Decimal part: High volatility → Optimized XOR compression

#### INTEGER ENCODING (Algorithm 1)

1. First value: Store as raw 64-bit block
2. Subsequent values:

```
Calculate diff = current_int - previous_int
|diff| ≤ 1 → Encode as (diff+1) in 2 bits
|diff| > 1 →
  diff < 8 → '0' prefix + 3-bit value
  diff ≥ 8 → '1' prefix + 16-bit value
```
#### DECIMAL ENCODING (Algorithm 2)

- Calculate decimal places l (stored in 2 bits. e.g., 3.141 → l=3)
- Compute dxor reference:  dxor = value.decimal - (2^-l * floor(value.decimal / 2^-l))
   Example: For value=1.234 (l=3), dxor=1.234 - 0.125=1.109 → XOR yields **​more trailing zeros​ than Gorilla's approach**.
- XOR: v ↔ dxor → Extract center bits (Store ​only center bits​ (length=l) + dxor)
- **Extra optimization**: Gorilla fallback
When l > threshold (e.g., 10+): Revert to Gorilla's XOR-with-prior method.Prevents overflow in dxor calculations

#### ENGINEERING IMPROVEMENTS
- BitStream integration: WriteVarInt for compact integer storage
- Safety mechanism: Gorilla fallback prevents overflows

#### Comparison with Gorilla Encoding:​​
The Camel algorithm demonstrates slightly inferior read/write performance compared to Gorilla encoding. However, it achieves higher compression ratios when processing non-repetitive data with strong regularity patterns (such as arithmetic sequences).

#### Performance Testing Using the Dataset from the Camel Paper
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/76141/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/76141/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
</head>

<body link="#0563C1" vlink="#954F72">


文件名 | 原文件大小(MB) | Camel写入耗时(ms) | gorilla写入耗时(ms) | camel读取耗时(ms) | gorilla读取耗时(ms) | camel压缩文件大小(MB) | gorilla压缩文件大小(MB) | camel压缩比 | gorilla压缩比
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
Air-pressure.csv | 0.93 | 515 | 75 | 167 | 23 | 0.44 | 0.65 | 2.14 | 1.43
Air-sensor.csv | 0.16 | 30 | 21 | 6 | 3 | 0.07 | 0.07 | 2.31 | 2.38
Basel-temp.csv | 1.03 | 68 | 37 | 29 | 22 | 0.52 | 0.79 | 1.98 | 1.31
Basel-wind.csv | 0.99 | 68 | 24 | 25 | 10 | 0.5 | 0.78 | 1.95 | 1.26
Bird-migration.csv | 0.81 | 26 | 17 | 15 | 8 | 0.4 | 0.58 | 2.03 | 1.39
Bitcoin-price.csv | 0.08 | 5 | 3 | 2 | 1 | 0.03 | 0.05 | 2.43 | 1.61
Blockchain-tr.csv | 0.75 | 40 | 17 | 14 | 7 | 0.43 | 0.58 | 1.77 | 1.29
City-lat.csv | 0.35 | 12 | 8 | 6 | 3 | 0.17 | 0.33 | 2.08 | 1.07
City-lon.csv | 0.37 | 11 | 8 | 5 | 3 | 0.18 | 0.33 | 2.02 | 1.11
City-temp.csv | 0.54 | 17 | 13 | 11 | 7 | 0.3 | 0.69 | 1.83 | 0.78
Cpu-usage.csv | 1.24 | 28 | 18 | 13 | 8 | 0.6 | 0.74 | 2.08 | 1.68
Cpu-usage_right.csv | 1.13 | 26 | 19 | 11 | 6 | 0.58 | 0.73 | 1.96 | 1.55
Dew-point-temp.csv | 0.67 | 18 | 13 | 10 | 8 | 0.32 | 0.66 | 2.11 | 1.01
Disk-usage.csv | 1.02 | 25 | 13 | 11 | 5 | 0.56 | 0.69 | 1.81 | 1.48
electric_vehicle_charging.csv | 0.02 | 3 | 2 | 1 | 2 | 0.01 | 0.03 | 1.71 | 0.71
Food-price.csv | 0.65 | 20 | 13 | 10 | 6 | 0.31 | 0.48 | 2.09 | 1.35
init.csv | 0.56 | 17 | 14 | 10 | 8 | 0.31 | 0.68 | 1.84 | 0.82
IR-bio-temp.csv | 0.66 | 22 | 12 | 9 | 7 | 0.32 | 0.61 | 2.07 | 1.08
Mem-usage.csv | 1.13 | 25 | 14 | 10 | 6 | 0.55 | 0.68 | 2.05 | 1.67
PM10-dust.csv | 0.66 | 20 | 15 | 11 | 7 | 0.3 | 0.4 | 2.21 | 1.66
POI-lat.csv | 1.91 | 50 | 24 | 9 | 6 | 0.83 | 0.8 | 2.31 | 2.38
POI-lon.csv | 1.95 | 39 | 27 | 9 | 6 | 0.83 | 0.8 | 2.35 | 2.42
SSD-bench.csv | 0.06 | 3 | 3 | 1 | 1 | 0.03 | 0.04 | 1.83 | 1.3
Stocks-DE.csv | 0.7 | 18 | 13 | 10 | 6 | 0.35 | 0.59 | 2.02 | 1.19
Stocks-UK.csv | 0.69 | 19 | 15 | 10 | 6 | 0.3 | 0.49 | 2.26 | 1.4
Stocks-USA.csv | 0.68 | 17 | 15 | 10 | 6 | 0.32 | 0.56 | 2.12 | 1.21
test.csv | 0 | 1 | 1 | 0 | 1 | 0 | 0 | 0.13 | 0.12
Wind-Speed.csv | 0.56 | 18 | 13 | 10 | 6 | 0.31 | 0.68 | 1.84 | 0.82



</body>

</html>


<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/76141/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/76141/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
</head>

<body link="#0563C1" vlink="#954F72">


数据集 | 原数据大小(MB) | Camel写入耗时(ms) | Gorilla写入耗时(ms) | Camel读取耗时(ms) | Gorilla读取耗时(ms) | Camel压缩文件大小(MB) | Gorilla压缩文件大小(MB) | Camel压缩比 | Gorilla压缩比
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
arithmetic | 7.63 | 653 | 176 | 261 | 110 | 3.28 | 5.63 | 2.33 | 1.36
random | 7.63 | 181 | 104 | 117 | 60 | 4.87 | 7.09 | 1.57 | 1.08
repeated | 7.63 | 161 | 59 | 94 | 43 | 4.46 | 0.29 | 1.71 | 26.09
</body>

</html>
