### PR TITLE
TimeFilter.canSkip() use getStatistics() method

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/read/filter/basic/TimeFilter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/filter/basic/TimeFilter.java
@@ -152,7 +152,7 @@ public abstract class TimeFilter extends Filter {
 
   @Override
   public boolean allSatisfy(IMetadata metadata) {
-    Statistics<? extends Serializable> timeStatistics = metadata.getTimeStatistics();
-    return containStartEndTime(timeStatistics.getStartTime(), timeStatistics.getEndTime());
+    Statistics<? extends Serializable> statistics = metadata.getStatistics();
+    return containStartEndTime(statistics.getStartTime(), statistics.getEndTime());
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/filter/basic/TimeFilter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/filter/basic/TimeFilter.java
@@ -146,8 +146,8 @@ public abstract class TimeFilter extends Filter {
 
   @Override
   public boolean canSkip(IMetadata metadata) {
-    Statistics<? extends Serializable> timeStatistics = metadata.getTimeStatistics();
-    return !satisfyStartEndTime(timeStatistics.getStartTime(), timeStatistics.getEndTime());
+    Statistics<? extends Serializable> statistics = metadata.getStatistics();
+    return !satisfyStartEndTime(statistics.getStartTime(), statistics.getEndTime());
   }
 
   @Override


### PR DESCRIPTION
This PR fixes an inconsistency in time-filter based skipping of TimeseriesMetadata that may lead to an infinite loop during metadata unpacking.

In the current implementation, the canSkip decision is made using
timeSeriesMetadata.getTimeStatistics(), while the subsequent processing logic relies on getStatistics().
These two statistics sources are not always equivalent.

Specifically, when a value column contains only one measurement, getStatistics() may directly reuse the statistics from the value column’s TimeseriesMetadata, which can produce a different time range from getTimeStatistics().

As a result:

A TimeseriesMetadata that should have been filtered out may pass the canSkip check

Later, during the unpacking of overlapped TimeseriesMetadata, no actual overlap can be found

This causes the unpacking logic to repeatedly retry and enter an infinite loop

The root cause is that:

The time filter overlaps with getTimeStatistics()

But does not overlap with the time range returned by getStatistics()

This PR ensures that the same and consistent time statistics are used throughout the skip decision and subsequent processing, preventing mismatched judgments and eliminating the infinite loop scenario.