### PR TITLE
2.x examples are based table model 

### DIFF
--- a/src/.vuepress/sidebar/v2.x/en.ts
+++ b/src/.vuepress/sidebar/v2.x/en.ts
@@ -60,7 +60,7 @@ export const enSidebar = {
         { text: 'InterfaceDefinition-Python', link: 'InterfaceDefinition-Python' },
       ],
     },
-    {
+    /* {
       text: 'Ecosystem Integration',
       collapsible: true,
       prefix: 'Ecosystem-Integration/',
@@ -69,6 +69,6 @@ export const enSidebar = {
         { text: 'Apache Spark', link: 'Spark-TsFile' },           
         { text: 'Apache Hive', link: 'Hive-TsFile' },
       ],
-    },
+    }, */
   ]
 };

--- a/src/.vuepress/sidebar/v2.x/zh.ts
+++ b/src/.vuepress/sidebar/v2.x/zh.ts
@@ -60,7 +60,7 @@ export const zhSidebar = {
         { text: '接口定义-Python', link: 'InterfaceDefinition-Python' },
       ],
     },
-    {
+    /* {
       text: '生态集成',
       collapsible: true,
       prefix: 'Ecosystem-Integration/',
@@ -69,6 +69,6 @@ export const zhSidebar = {
         { text: 'Apache Spark', link: 'Spark-TsFile' },           
         { text: 'Apache Hive', link: 'Hive-TsFile' },
       ],
-    },
+    }, */
   ]
 };

--- a/src/UserGuide/develop/QuickStart/QuickStart-C.md
+++ b/src/UserGuide/develop/QuickStart/QuickStart-C.md
@@ -261,3 +261,4 @@ The sample code of using these interfaces is in <https://github.com/apache/tsfil
 
 The sample code of using these interfaces is in <https://github.com/apache/tsfile/blob/develop/cpp/examples/c_examples/demo_read.c>
 
+> Note: The above read/write examples are all based on the table model interface. For details about the interface definition, please refer to [C Interface Definition](./InterfaceDefinition/InterfaceDefinition-C.md). If you need information regarding the tree model, please contact us.

--- a/src/UserGuide/develop/QuickStart/QuickStart-CPP.md
+++ b/src/UserGuide/develop/QuickStart/QuickStart-CPP.md
@@ -62,6 +62,7 @@ mvn clean install -P with-cpp -DskipTests \
 - `Full build:` ~3.2MB
 - `With ANTLR4 disabled:` ~1.9MB
 - `With all compression algorithms disabled:` ~1.7MB
+
 ### Directory Structure
 
 • **Include Directory**: Located at `tsfile/cpp/target/build/include`, it contains header files for integration. Add this path to the compiler's include path (e.g., using `-I` flag).
@@ -246,3 +247,4 @@ The sample code of using these interfaces is in <https://github.com/apache/tsfil
 
 The sample code of using these interfaces is in <https://github.com/apache/tsfile/blob/develop/cpp/examples/cpp_examples/demo_read.cpp>
 
+> Note: The above read/write examples are all based on the table model interface. For details about the interface definition, please refer to [C++ Interface Definition](./InterfaceDefinition/InterfaceDefinition-CPP.md). If you need information regarding the tree model, please contact us.

--- a/src/UserGuide/develop/QuickStart/QuickStart-JAVA.md
+++ b/src/UserGuide/develop/QuickStart/QuickStart-JAVA.md
@@ -174,3 +174,4 @@ reader.close();
 
 The sample code of using these interfaces is in <https://github.com/apache/tsfile/blob/develop/java/examples/src/main/java/org/apache/tsfile/v4/ITsFileReaderAndITsFileWriter.java>
 
+> Note: The above read/write examples are all based on the table model interface. For details about the interface definition, please refer to [Java Interface Definition](./InterfaceDefinition/InterfaceDefinition-Java.md). If you need information regarding the tree model, please contact us.

--- a/src/UserGuide/develop/QuickStart/QuickStart-PYTHON.md
+++ b/src/UserGuide/develop/QuickStart/QuickStart-PYTHON.md
@@ -60,6 +60,7 @@ Platform support:
 To download wheel from pypi: https://pypi.org/project/tsfile/#files
 
 
