### PR TITLE
Fix/cpp get device schema

### DIFF
--- a/cpp/src/file/tsfile_io_reader.cc
+++ b/cpp/src/file/tsfile_io_reader.cc
@@ -701,13 +701,28 @@ int TsFileIOReader::do_load_all_timeseries_index(
     for (const auto &index_node_entry : index_node_entry_list) {
         int64_t start_offset = index_node_entry.first->get_offset(),
                 end_offset = index_node_entry.second;
-        const std::string target_measurement_name(
-            index_node_entry.first->get_name().to_std_string());
-        ITimeseriesIndex *ts_idx;
-        ret = do_load_timeseries_index(target_measurement_name, start_offset,
-                                       end_offset, in_timeseries_index_pa,
-                                       ts_idx);
-        if (IS_SUCC(ret)) {
+        int32_t read_size = (int32_t)(end_offset - start_offset);
+        int32_t ret_read_len = 0;
+        char *ti_buf = in_timeseries_index_pa.alloc(read_size);
+        if (IS_NULL(ti_buf)) {
+            return E_OOM;
+        }
+        if (RET_FAIL(read_file_->read(start_offset, ti_buf, read_size,
+                                      ret_read_len))) {
+            return ret;
+        }
+        ByteStream bs;
+        bs.wrap_from(ti_buf, read_size);
+        while (bs.has_remaining()) {
+            TimeseriesIndex cur_timeseries_index;
+            if (RET_FAIL(cur_timeseries_index.deserialize_from(
+                    bs, &in_timeseries_index_pa))) {
+                return ret;
+            }
+            if (cur_timeseries_index.get_measurement_name().len_ == 0) continue;
+            void *buf = in_timeseries_index_pa.alloc(sizeof(TimeseriesIndex));
+            auto ts_idx = new (buf) TimeseriesIndex;
+            ts_idx->clone_from(cur_timeseries_index, &in_timeseries_index_pa);
             ts_indexs.push_back(ts_idx);
         }
     }

--- a/cpp/src/file/tsfile_io_reader.cc
+++ b/cpp/src/file/tsfile_io_reader.cc
@@ -714,15 +714,13 @@ int TsFileIOReader::do_load_all_timeseries_index(
         ByteStream bs;
         bs.wrap_from(ti_buf, read_size);
         while (bs.has_remaining()) {
-            TimeseriesIndex cur_timeseries_index;
-            if (RET_FAIL(cur_timeseries_index.deserialize_from(
-                    bs, &in_timeseries_index_pa))) {
-                return ret;
-            }
-            if (cur_timeseries_index.get_measurement_name().len_ == 0) continue;
             void *buf = in_timeseries_index_pa.alloc(sizeof(TimeseriesIndex));
             auto ts_idx = new (buf) TimeseriesIndex;
-            ts_idx->clone_from(cur_timeseries_index, &in_timeseries_index_pa);
+            if (RET_FAIL(
+                    ts_idx->deserialize_from(bs, &in_timeseries_index_pa))) {
+                return ret;
+            }
+            if (ts_idx->get_measurement_name().len_ == 0) continue;
             ts_indexs.push_back(ts_idx);
         }
     }

--- a/cpp/test/reader/tree_view/tsfile_reader_tree_test.cc
+++ b/cpp/test/reader/tree_view/tsfile_reader_tree_test.cc
@@ -113,6 +113,7 @@ TEST_F(TsFileTreeReaderTest, ExtendedRowsAndColumnsTest) {
     std::vector<std::string> device_ids = {"device_1", "device_2", "device_3"};
     std::vector<std::string> measurement_ids = {"temperature", "humidity",
                                                 "pressure", "voltage"};
+    std::sort(measurement_ids.begin(), measurement_ids.end());
     std::vector<TSDataType> data_types = {INT64, DOUBLE, FLOAT, INT32};
     std::vector<MeasurementSchema*> measurements;
     for (size_t i = 0; i < measurement_ids.size(); ++i) {
@@ -166,6 +167,12 @@ TEST_F(TsFileTreeReaderTest, ExtendedRowsAndColumnsTest) {
     ASSERT_EQ(read_device_ids.size(), device_ids.size());
     for (size_t i = 0; i < device_ids.size(); ++i) {
         EXPECT_EQ(read_device_ids[i], device_ids[i]);
+    }
+
+    auto device_schema = reader.get_device_schema(device_ids[0]);
+    for (int i = 0; i < measurements.size(); ++i) {
+        EXPECT_EQ(measurements[i]->measurement_name_,
+                  device_schema[i].measurement_name_);
     }
 
     ResultSet* result;


### PR DESCRIPTION
Fix the getDeviceSchema interface in TsFile-CPP to resolve the issue of only returning the first MeasurementSchema.