### PR TITLE
Refactor UnknownType to extend AbstractType

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/type/UnknownType.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/type/UnknownType.java
@@ -19,13 +19,14 @@
 
 package org.apache.tsfile.read.common.type;
 
-import static org.apache.tsfile.utils.Preconditions.checkArgument;
-
-import java.util.Collections;
-import java.util.List;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnBuilder;
 import org.apache.tsfile.read.common.block.column.BooleanColumnBuilder;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.tsfile.utils.Preconditions.checkArgument;
 
 public class UnknownType extends AbstractType {
   public static final UnknownType UNKNOWN = new UnknownType();

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/type/UnknownType.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/type/UnknownType.java
@@ -19,16 +19,15 @@
 
 package org.apache.tsfile.read.common.type;
 
+import static org.apache.tsfile.utils.Preconditions.checkArgument;
+
+import java.util.Collections;
+import java.util.List;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnBuilder;
 import org.apache.tsfile.read.common.block.column.BooleanColumnBuilder;
 
-import java.util.Collections;
-import java.util.List;
-
-import static org.apache.tsfile.utils.Preconditions.checkArgument;
-
-public class UnknownType implements Type {
+public class UnknownType extends AbstractType {
   public static final UnknownType UNKNOWN = new UnknownType();
   public static final String NAME = "unknown";
 


### PR DESCRIPTION
This pull request refactors the `UnknownType` class in the `java/tsfile` module to improve code structure and maintainability. The primary change involves modifying the inheritance hierarchy of the `UnknownType` class.

### Code structure improvements:

* [`java/tsfile/src/main/java/org/apache/tsfile/read/common/type/UnknownType.java`](diffhunk://#diff-f62ae8c30afb936a6cd19cb1d1610ddad61d1ab7da62fbfc35ffef6fb31abd86L22-R30): Changed the `UnknownType` class to extend `AbstractType` instead of directly implementing the `Type` interface, aligning it with other type implementations in the codebase.