+
 ### Compile on your local envirment
 Clone the source code from git:
 
@@ -146,3 +147,5 @@ with TsFileReader(table_data_dir) as reader:
             print(result.get_value_by_name("value"))
             print(result.read_data_frame())
 ```
+
+> Note: The above read/write examples are all based on the table model interface. For details about the interface definition, please refer to [Python Interface Definition](./InterfaceDefinition/InterfaceDefinition-Python.md). If you need information regarding the tree model, please contact us.

--- a/src/UserGuide/latest/QuickStart/QuickStart-C.md
+++ b/src/UserGuide/latest/QuickStart/QuickStart-C.md
@@ -261,3 +261,4 @@ The sample code of using these interfaces is in <https://github.com/apache/tsfil
 
 The sample code of using these interfaces is in <https://github.com/apache/tsfile/blob/develop/cpp/examples/c_examples/demo_read.c>
 
+> Note: The above read/write examples are all based on the table model interface. For details about the interface definition, please refer to [C Interface Definition](./InterfaceDefinition/InterfaceDefinition-C.md). If you need information regarding the tree model, please contact us.

--- a/src/UserGuide/latest/QuickStart/QuickStart-CPP.md
+++ b/src/UserGuide/latest/QuickStart/QuickStart-CPP.md
@@ -247,3 +247,4 @@ The sample code of using these interfaces is in <https://github.com/apache/tsfil
 
 The sample code of using these interfaces is in <https://github.com/apache/tsfile/blob/develop/cpp/examples/cpp_examples/demo_read.cpp>
 
+> Note: The above read/write examples are all based on the table model interface. For details about the interface definition, please refer to [C++ Interface Definition](./InterfaceDefinition/InterfaceDefinition-CPP.md). If you need information regarding the tree model, please contact us.

--- a/src/UserGuide/latest/QuickStart/QuickStart-PYTHON.md
+++ b/src/UserGuide/latest/QuickStart/QuickStart-PYTHON.md
@@ -147,3 +147,5 @@ with TsFileReader(table_data_dir) as reader:
             print(result.get_value_by_name("value"))
             print(result.read_data_frame())
 ```
+
+> Note: The above read/write examples are all based on the table model interface. For details about the interface definition, please refer to [Python Interface Definition](./InterfaceDefinition/InterfaceDefinition-Python.md). If you need information regarding the tree model, please contact us.

--- a/src/UserGuide/latest/QuickStart/QuickStart.md
+++ b/src/UserGuide/latest/QuickStart/QuickStart.md
@@ -174,3 +174,4 @@ reader.close();
 
 The sample code of using these interfaces is in <https://github.com/apache/tsfile/blob/develop/java/examples/src/main/java/org/apache/tsfile/v4/ITsFileReaderAndITsFileWriter.java>
 
+> Note: The above read/write examples are all based on the table model interface. For details about the interface definition, please refer to [Java Interface Definition](./InterfaceDefinition/InterfaceDefinition-Java.md). If you need information regarding the tree model, please contact us.

--- a/src/zh/UserGuide/develop/QuickStart/QuickStart-C.md
+++ b/src/zh/UserGuide/develop/QuickStart/QuickStart-C.md
@@ -262,3 +262,5 @@ The sample code of using these interfaces is in <https://github.com/apache/tsfil
 
 The sample code of using these interfaces is in <https://github.com/apache/tsfile/blob/develop/cpp/examples/c_examples/demo_read.c>
 
+
+> 注意：以上读写示例均基于表模型接口，接口定义介绍可见[C 接口定义](./InterfaceDefinition/InterfaceDefinition-C.md)。若需了解树模型相关内容，请联系我们。

--- a/src/zh/UserGuide/develop/QuickStart/QuickStart-CPP.md
+++ b/src/zh/UserGuide/develop/QuickStart/QuickStart-CPP.md
@@ -244,3 +244,4 @@ target_link_libraries(your_target ${TSFILE_LIB})
 
 使用这些接口的示例代码可以在以下链接中找到 <https://github.com/apache/tsfile/blob/develop/cpp/examples/cpp_examples/demo_read.cpp>
 
