### PR TITLE
Avoid invoke their max and min statistics function on the Blob and TEXT type

### DIFF
--- a/java/tsfile/src/main/codegen/templates/FilterOperatorsTemplate.ftl
+++ b/java/tsfile/src/main/codegen/templates/FilterOperatorsTemplate.ftl
@@ -37,6 +37,10 @@ import org.apache.tsfile.common.regexp.LikePattern;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.NotImplementedException;
 import org.apache.tsfile.file.metadata.IMetadata;
+<#if filter.javaBoxName == "String">
+import org.apache.tsfile.file.metadata.statistics.BinaryStatistics;
+import org.apache.tsfile.file.metadata.statistics.BlobStatistics;
+</#if>
 import org.apache.tsfile.file.metadata.statistics.Statistics;
 import org.apache.tsfile.read.filter.basic.Filter;
 import org.apache.tsfile.read.filter.basic.${filter.javaBoxName}Filter;
@@ -177,6 +181,9 @@ public final class ${className} {
       if(statistics.isEmpty()){
         return false;
       }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
+        return false;
+      }
       if((statistics.getMinValue() instanceof Binary) && (statistics.getMaxValue() instanceof Binary)){
         return constant.compareTo((${filter.dataType}) statistics.getMinValue()) < 0
             || constant.compareTo((${filter.dataType}) statistics.getMaxValue()) > 0;
@@ -197,6 +204,9 @@ public final class ${className} {
       <#elseif filter.dataType == "Binary">
         <#if filter.javaBoxName == "String">
       if(statistics.isEmpty()){
+        return false;
+      }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
         return false;
       }
       if((statistics.getMinValue() instanceof Binary) && (statistics.getMaxValue() instanceof Binary)){
@@ -228,6 +238,9 @@ public final class ${className} {
       if(statistics.isEmpty()){
         return false;
       }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
+        return false;
+      }
       if((statistics.getMinValue() instanceof Binary) && (statistics.getMaxValue() instanceof Binary)){
         return constant.compareTo((${filter.dataType}) statistics.getMinValue()) == 0
             && constant.compareTo((${filter.dataType}) statistics.getMaxValue()) == 0;
@@ -242,6 +255,9 @@ public final class ${className} {
       <#elseif filter.dataType == "Binary">
         <#if filter.javaBoxName == "String">
       if(statistics.isEmpty()){
+        return false;
+      }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
         return false;
       }
       if((statistics.getMinValue() instanceof Binary) && (statistics.getMaxValue() instanceof Binary)){
@@ -318,6 +334,9 @@ public final class ${className} {
       if(statistics.isEmpty()){
         return false;
       }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
+        return false;
+      }
       if((statistics.getMinValue() instanceof Binary) && (statistics.getMaxValue() instanceof Binary)){
         return constant.compareTo((${filter.dataType}) statistics.getMinValue()) == 0
             && constant.compareTo((${filter.dataType}) statistics.getMaxValue()) == 0;
@@ -332,6 +351,9 @@ public final class ${className} {
       <#elseif filter.dataType == "Binary">
         <#if filter.javaBoxName == "String">
       if(statistics.isEmpty()){
+        return false;
+      }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
         return false;
       }
       if((statistics.getMinValue() instanceof Binary) && (statistics.getMaxValue() instanceof Binary)){
@@ -364,6 +386,9 @@ public final class ${className} {
       if(statistics.isEmpty()){
         return false;
       }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
+        return false;
+      }
       if((statistics.getMinValue() instanceof Binary) && (statistics.getMaxValue() instanceof Binary)){
         return constant.compareTo((${filter.dataType}) statistics.getMinValue()) < 0
             || constant.compareTo((${filter.dataType}) statistics.getMaxValue()) > 0;
@@ -378,6 +403,9 @@ public final class ${className} {
       <#elseif filter.dataType == "Binary">
         <#if filter.javaBoxName == "String">
       if(statistics.isEmpty()){
+        return false;
+      }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
         return false;
       }
       if((statistics.getMinValue() instanceof Binary) && (statistics.getMaxValue() instanceof Binary)){
@@ -456,6 +484,9 @@ public final class ${className} {
       if(statistics.isEmpty()){
         return false;
       }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
+        return false;
+      }
       if(statistics.getMinValue() instanceof Binary){
         return constant.compareTo((${filter.dataType}) statistics.getMinValue()) <= 0;
       }
@@ -468,6 +499,9 @@ public final class ${className} {
       <#elseif filter.dataType == "Binary">
         <#if filter.javaBoxName == "String">
       if(statistics.isEmpty()){
+        return false;
+      }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
         return false;
       }
       if(statistics.getMinValue() instanceof Binary) {
@@ -497,6 +531,9 @@ public final class ${className} {
       if(statistics.isEmpty()){
         return false;
       }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
+        return false;
+      }
       if(statistics.getMaxValue() instanceof Binary){
         return constant.compareTo((${filter.dataType}) statistics.getMaxValue()) > 0;
       }
@@ -509,6 +546,9 @@ public final class ${className} {
       <#elseif filter.dataType == "Binary">
         <#if filter.javaBoxName == "String">
       if(statistics.isEmpty()){
+        return false;
+      }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
         return false;
       }
       if(statistics.getMaxValue() instanceof Binary){
@@ -584,6 +624,9 @@ public final class ${className} {
       if(statistics.isEmpty()){
         return false;
       }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
+        return false;
+      }
       if(statistics.getMinValue() instanceof Binary){
         return constant.compareTo((${filter.dataType}) statistics.getMinValue()) < 0;
       }
@@ -596,6 +639,9 @@ public final class ${className} {
       <#elseif filter.dataType == "Binary">
         <#if filter.javaBoxName == "String">
       if(statistics.isEmpty()){
+        return false;
+      }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
         return false;
       }
       if(statistics.getMinValue() instanceof Binary) {
@@ -625,6 +671,9 @@ public final class ${className} {
       if(statistics.isEmpty()){
         return false;
       }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
+        return false;
+      }
       if(statistics.getMaxValue() instanceof Binary){
         return constant.compareTo((${filter.dataType}) statistics.getMaxValue()) >= 0;
       }
@@ -637,6 +686,9 @@ public final class ${className} {
       <#elseif filter.dataType == "Binary">
         <#if filter.javaBoxName == "String">
       if(statistics.isEmpty()){
+        return false;
+      }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
         return false;
       }
       if(statistics.getMaxValue() instanceof Binary){
@@ -712,6 +764,9 @@ public final class ${className} {
       if(statistics.isEmpty()){
         return false;
       }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
+        return false;
+      }
       if(statistics.getMaxValue() instanceof Binary){
         return constant.compareTo((${filter.dataType}) statistics.getMaxValue()) >= 0;
       }
@@ -724,6 +779,9 @@ public final class ${className} {
       <#elseif filter.dataType == "Binary">
         <#if filter.javaBoxName == "String">
       if(statistics.isEmpty()){
+        return false;
+      }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
         return false;
       }
       if(statistics.getMaxValue() instanceof Binary) {
@@ -753,6 +811,9 @@ public final class ${className} {
       if(statistics.isEmpty()){
         return false;
       }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
+        return false;
+      }
       if(statistics.getMinValue() instanceof Binary){
         return constant.compareTo((${filter.dataType}) statistics.getMinValue()) < 0;
       }
@@ -765,6 +826,9 @@ public final class ${className} {
       <#elseif filter.dataType == "Binary">
         <#if filter.javaBoxName == "String">
       if(statistics.isEmpty()){
+        return false;
+      }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
         return false;
       }
       if(statistics.getMinValue() instanceof Binary){
@@ -840,6 +904,9 @@ public final class ${className} {
       if(statistics.isEmpty()){
         return false;
       }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
+        return false;
+      }
       if(statistics.getMaxValue() instanceof Binary){
         return constant.compareTo((${filter.dataType}) statistics.getMaxValue()) > 0;
       }
@@ -852,6 +919,9 @@ public final class ${className} {
       <#elseif filter.dataType == "Binary">
         <#if filter.javaBoxName == "String">
       if(statistics.isEmpty()){
+        return false;
+      }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
         return false;
       }
       if(statistics.getMaxValue() instanceof Binary) {
@@ -881,6 +951,9 @@ public final class ${className} {
       if(statistics.isEmpty()){
         return false;
       }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
+        return false;
+      }
       if(statistics.getMinValue() instanceof Binary){
         return constant.compareTo((${filter.dataType}) statistics.getMinValue()) <= 0;
       }
@@ -893,6 +966,9 @@ public final class ${className} {
       <#elseif filter.dataType == "Binary">
         <#if filter.javaBoxName == "String">
       if(statistics.isEmpty()){
+        return false;
+      }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
         return false;
       }
       if(statistics.getMinValue() instanceof Binary){
@@ -1038,6 +1114,9 @@ public final class ${className} {
       if(statistics.isEmpty()){
         return false;
       }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
+        return false;
+      }
       if((statistics.getMinValue() instanceof Binary) && (statistics.getMaxValue() instanceof Binary)){
         return ((${filter.dataType}) statistics.getMaxValue()).compareTo(min) < 0
             || ((${filter.dataType}) statistics.getMinValue()).compareTo(max) > 0;
@@ -1052,6 +1131,9 @@ public final class ${className} {
       <#elseif filter.dataType == "Binary">
         <#if filter.javaBoxName == "String">
       if(statistics.isEmpty()){
+        return false;
+      }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
         return false;
       }
       if((statistics.getMaxValue() instanceof Binary) && (statistics.getMinValue() instanceof Binary)) {
@@ -1083,6 +1165,9 @@ public final class ${className} {
       if(statistics.isEmpty()){
         return false;
       }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
+        return false;
+      }
       if((statistics.getMinValue() instanceof Binary) && (statistics.getMaxValue() instanceof Binary)){
         return ((${filter.dataType}) statistics.getMinValue()).compareTo(min) >= 0
             && ((${filter.dataType}) statistics.getMaxValue()).compareTo(max) <= 0;
@@ -1097,6 +1182,9 @@ public final class ${className} {
       <#elseif filter.dataType == "Binary">
         <#if filter.javaBoxName == "String">
       if(statistics.isEmpty()){
+        return false;
+      }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
         return false;
       }
       if((statistics.getMinValue() instanceof Binary) && (statistics.getMaxValue() instanceof Binary)){
@@ -1176,6 +1264,9 @@ public final class ${className} {
       if(statistics.isEmpty()){
         return false;
       }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
+        return false;
+      }
       if((statistics.getMinValue() instanceof Binary) && (statistics.getMaxValue() instanceof Binary)){
         return ((${filter.dataType}) statistics.getMinValue()).compareTo(min) >= 0
             && ((${filter.dataType}) statistics.getMaxValue()).compareTo(max) <= 0;
@@ -1190,6 +1281,9 @@ public final class ${className} {
       <#elseif filter.dataType == "Binary">
         <#if filter.javaBoxName == "String">
       if(statistics.isEmpty()){
+        return false;
+      }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
         return false;
       }
       if((statistics.getMinValue() instanceof Binary) && (statistics.getMaxValue() instanceof Binary)) {
@@ -1221,6 +1315,9 @@ public final class ${className} {
       if(statistics.isEmpty()){
         return false;
       }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
+        return false;
+      }
       if((statistics.getMinValue() instanceof Binary) && (statistics.getMaxValue() instanceof Binary)){
         return ((${filter.dataType}) statistics.getMinValue()).compareTo(max) > 0
             || ((${filter.dataType}) statistics.getMaxValue()).compareTo(min) < 0;
@@ -1235,6 +1332,9 @@ public final class ${className} {
       <#elseif filter.dataType == "Binary">
         <#if filter.javaBoxName == "String">
       if(statistics.isEmpty()){
+        return false;
+      }
+      if(statistics instanceof BlobStatistics || statistics instanceof BinaryStatistics){
         return false;
       }
       if((statistics.getMinValue() instanceof Binary) && (statistics.getMaxValue() instanceof Binary)){
@@ -1427,6 +1527,9 @@ public final class ${className} {
         <#if filter.dataType == "Binary" && filter.javaBoxName == "String">
         ${filter.dataType} valuesMin;
         ${filter.dataType} valuesMax;
+        if(stat instanceof BlobStatistics || stat instanceof BinaryStatistics){
+          return false;
+        }
         if(stat.getMinValue() instanceof Binary){
           valuesMin = (${filter.dataType}) stat.getMinValue();
         }
@@ -1496,6 +1599,9 @@ public final class ${className} {
         <#if filter.dataType == "Binary" && filter.javaBoxName == "String">
         ${filter.dataType} valuesMin;
         ${filter.dataType} valuesMax;
+        if(stat instanceof BlobStatistics || stat instanceof BinaryStatistics){
+          return false;
+        }
         if(stat.getMinValue() instanceof Binary){
           valuesMin = (${filter.dataType}) stat.getMinValue();
         }


### PR DESCRIPTION
Avoid invoke their max and min statistics function on the Blob and TEXT type, because they don't support filter comparison with value of string type in the where clause.

This is a failure IT test case:
![img_v3_02tg_f34da319-82e6-402f-98d5-9f4543cc8ddg](https://github.com/user-attachments/assets/406b0439-a3ef-4ce8-a4ff-af0183cd8f21)
2025-12-31 10:27:14,930 [Query-Worker-Thread-10$20251231_022714_71241_1.1.0.1] WARN  o.a.i.d.q.e.s.AbstractDriverThread:95 - [ExecuteFailed] 
org.apache.tsfile.exception.filter.StatisticsClassException: TEXT statistics does not support: max
        at org.apache.tsfile.file.metadata.statistics.BinaryStatistics.getMaxValue(BinaryStatistics.java:103)
        at org.apache.tsfile.file.metadata.statistics.BinaryStatistics.getMaxValue(BinaryStatistics.java:38)
        at org.apache.tsfile.read.filter.operator.StringFilterOperators$ValueGtEq.canSkip(StringFilterOperators.java:468)
        at java.base/java.util.Optional.map(Optional.java:260)
        at org.apache.tsfile.read.filter.basic.ValueFilter.canSkip(ValueFilter.java:148)
        at org.apache.iotdb.db.queryengine.execution.operator.source.SeriesScanUtil.filterFirstChunkMetadata(SeriesScanUtil.java:424)
        at org.apache.iotdb.db.queryengine.execution.operator.source.SeriesScanUtil.hasNextChunk(SeriesScanUtil.java:407)
        at org.apache.iotdb.db.queryengine.execution.operator.source.AbstractSeriesScanOperator.readChunkData(AbstractSeriesScanOperator.java:113)
        at org.apache.iotdb.db.queryengine.execution.operator.source.AbstractSeriesScanOperator.readFileData(AbstractSeriesScanOperator.java:105)
        at org.apache.iotdb.db.queryengine.execution.operator.source.AbstractSeriesScanOperator.hasNext(AbstractSeriesScanOperator.java:81)
        at org.apache.iotdb.db.queryengine.execution.operator.Operator.hasNextWithTimer(Operator.java:72)
        at org.apache.iotdb.db.queryengine.execution.driver.Driver.processInternal(Driver.java:240)
        at org.apache.iotdb.db.queryengine.execution.driver.Driver.lambda$processFor$1(Driver.java:152)
        at org.apache.iotdb.db.queryengine.execution.driver.Driver.tryWithLock(Driver.java:337)
        at org.apache.iotdb.db.queryengine.execution.driver.Driver.processFor(Driver.java:133)
        at org.apache.iotdb.db.queryengine.execution.schedule.DriverTaskThread.execute(DriverTaskThread.java:83)
        at org.apache.iotdb.db.queryengine.execution.schedule.AbstractDriverThread.run(AbstractDriverThread.java:79)
2025-12-31 10:27:14,929 [pool-36-IoTDB-ClientRPC-Processor-1] WARN  o.a.i.d.u.ErrorHandlingUtils:127 - Status code: 301, Query Statement: "select s1 from root.alter.construct_and_alter_column_type where s1 >= '1' and s2 > '2' order by time". executeStatement failed because TEXT statistics does not support: max 
org.apache.iotdb.commons.exception.IoTDBException: org.apache.tsfile.exception.filter.StatisticsClassException: TEXT statistics does not support: max
        at org.apache.iotdb.db.queryengine.plan.execution.QueryExecution.dealWithException(QueryExecution.java:479)
        at org.apache.iotdb.db.queryengine.plan.execution.QueryExecution.getResult(QueryExecution.java:452)
        at org.apache.iotdb.db.queryengine.plan.execution.QueryExecution.getByteBufferBatchResult(QueryExecution.java:498)
        at org.apache.iotdb.db.utils.QueryDataSetUtils.convertQueryResultByFetchSize(QueryDataSetUtils.java:625)
        at org.apache.iotdb.db.protocol.thrift.impl.ClientRPCServiceImpl.lambda$static$0(ClientRPCServiceImpl.java:281)
        at org.apache.iotdb.db.protocol.thrift.impl.ClientRPCServiceImpl.executeStatementInternal(ClientRPCServiceImpl.java:460)
        at org.apache.iotdb.db.protocol.thrift.impl.ClientRPCServiceImpl.executeStatementV2(ClientRPCServiceImpl.java:965)
        at org.apache.iotdb.db.protocol.thrift.impl.ClientRPCServiceImpl.executeQueryStatementV2(ClientRPCServiceImpl.java:955)
        at org.apache.iotdb.service.rpc.thrift.IClientRPCService$Processor$executeQueryStatementV2.getResult(IClientRPCService.java:4054)
        at org.apache.iotdb.service.rpc.thrift.IClientRPCService$Processor$executeQueryStatementV2.getResult(IClientRPCService.java:4034)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
        at org.apache.iotdb.db.protocol.thrift.ProcessorWithMetrics.process(ProcessorWithMetrics.java:64)
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:248)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:842)
Caused by: org.apache.tsfile.exception.filter.StatisticsClassException: TEXT statistics does not support: max
        at org.apache.tsfile.file.metadata.statistics.BinaryStatistics.getMaxValue(BinaryStatistics.java:103)
        at org.apache.tsfile.file.metadata.statistics.BinaryStatistics.getMaxValue(BinaryStatistics.java:38)
        at org.apache.tsfile.read.filter.operator.StringFilterOperators$ValueGtEq.canSkip(StringFilterOperators.java:468)
        at java.base/java.util.Optional.map(Optional.java:260)
        at org.apache.tsfile.read.filter.basic.ValueFilter.canSkip(ValueFilter.java:148)
        at org.apache.iotdb.db.queryengine.execution.operator.source.SeriesScanUtil.filterFirstChunkMetadata(SeriesScanUtil.java:424)
        at org.apache.iotdb.db.queryengine.execution.operator.source.SeriesScanUtil.hasNextChunk(SeriesScanUtil.java:407)
        at org.apache.iotdb.db.queryengine.execution.operator.source.AbstractSeriesScanOperator.readChunkData(AbstractSeriesScanOperator.java:113)
        at org.apache.iotdb.db.queryengine.execution.operator.source.AbstractSeriesScanOperator.readFileData(AbstractSeriesScanOperator.java:105)
        at org.apache.iotdb.db.queryengine.execution.operator.source.AbstractSeriesScanOperator.hasNext(AbstractSeriesScanOperator.java:81)
        at org.apache.iotdb.db.queryengine.execution.operator.Operator.hasNextWithTimer(Operator.java:72)
        at org.apache.iotdb.db.queryengine.execution.driver.Driver.processInternal(Driver.java:240)
        at org.apache.iotdb.db.queryengine.execution.driver.Driver.lambda$processFor$1(Driver.java:152)
        at org.apache.iotdb.db.queryengine.execution.driver.Driver.tryWithLock(Driver.java:337)
        at org.apache.iotdb.db.queryengine.execution.driver.Driver.processFor(Driver.java:133)
        at org.apache.iotdb.db.queryengine.execution.schedule.DriverTaskThread.execute(DriverTaskThread.java:83)
        at org.apache.iotdb.db.queryengine.execution.schedule.AbstractDriverThread.run(AbstractDriverThread.java:79)