### PR TITLE
Prevent modified flag from being overwritten

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/file/header/PageHeader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/header/PageHeader.java
@@ -170,7 +170,7 @@ public class PageHeader implements IMetadata {
   }
 
   public void setModified(boolean modified) {
-    this.modified = modified;
+    this.modified |= modified;
   }
 
   /** max page header size without statistics. */

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/ChunkMetadata.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/ChunkMetadata.java
@@ -334,7 +334,7 @@ public class ChunkMetadata implements IChunkMetadata {
 
   @Override
   public void setModified(boolean modified) {
-    this.modified = modified;
+    this.modified |= modified;
   }
 
   public static long calculateRamSize(String measurementId, TSDataType dataType) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/TimeseriesMetadata.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/TimeseriesMetadata.java
@@ -355,7 +355,7 @@ public class TimeseriesMetadata implements ITimeSeriesMetadata {
 
   @Override
   public void setModified(boolean modified) {
-    this.modified = modified;
+    this.modified |= modified;
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/reader/page/AbstractAlignedPageReader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/reader/page/AbstractAlignedPageReader.java
@@ -350,7 +350,7 @@ public abstract class AbstractAlignedPageReader implements IPageReader {
 
   @Override
   public void setModified(boolean modified) {
-    this.isModified = modified;
+    this.isModified |= modified;
   }
 
   @Override


### PR DESCRIPTION
Use logical OR assignment in setModified to ensure the modified state is sticky once it becomes true.