+> 注意：以上读写示例均基于表模型接口，接口定义介绍可见[C++ 接口定义](./InterfaceDefinition/InterfaceDefinition-CPP.md)。若需了解树模型相关内容，请联系我们。

--- a/src/zh/UserGuide/develop/QuickStart/QuickStart-JAVA.md
+++ b/src/zh/UserGuide/develop/QuickStart/QuickStart-JAVA.md
@@ -174,3 +174,4 @@ reader.close();
 
 使用这些接口的示例代码位于：<https://github.com/apache/tsfile/blob/develop/java/examples/src/main/java/org/apache/tsfile/v4/ITsFileReaderAndITsFileWriter.java>
 
+> 注意：以上读写示例均基于表模型接口，接口定义介绍可见[Java 接口定义](./InterfaceDefinition/InterfaceDefinition-Java.md)。若需了解树模型相关内容，请联系我们。

--- a/src/zh/UserGuide/develop/QuickStart/QuickStart-PYTHON.md
+++ b/src/zh/UserGuide/develop/QuickStart/QuickStart-PYTHON.md
@@ -148,3 +148,5 @@ with TsFileReader(table_data_dir) as reader:
             print(result.get_value_by_name("value"))
             print(result.read_data_frame())
 ```
+
+> 注意：以上读写示例均基于表模型接口，接口定义介绍可见[Python 接口定义](./InterfaceDefinition/InterfaceDefinition-Python.md)。若需了解树模型相关内容，请联系我们。

--- a/src/zh/UserGuide/latest/QuickStart/QuickStart-C.md
+++ b/src/zh/UserGuide/latest/QuickStart/QuickStart-C.md
@@ -262,3 +262,5 @@ The sample code of using these interfaces is in <https://github.com/apache/tsfil
 
 The sample code of using these interfaces is in <https://github.com/apache/tsfile/blob/develop/cpp/examples/c_examples/demo_read.c>
 
+
+> 注意：以上读写示例均基于表模型接口，接口定义介绍可见[C 接口定义](./InterfaceDefinition/InterfaceDefinition-C.md)。若需了解树模型相关内容，请联系我们。

--- a/src/zh/UserGuide/latest/QuickStart/QuickStart-CPP.md
+++ b/src/zh/UserGuide/latest/QuickStart/QuickStart-CPP.md
@@ -244,3 +244,4 @@ target_link_libraries(your_target ${TSFILE_LIB})
 
 使用这些接口的示例代码可以在以下链接中找到 <https://github.com/apache/tsfile/blob/develop/cpp/examples/cpp_examples/demo_read.cpp>
 
+> 注意：以上读写示例均基于表模型接口，接口定义介绍可见[C++ 接口定义](./InterfaceDefinition/InterfaceDefinition-CPP.md)。若需了解树模型相关内容，请联系我们。

--- a/src/zh/UserGuide/latest/QuickStart/QuickStart-PYTHON.md
+++ b/src/zh/UserGuide/latest/QuickStart/QuickStart-PYTHON.md
@@ -148,3 +148,5 @@ with TsFileReader(table_data_dir) as reader:
             print(result.get_value_by_name("value"))
             print(result.read_data_frame())
 ```
+
+> 注意：以上读写示例均基于表模型接口，接口定义介绍可见[Python 接口定义](./InterfaceDefinition/InterfaceDefinition-Python.md)。若需了解树模型相关内容，请联系我们。

--- a/src/zh/UserGuide/latest/QuickStart/QuickStart.md
+++ b/src/zh/UserGuide/latest/QuickStart/QuickStart.md
@@ -174,3 +174,4 @@ reader.close();
 
 使用这些接口的示例代码位于：<https://github.com/apache/tsfile/blob/develop/java/examples/src/main/java/org/apache/tsfile/v4/ITsFileReaderAndITsFileWriter.java>
 
+> 注意：以上读写示例均基于表模型接口，接口定义介绍可见[Java 接口定义](./InterfaceDefinition/InterfaceDefinition-Java.md)。若需了解树模型相关内容，请联系我们。


### PR DESCRIPTION
The 2.x read/write examples are all based on the table model interface. For details about the interface definition, please refer to Interface Definition. If you need information regarding the tree model, please contact us.
Remove ecosystem integration of 2.x.