### PR TITLE
Increment the getBinary() function in nonBinary Column

### DIFF
--- a/java/common/src/main/java/org/apache/tsfile/utils/TsPrimitiveType.java
+++ b/java/common/src/main/java/org/apache/tsfile/utils/TsPrimitiveType.java
@@ -22,6 +22,7 @@ import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.write.UnSupportedDataTypeException;
 
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 public abstract class TsPrimitiveType implements Serializable {
@@ -199,6 +200,11 @@ public abstract class TsPrimitiveType implements Serializable {
     }
 
     @Override
+    public Binary getBinary() {
+      return new Binary(String.valueOf(this.value), StandardCharsets.UTF_8);
+    }
+
+    @Override
     public void setObject(Object val) {
       if (val instanceof Boolean) {
         setBoolean((Boolean) val);
@@ -281,6 +287,11 @@ public abstract class TsPrimitiveType implements Serializable {
     }
 
     @Override
+    public Binary getBinary() {
+      return new Binary(String.valueOf(this.value), StandardCharsets.UTF_8);
+    }
+
+    @Override
     public void setInt(int val) {
       this.value = val;
     }
@@ -355,6 +366,11 @@ public abstract class TsPrimitiveType implements Serializable {
     @Override
     public double getDouble() {
       return (double) value;
+    }
+
+    @Override
+    public Binary getBinary() {
+      return new Binary(String.valueOf(this.value), StandardCharsets.UTF_8);
     }
 
     @Override
@@ -435,6 +451,11 @@ public abstract class TsPrimitiveType implements Serializable {
     }
 
     @Override
+    public Binary getBinary() {
+      return new Binary(String.valueOf(this.value), StandardCharsets.UTF_8);
+    }
+
+    @Override
     public void setFloat(float val) {
       this.value = val;
     }
@@ -504,6 +525,11 @@ public abstract class TsPrimitiveType implements Serializable {
     @Override
     public double getDouble() {
       return value;
+    }
+
+    @Override
+    public Binary getBinary() {
+      return new Binary(String.valueOf(this.value), StandardCharsets.UTF_8);
     }
 
     @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BooleanColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BooleanColumn.java
@@ -22,9 +22,11 @@ package org.apache.tsfile.read.common.block.column;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnEncoding;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -94,8 +96,22 @@ public class BooleanColumn implements Column {
   }
 
   @Override
+  public Binary getBinary(int position) {
+    return new Binary(String.valueOf(values[position + arrayOffset]), StandardCharsets.UTF_8);
+  }
+
+  @Override
   public boolean[] getBooleans() {
     return values;
+  }
+
+  @Override
+  public Binary[] getBinaries() {
+    Binary[] binaries = new Binary[values.length];
+    for (int i = 0; i < values.length; i++) {
+      binaries[i] = new Binary(String.valueOf(values[i]), StandardCharsets.UTF_8);
+    }
+    return binaries;
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/DoubleColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/DoubleColumn.java
@@ -22,9 +22,11 @@ package org.apache.tsfile.read.common.block.column;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnEncoding;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -95,8 +97,22 @@ public class DoubleColumn implements Column {
   }
 
   @Override
+  public Binary getBinary(int position) {
+    return new Binary(String.valueOf(values[position + arrayOffset]), StandardCharsets.UTF_8);
+  }
+
+  @Override
   public double[] getDoubles() {
     return values;
+  }
+
+  @Override
+  public Binary[] getBinaries() {
+    Binary[] binaries = new Binary[values.length];
+    for (int i = 0; i < values.length; i++) {
+      binaries[i] = new Binary(String.valueOf(values[i]), StandardCharsets.UTF_8);
+    }
+    return binaries;
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/FloatColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/FloatColumn.java
@@ -22,9 +22,11 @@ package org.apache.tsfile.read.common.block.column;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnEncoding;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -101,6 +103,11 @@ public class FloatColumn implements Column {
   }
 
   @Override
+  public Binary getBinary(int position) {
+    return new Binary(String.valueOf(values[position + arrayOffset]), StandardCharsets.UTF_8);
+  }
+
+  @Override
   public float[] getFloats() {
     return values;
   }
@@ -112,6 +119,15 @@ public class FloatColumn implements Column {
       doubles[i] = values[i];
     }
     return doubles;
+  }
+
+  @Override
+  public Binary[] getBinaries() {
+    Binary[] binaries = new Binary[values.length];
+    for (int i = 0; i < values.length; i++) {
+      binaries[i] = new Binary(String.valueOf(values[i]), StandardCharsets.UTF_8);
+    }
+    return binaries;
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/IntColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/IntColumn.java
@@ -22,9 +22,11 @@ package org.apache.tsfile.read.common.block.column;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnEncoding;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -111,6 +113,11 @@ public class IntColumn implements Column {
   }
 
   @Override
+  public Binary getBinary(int position) {
+    return new Binary(String.valueOf(values[position + arrayOffset]), StandardCharsets.UTF_8);
+  }
+
+  @Override
   public int[] getInts() {
     return values;
   }
@@ -140,6 +147,15 @@ public class IntColumn implements Column {
       result[i] = values[i];
     }
     return result;
+  }
+
+  @Override
+  public Binary[] getBinaries() {
+    Binary[] binaries = new Binary[values.length];
+    for (int i = 0; i < values.length; i++) {
+      binaries[i] = new Binary(String.valueOf(values[i]), StandardCharsets.UTF_8);
+    }
+    return binaries;
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/LongColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/LongColumn.java
@@ -22,9 +22,11 @@ package org.apache.tsfile.read.common.block.column;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnEncoding;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -101,6 +103,11 @@ public class LongColumn implements Column {
   }
 
   @Override
+  public Binary getBinary(int position) {
+    return new Binary(String.valueOf(values[position + arrayOffset]), StandardCharsets.UTF_8);
+  }
+
+  @Override
   public long[] getLongs() {
     return values;
   }
@@ -112,6 +119,15 @@ public class LongColumn implements Column {
       doubles[i] = values[i];
     }
     return doubles;
+  }
+
+  @Override
+  public Binary[] getBinaries() {
+    Binary[] binaries = new Binary[values.length];
+    for (int i = 0; i < values.length; i++) {
+      binaries[i] = new Binary(String.valueOf(values[i]), StandardCharsets.UTF_8);
+    }
+    return binaries;
   }
 
   @Override

--- a/java/tsfile/src/test/java/org/apache/tsfile/read/common/ColumnTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/read/common/ColumnTest.java
@@ -38,11 +38,13 @@ import org.apache.tsfile.read.common.block.column.NullColumn;
 import org.apache.tsfile.read.common.block.column.RunLengthEncodedColumn;
 import org.apache.tsfile.read.common.block.column.TimeColumn;
 import org.apache.tsfile.read.common.block.column.TimeColumnBuilder;
+import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.BytesUtils;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 public class ColumnTest {
@@ -224,7 +226,11 @@ public class ColumnTest {
     Assert.assertTrue(columnByGetPositions instanceof DictionaryColumn);
     Assert.assertEquals(2, columnByGetPositions.getPositionCount());
     Assert.assertFalse(columnByGetPositions.getBoolean(0));
+    Assert.assertEquals(
+        new Binary("false", StandardCharsets.UTF_8), columnByGetPositions.getBinary(0));
     Assert.assertTrue(columnByGetPositions.getBoolean(1));
+    Assert.assertEquals(
+        new Binary("true", StandardCharsets.UTF_8), columnByGetPositions.getBinary(1));
 
     Column columnByCopyPositions = originalColumn.copyPositions(selectedPositions, 1, 2);
     Assert.assertEquals(2, columnByCopyPositions.getPositionCount());
@@ -242,7 +248,9 @@ public class ColumnTest {
     doubleColumn1 = (DoubleColumn) doubleColumn1.subColumn(5);
     Assert.assertEquals(5, doubleColumn1.getPositionCount());
     Assert.assertEquals(5.0, doubleColumn1.getDouble(0), 0.001);
+    Assert.assertEquals(new Binary("5.0", StandardCharsets.UTF_8), doubleColumn1.getBinary(0));
     Assert.assertEquals(9.0, doubleColumn1.getDouble(4), 0.001);
+    Assert.assertEquals(new Binary("9.0", StandardCharsets.UTF_8), doubleColumn1.getBinary(4));
 
     DoubleColumn doubleColumn2 = (DoubleColumn) doubleColumn1.subColumn(3);
     Assert.assertEquals(2, doubleColumn2.getPositionCount());
@@ -303,7 +311,9 @@ public class ColumnTest {
     floatColumn1 = (FloatColumn) floatColumn1.subColumn(5);
     Assert.assertEquals(5, floatColumn1.getPositionCount());
     Assert.assertEquals(5.0, floatColumn1.getFloat(0), 0.001);
+    Assert.assertEquals(new Binary("5.0", StandardCharsets.UTF_8), floatColumn1.getBinary(0));
     Assert.assertEquals(9.0, floatColumn1.getFloat(4), 0.001);
+    Assert.assertEquals(new Binary("9.0", StandardCharsets.UTF_8), floatColumn1.getBinary(4));
 
     FloatColumn floatColumn2 = (FloatColumn) floatColumn1.subColumn(3);
     Assert.assertEquals(2, floatColumn2.getPositionCount());
@@ -414,6 +424,10 @@ public class ColumnTest {
     Assert.assertEquals(2, columnByCopyPositions.getPositionCount());
     Assert.assertEquals(3, columnByCopyPositions.getInt(0));
     Assert.assertEquals(5, columnByCopyPositions.getInt(1));
+    Assert.assertEquals(
+        new Binary("3", StandardCharsets.UTF_8), columnByCopyPositions.getBinary(0));
+    Assert.assertEquals(
+        new Binary("5", StandardCharsets.UTF_8), columnByCopyPositions.getBinary(1));
   }
 
   @Test
@@ -427,11 +441,15 @@ public class ColumnTest {
     Assert.assertEquals(5, longColumn1.getPositionCount());
     Assert.assertEquals(5, longColumn1.getLong(0));
     Assert.assertEquals(9, longColumn1.getLong(4));
+    Assert.assertEquals(new Binary("5", StandardCharsets.UTF_8), longColumn1.getBinary(0));
+    Assert.assertEquals(new Binary("9", StandardCharsets.UTF_8), longColumn1.getBinary(4));
 
     LongColumn longColumn2 = (LongColumn) longColumn1.subColumn(3);
     Assert.assertEquals(2, longColumn2.getPositionCount());
     Assert.assertEquals(8, longColumn2.getLong(0));
     Assert.assertEquals(9, longColumn2.getLong(1));
+    Assert.assertEquals(new Binary("8", StandardCharsets.UTF_8), longColumn2.getBinary(0));
+    Assert.assertEquals(new Binary("9", StandardCharsets.UTF_8), longColumn2.getBinary(1));
 
     Assert.assertSame(longColumn1.getLongs(), longColumn2.getLongs());
   }


### PR DESCRIPTION
Allow other value of data type can be converted to value of Binary data type when find type is not consistence in the column of tsblock.
Resolve this problem :
<img width="3011" height="1052" alt="image" src="https://github.com/user-attachments/assets/cfa0c4b0-2b4c-42d7-99ad-01b9edd4b818" />
