### PR TITLE
Fix value and time chunk misalignment when rewriting with time deletion

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/Chunk.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/Chunk.java
@@ -234,7 +234,16 @@ public class Chunk {
             encryptParam);
     List<Chunk> valueChunks = new ArrayList<>();
     valueChunks.add(this);
-    TableChunkReader chunkReader = new TableChunkReader(timeChunk, valueChunks, null);
+    TableChunkReader chunkReader =
+        new TableChunkReader(
+            new Chunk(
+                timeChunk.getHeader(),
+                timeChunk.getData(),
+                null,
+                timeChunk.getChunkStatistic(),
+                timeChunk.getEncryptParam()),
+            valueChunks,
+            null);
     List<IPageReader> pages = chunkReader.loadPageReaderList();
     for (IPageReader page : pages) {
       IPointReader pointReader = page.getAllSatisfiedPageData().getBatchDataIterator();

--- a/java/tsfile/src/test/java/org/apache/tsfile/write/ChunkRewriteTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/write/ChunkRewriteTest.java
@@ -24,6 +24,7 @@ import org.apache.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.tsfile.read.TimeValuePair;
 import org.apache.tsfile.read.common.BatchData;
 import org.apache.tsfile.read.common.Chunk;
+import org.apache.tsfile.read.common.TimeRange;
 import org.apache.tsfile.read.reader.IPageReader;
 import org.apache.tsfile.read.reader.IPointReader;
 import org.apache.tsfile.read.reader.chunk.AlignedChunkReader;
@@ -43,6 +44,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -108,6 +110,76 @@ public class ChunkRewriteTest {
         i++;
       }
       assertEquals(20, i - 1);
+    }
+    timeChunk.getData().flip();
+    valueChunks.get(0).getData().flip();
+    valueChunks.get(1).getData().flip();
+    valueChunks.get(2).getData().flip();
+
+    //
+
+  }
+
+  @Test
+  public void AlignedChunkSinglePageWithTimeDeletionTest() throws IOException {
+    String[] measurements = new String[] {"s1", "s2", "s3"};
+    TSDataType[] types = new TSDataType[] {TSDataType.FLOAT, TSDataType.INT32, TSDataType.DOUBLE};
+    VectorMeasurementSchema measurementSchema =
+        new VectorMeasurementSchema("table1.d1", measurements, types);
+    AlignedChunkWriterImpl chunkWriter = new AlignedChunkWriterImpl(measurementSchema);
+
+    for (int time = 1; time <= 20; time++) {
+      chunkWriter.write(time, (float) time, false);
+      chunkWriter.write(time, time, false);
+      chunkWriter.write(time, (double) time, false);
+      chunkWriter.write(time);
+    }
+    chunkWriter.sealCurrentPage();
+
+    TimeChunkWriter timeChunkWriter = chunkWriter.getTimeChunkWriter();
+    List<ValueChunkWriter> valueChunkWriters = chunkWriter.getValueChunkWriterList();
+
+    Chunk timeChunk = getTimeChunk(measurementSchema, timeChunkWriter);
+
+    List<Chunk> valueChunks = getValueChunks(valueChunkWriters);
+
+    AlignedChunkReader chunkReader = new AlignedChunkReader(timeChunk, valueChunks);
+    List<IPageReader> pageReaders = chunkReader.loadPageReaderList();
+    for (IPageReader page : pageReaders) {
+      IPointReader pointReader = ((AlignedPageReader) page).getLazyPointReader();
+      int i = 1;
+      while (pointReader.hasNextTimeValuePair()) {
+        TimeValuePair point = pointReader.nextTimeValuePair();
+        assertEquals((long) i, point.getTimestamp());
+        assertEquals((float) i, point.getValue().getVector()[0].getValue());
+        assertEquals(i, point.getValue().getVector()[1].getValue());
+        assertEquals((double) i, point.getValue().getVector()[2].getValue());
+        i++;
+      }
+    }
+    timeChunk.getData().flip();
+    valueChunks.get(0).getData().flip();
+    valueChunks.get(1).getData().flip();
+    valueChunks.get(2).getData().flip();
+    // delete
+    timeChunk.setDeleteIntervalList(Collections.singletonList(new TimeRange(0, 9)));
+    // rewrite INT32->DOUBLE
+    Chunk newValueChunk = valueChunks.get(1).rewrite(TSDataType.DOUBLE, timeChunk);
+    valueChunks.set(1, newValueChunk);
+    TableChunkReader newChunkReader = new TableChunkReader(timeChunk, valueChunks, null);
+    List<IPageReader> newPageReaders = newChunkReader.loadPageReaderList();
+    for (IPageReader page : newPageReaders) {
+      IPointReader pointReader = page.getAllSatisfiedPageData().getBatchDataIterator();
+      int i = 1;
+      while (pointReader.hasNextTimeValuePair()) {
+        TimeValuePair point = pointReader.nextTimeValuePair();
+        assertEquals((long) i + 9, point.getTimestamp());
+        assertEquals((float) (i + 9), point.getValue().getVector()[0].getValue());
+        assertEquals((double) (i + 9), point.getValue().getVector()[1].getValue());
+        assertEquals((double) (i + 9), point.getValue().getVector()[2].getValue());
+        i++;
+      }
+      assertEquals(11, i - 1);
     }
     timeChunk.getData().flip();
     valueChunks.get(0).getData().flip();


### PR DESCRIPTION
## Background

When rewriting a value chunk to a new data type, the rewrite logic relies on
TableChunkReader to iterate over time-value pairs using the provided time
chunk and value chunk.

However, in the presence of time deletions, the original implementation
passed the original timeChunk directly into TableChunkReader. Since the
time chunk still contained deletion intervals, the filtered time sequence could
become inconsistent with the value chunk being rewritten.

## Problem

With time deletions applied, the rewritten value chunk could contain points
that are not properly aligned with the corresponding timestamps in the time
chunk. This results in:

* Incorrect time-value pairing
* Inconsistent rewritten chunks
* Potential query correctness issues after type modification

## Solution

This PR fixes the issue by reconstructing a clean time chunk before rewrite:

* A new Chunk is created from the original time chunk’s header, data,
statistics, and encryption parameters
* Deletion intervals are intentionally removed from the time chunk used by
TableChunkReader
* The rewrite process now iterates over fully aligned time-value pairs

This guarantees that the rewritten value chunk remains correctly aligned with
the time chunk, even when time deletions exist.

## Impact

* Ensures correctness when rewriting value chunks with a new data type
* Fixes potential time-value misalignment caused by time deletions
* No behavior change for cases without deletions