### PR TITLE
Resolve the problem that python client don't support DATE data type in the IntColumn

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/TimeseriesMetadata.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/TimeseriesMetadata.java
@@ -328,7 +328,7 @@ public class TimeseriesMetadata implements ITimeSeriesMetadata {
   }
 
   public boolean typeMatch(TSDataType dataType) {
-    return (this.dataType == dataType) || dataType.isCompatible(getTsDataType());
+    return dataType.isCompatible(getTsDataType());
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/TimeseriesMetadata.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/TimeseriesMetadata.java
@@ -328,7 +328,7 @@ public class TimeseriesMetadata implements ITimeSeriesMetadata {
   }
 
   public boolean typeMatch(TSDataType dataType) {
-    return this.dataType == dataType;
+    return (this.dataType == dataType) || dataType.isCompatible(getTsDataType());
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TsBlockSerde.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TsBlockSerde.java
@@ -103,6 +103,9 @@ public class TsBlockSerde {
 
     // Value column data types.
     for (int i = 0; i < tsBlock.getValueColumnCount(); i++) {
+      if (tsBlock.getColumn(i).getDataType() == TSDataType.DATE) {
+        ((IntColumn) tsBlock.getColumn(i)).modifyDataType(TSDataType.INT32);
+      }
       tsBlock.getColumn(i).getDataType().serializeTo(dataOutputStream);
     }
 


### PR DESCRIPTION
Resolve the problem that python client don't support DATE data type in the IntColumn;
Support data type compatible validation in the TimeSeriesMetadata.

cd iotdb/iotdb-client/client-py, run “python session_example_date.py”
<img width="599" height="161" alt="image" src="https://github.com/user-attachments/assets/05736751-651d-4ef5-8c14-fffd24fc3974" />
