### PR TITLE
feat: add markRange / unmarkRange / merge for high-performance bit manipulation

### DIFF
--- a/java/common/src/main/java/org/apache/tsfile/utils/BitMap.java
+++ b/java/common/src/main/java/org/apache/tsfile/utils/BitMap.java
@@ -74,6 +74,35 @@ public class BitMap {
     bits[position / Byte.SIZE] |= BIT_UTIL[position % Byte.SIZE];
   }
 
+  public void markRange(int startPosition, int length) {
+    if (length <= 0) {
+      return;
+    }
+
+    if (startPosition < 0 || startPosition + length > size) {
+      throw new IndexOutOfBoundsException(
+          "startPosition " + startPosition + " + length " + length + " is out of range " + size);
+    }
+
+    int bitEnd = startPosition + length - 1;
+    int byte0 = startPosition >>> 3;
+    int byte1 = bitEnd >>> 3;
+
+    if (byte0 == byte1) {
+      int mask = ((1 << length) - 1) << (startPosition & 7);
+      bits[byte0] |= (byte) mask;
+      return;
+    }
+
+    bits[byte0++] |= (byte) (0xFF << (startPosition & 7));
+
+    while (byte0 < byte1) {
+      bits[byte0++] = (byte) 0xFF;
+    }
+
+    bits[byte1] |= (byte) (0xFF >>> (7 - (bitEnd & 7)));
+  }
+
   /** mark as 0 at all positions. */
   public void reset() {
     Arrays.fill(bits, (byte) 0);
@@ -81,6 +110,69 @@ public class BitMap {
 
   public void unmark(int position) {
     bits[position / Byte.SIZE] &= UNMARK_BIT_UTIL[position % Byte.SIZE];
+  }
+
+  public void unmarkRange(int startPosition, int length) {
+    if (length <= 0) {
+      return;
+    }
+
+    if (startPosition < 0 || startPosition + length > size) {
+      throw new IndexOutOfBoundsException(
+          "startPosition " + startPosition + " + length " + length + " is out of range " + size);
+    }
+
+    int bitEnd = startPosition + length - 1;
+    int byte0 = startPosition >>> 3;
+    int byte1 = bitEnd >>> 3;
+
+    if (byte0 == byte1) {
+      int clearBits = ((1 << length) - 1) << (startPosition & 7);
+      bits[byte0] &= (byte) ~clearBits;
+      return;
+    }
+
+    bits[byte0++] &= (byte) (0xFF << ((startPosition & 7) + 1));
+
+    while (byte0 < byte1) {
+      bits[byte0++] = 0;
+    }
+
+    bits[byte1] &= (byte) (0xFF << ((bitEnd & 7) + 1));
+  }
+
+  public void merge(BitMap src, int srcStart, int destStart, int len) {
+    if (len <= 0) return;
+    if (srcStart < 0 || destStart < 0 || srcStart + len > src.size || destStart + len > this.size) {
+      throw new IndexOutOfBoundsException();
+    }
+
+    int done = 0;
+    int dstBit = destStart & 7;
+    while (done < len) {
+      int size = Math.min(len - done, 64);
+      long bits = extractBits(src.bits, srcStart + done, size);
+      int destStartByte = (destStart + done) >>> 3;
+      this.bits[destStartByte++] |= (byte) ((bits << dstBit) & 255L);
+      bits = bits >>> (8 - dstBit);
+      while (bits > 0L) {
+        this.bits[destStartByte++] |= (byte) (bits & 255L);
+        bits = bits >>> 8;
+      }
+      done += size;
+    }
+  }
+
+  private long extractBits(byte[] buf, int off, int len) {
+    int start = off >>> 3;
+    int size = 8 - (off & 7);
+    long val = (buf[start++] & 0xFFL) >>> (off & 7);
+    while (size < len) {
+      val |= ((buf[start++] & 0xFFL) << size);
+      size += 8;
+    }
+
+    return val & (0xffff_ffff_ffff_ffffL >>> (64 - len));
   }
 
   /** whether all bits are zero, i.e., no Null value */

--- a/java/common/src/main/java/org/apache/tsfile/utils/BitMap.java
+++ b/java/common/src/main/java/org/apache/tsfile/utils/BitMap.java
@@ -89,8 +89,7 @@ public class BitMap {
     int byte1 = bitEnd >>> 3;
 
     if (byte0 == byte1) {
-      int mask = ((1 << length) - 1) << (startPosition & 7);
-      bits[byte0] |= (byte) mask;
+      bits[byte0] |= (byte) (((1 << length) - 1) << (startPosition & 7));
       return;
     }
 
@@ -127,12 +126,11 @@ public class BitMap {
     int byte1 = bitEnd >>> 3;
 
     if (byte0 == byte1) {
-      int clearBits = ((1 << length) - 1) << (startPosition & 7);
-      bits[byte0] &= (byte) ~clearBits;
+      bits[byte0] &= (byte) ~(((1 << length) - 1) << (startPosition & 7));
       return;
     }
 
-    bits[byte0++] &= (byte) (0xFF << ((startPosition & 7) + 1));
+    bits[byte0++] &= (byte) ~(0xFF << (startPosition & 7));
 
     while (byte0 < byte1) {
       bits[byte0++] = 0;

--- a/java/tsfile/src/test/java/org/apache/tsfile/utils/BitMapTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/utils/BitMapTest.java
@@ -20,6 +20,9 @@ package org.apache.tsfile.utils;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Random;
+
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -103,5 +106,104 @@ public class BitMapTest {
     assertEquals(2, truncatedArray.length);
 
     assertEquals((byte) 0b00001000, truncatedArray[0]);
+  }
+
+  @Test
+  public void exhaustiveMergeTest() {
+    int maxLen = 96;
+    int maxSize = 128;
+    for (int i = 1; i <= maxLen; i++) {
+      for (int j = i; j <= maxSize; j++) {
+        for (int k = 0; k <= j - i; k++) {
+          for (int m = 0; m <= maxSize - i; m++) {
+            runOneCase(j, k, maxSize, m, i);
+          }
+        }
+      }
+    }
+  }
+
+  private static void runOneCase(int srcSize, int srcStart, int destSize, int destStart, int len) {
+    Random r = new Random();
+    BitMap src = new BitMap(srcSize);
+    BitMap dst = new BitMap(destSize);
+
+    for (int i = 0; i < src.getSize(); i++) {
+      if (r.nextBoolean()) {
+        src.mark(i);
+      }
+    }
+
+    for (int i = 0; i < dst.getSize(); i++) {
+      if (r.nextBoolean()) {
+        dst.mark(i);
+      }
+    }
+
+    BitMap copy =
+        new BitMap(src.getSize(), Arrays.copyOf(dst.getByteArray(), dst.getByteArray().length));
+
+    for (int i = 0; i < len; i++) {
+      if (src.isMarked(srcStart + i)) {
+        copy.mark(destStart + i);
+      }
+    }
+
+    dst.merge(src, srcStart, destStart, len);
+    assertArrayEquals(copy.getByteArray(), dst.getByteArray());
+  }
+
+  @Test
+  public void emptyRange() {
+    BitMap map = new BitMap(1);
+    map.markRange( 0, 0);
+    assertEquals((byte) 0x00, map.getByteArray()[0]);
+  }
+
+  @Test
+  public void singleByteAllBits() {
+    for (int i = 0; i < 8; i++) {
+      for (int j = 0; j <= 8 - i; j++) {
+        doTest(8, i, j);
+      }
+    }
+  }
+
+  @Test
+  public void twoBytesHeadTail() {
+    for (int i = 0; i < 64; i++) {
+      for (int j = 0; j <= 64 - i; j += 8) {
+        doTest(64, i, j);
+      }
+    }
+  }
+
+  @Test
+  public void twoBytesPartialHead() {
+    for (int i = 0; i < 64; i += 8) {
+      for (int j = 0; j <= 64 - i; j += 8) {
+        doTest(64, i, j);
+      }
+    }
+  }
+
+  @Test
+  public void twoBytesPartialTail() {
+    int size = 64;
+    for (int i = 0; i < size; i += 8) {
+      for (int j = 1; j <= size - i; j++) {
+        doTest(size, i, j);
+      }
+    }
+  }
+
+  private void doTest(int size, int start, int length) {
+    BitMap map = new BitMap(size);
+    BitMap bitMap = new BitMap(size);
+    map.markRange(start, length);
+    for (int i = start; i < start + length; i++) {
+      bitMap.mark(i);
+    }
+    assertArrayEquals(map.getByteArray(), bitMap.getByteArray());
   }
 }

--- a/java/tsfile/src/test/java/org/apache/tsfile/utils/BitMapTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/utils/BitMapTest.java
@@ -156,7 +156,7 @@ public class BitMapTest {
   @Test
   public void emptyRange() {
     BitMap map = new BitMap(1);
-    map.markRange( 0, 0);
+    map.markRange(0, 0);
     assertEquals((byte) 0x00, map.getByteArray()[0]);
   }
 
@@ -204,6 +204,13 @@ public class BitMapTest {
     for (int i = start; i < start + length; i++) {
       bitMap.mark(i);
     }
-    assertArrayEquals(map.getByteArray(), bitMap.getByteArray());
+    assertArrayEquals(bitMap.getByteArray(), map.getByteArray());
+
+    map.unmarkRange(start, length);
+    for (int i = start; i < start + length; i++) {
+      bitMap.unmark(i);
+    }
+    System.out.println(start + "        " + length);
+    assertArrayEquals(bitMap.getByteArray(), map.getByteArray());
   }
 }


### PR DESCRIPTION
Optimized: O(1) bulk bit ops, flat 2–3 ns.
Unoptimized (Native): bit-by-bit mark/unmark, O(n) time, ≈1.8 µs at 1024 bits.

```
Benchmark                          (len)  Mode  Cnt     Score     Error  Units
BitMapBenchmark.markRange              1  avgt    5     2.087 ±   0.254  ns/op
BitMapBenchmark.markRange              2  avgt    5     2.095 ±   0.256  ns/op
BitMapBenchmark.markRange              4  avgt    5     2.115 ±   0.162  ns/op
BitMapBenchmark.markRange              8  avgt    5     2.103 ±   0.110  ns/op
BitMapBenchmark.markRange             16  avgt    5     2.195 ±   0.025  ns/op
BitMapBenchmark.markRange             32  avgt    5     2.406 ±   0.009  ns/op
BitMapBenchmark.markRange             64  avgt    5     2.412 ±   0.019  ns/op
BitMapBenchmark.markRange            128  avgt    5     3.207 ±   0.011  ns/op
BitMapBenchmark.markRange            256  avgt    5     3.221 ±   0.039  ns/op
BitMapBenchmark.markRange            512  avgt    5     3.218 ±   0.011  ns/op
BitMapBenchmark.markRange           1024  avgt    5     3.363 ±   0.051  ns/op
BitMapBenchmark.markRangeNative        1  avgt    5     1.918 ±   0.016  ns/op
BitMapBenchmark.markRangeNative        2  avgt    5     3.773 ±   0.231  ns/op
BitMapBenchmark.markRangeNative        4  avgt    5     7.376 ±   0.337  ns/op
BitMapBenchmark.markRangeNative        8  avgt    5    14.839 ±   0.958  ns/op
BitMapBenchmark.markRangeNative       16  avgt    5    15.782 ±   0.265  ns/op
BitMapBenchmark.markRangeNative       32  avgt    5    35.136 ±   2.760  ns/op
BitMapBenchmark.markRangeNative       64  avgt    5    74.027 ±   1.073  ns/op
BitMapBenchmark.markRangeNative      128  avgt    5   183.887 ±   5.462  ns/op
BitMapBenchmark.markRangeNative      256  avgt    5   421.424 ±  45.238  ns/op
BitMapBenchmark.markRangeNative      512  avgt    5   858.598 ±  61.117  ns/op
BitMapBenchmark.markRangeNative     1024  avgt    5  1840.542 ± 237.045  ns/op
BitMapBenchmark.merge                  1  avgt    5     2.360 ±   0.107  ns/op
BitMapBenchmark.merge                  2  avgt    5     2.358 ±   0.038  ns/op
BitMapBenchmark.merge                  4  avgt    5     2.345 ±   0.001  ns/op
BitMapBenchmark.merge                  8  avgt    5     3.093 ±   0.031  ns/op
BitMapBenchmark.merge                 16  avgt    5     3.122 ±   0.212  ns/op
BitMapBenchmark.merge                 32  avgt    5     5.627 ±   0.059  ns/op
BitMapBenchmark.merge                 64  avgt    5     7.969 ±   0.038  ns/op
BitMapBenchmark.merge                128  avgt    5    15.477 ±   0.399  ns/op
BitMapBenchmark.merge                256  avgt    5    30.616 ±   0.332  ns/op
BitMapBenchmark.merge                512  avgt    5    66.437 ±   0.941  ns/op
BitMapBenchmark.merge               1024  avgt    5   125.634 ±   2.399  ns/op
BitMapBenchmark.mergeNative            1  avgt    5     1.011 ±   0.103  ns/op
BitMapBenchmark.mergeNative            2  avgt    5     3.936 ±   0.444  ns/op
BitMapBenchmark.mergeNative            4  avgt    5     4.848 ±   0.037  ns/op
BitMapBenchmark.mergeNative            8  avgt    5    10.098 ±   0.711  ns/op
BitMapBenchmark.mergeNative           16  avgt    5    16.676 ±   1.106  ns/op
BitMapBenchmark.mergeNative           32  avgt    5    48.986 ±   2.203  ns/op
BitMapBenchmark.mergeNative           64  avgt    5    87.075 ±   9.431  ns/op
BitMapBenchmark.mergeNative          128  avgt    5   147.201 ±  20.776  ns/op
BitMapBenchmark.mergeNative          256  avgt    5   301.997 ±  27.788  ns/op
BitMapBenchmark.mergeNative          512  avgt    5   755.467 ±   9.501  ns/op
BitMapBenchmark.mergeNative         1024  avgt    5  1064.001 ±  29.296  ns/op
BitMapBenchmark.unmarkRange            1  avgt    5     2.174 ±   0.008  ns/op
BitMapBenchmark.unmarkRange            2  avgt    5     2.173 ±   0.008  ns/op
BitMapBenchmark.unmarkRange            4  avgt    5     2.173 ±   0.007  ns/op
BitMapBenchmark.unmarkRange            8  avgt    5     2.184 ±   0.032  ns/op
BitMapBenchmark.unmarkRange           16  avgt    5     2.187 ±   0.004  ns/op
BitMapBenchmark.unmarkRange           32  avgt    5     2.558 ±   0.086  ns/op
BitMapBenchmark.unmarkRange           64  avgt    5     2.410 ±   0.051  ns/op
BitMapBenchmark.unmarkRange          128  avgt    5     2.869 ±   0.099  ns/op
BitMapBenchmark.unmarkRange          256  avgt    5     3.240 ±   0.064  ns/op
BitMapBenchmark.unmarkRange          512  avgt    5     3.405 ±   0.811  ns/op
BitMapBenchmark.unmarkRange         1024  avgt    5     3.349 ±   0.037  ns/op
BitMapBenchmark.unmarkRangeNative      1  avgt    5     1.925 ±   0.012  ns/op
BitMapBenchmark.unmarkRangeNative      2  avgt    5     3.819 ±   0.162  ns/op
BitMapBenchmark.unmarkRangeNative      4  avgt    5     7.940 ±   1.119  ns/op
BitMapBenchmark.unmarkRangeNative      8  avgt    5    11.440 ±   0.219  ns/op
BitMapBenchmark.unmarkRangeNative     16  avgt    5    16.360 ±   1.900  ns/op
BitMapBenchmark.unmarkRangeNative     32  avgt    5    35.143 ±   0.991  ns/op
BitMapBenchmark.unmarkRangeNative     64  avgt    5    75.257 ±   0.285  ns/op
BitMapBenchmark.unmarkRangeNative    128  avgt    5   197.207 ±   5.872  ns/op
BitMapBenchmark.unmarkRangeNative    256  avgt    5   431.431 ±  14.840  ns/op
BitMapBenchmark.unmarkRangeNative    512  avgt    5   412.999 ±  51.569  ns/op
BitMapBenchmark.unmarkRangeNative   1024  avgt    5  1821.802 ± 114.809  ns/op
```
