### PR TITLE
perf: Optimize aligned object memory size calculation

### DIFF
--- a/java/common/src/main/java/org/apache/tsfile/utils/RamUsageEstimator.java
+++ b/java/common/src/main/java/org/apache/tsfile/utils/RamUsageEstimator.java
@@ -81,8 +81,8 @@ public final class RamUsageEstimator {
    * full multiple of this constant, possibly wasting some space.
    */
   public static final int NUM_BYTES_OBJECT_ALIGNMENT;
-  private static final int ALIGN_MASK;
 
+  private static final int ALIGN_MASK;
 
   /**
    * Approximate memory usage that we assign to all unknown queries - this maps roughly to a

--- a/java/common/src/main/java/org/apache/tsfile/utils/RamUsageEstimator.java
+++ b/java/common/src/main/java/org/apache/tsfile/utils/RamUsageEstimator.java
@@ -81,6 +81,8 @@ public final class RamUsageEstimator {
    * full multiple of this constant, possibly wasting some space.
    */
   public static final int NUM_BYTES_OBJECT_ALIGNMENT;
+  private static final int ALIGN_MASK;
+
 
   /**
    * Approximate memory usage that we assign to all unknown queries - this maps roughly to a
@@ -180,6 +182,8 @@ public final class RamUsageEstimator {
       NUM_BYTES_ARRAY_HEADER = NUM_BYTES_OBJECT_HEADER + Integer.BYTES;
     }
 
+    ALIGN_MASK = NUM_BYTES_OBJECT_ALIGNMENT - 1;
+
     // get min/max value of cached Long class instances:
     long longCacheMinValue = 0;
     while (longCacheMinValue > Long.MIN_VALUE
@@ -209,8 +213,7 @@ public final class RamUsageEstimator {
 
   /** Aligns an object size to be the next multiple of {@link #NUM_BYTES_OBJECT_ALIGNMENT}. */
   public static long alignObjectSize(long size) {
-    size += NUM_BYTES_OBJECT_ALIGNMENT - 1L;
-    return size - (size % NUM_BYTES_OBJECT_ALIGNMENT);
+    return (size + ALIGN_MASK) & ~ALIGN_MASK;
   }
 
   /**


### PR DESCRIPTION
The JVM configuration has indicated that this parameter is a power of 2, so the alignObjectSize function can be optimized because this function will be frequently called by other warehouses, such as calculating the memory to be written, WAL memory estimation, etc.
https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html
<img width="3086" height="334" alt="image" src="https://github.com/user-attachments/assets/b1b4e8a5-9994-407b-af8e-2d94d256db8e" />
