### PR TITLE
add 'dataTypeModifiedAndCannotUseStatistics'

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/AbstractAlignedChunkMetadata.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/AbstractAlignedChunkMetadata.java
@@ -86,6 +86,18 @@ public abstract class AbstractAlignedChunkMetadata implements IChunkMetadata {
   }
 
   @Override
+  public boolean isDataTypeModifiedAndCannotUseStatistics() {
+    return timeChunkMetadata.isDataTypeModifiedAndCannotUseStatistics();
+  }
+
+  @Override
+  public void setDataTypeModifiedAndCannotUseStatistics(
+      boolean dataTypeModifiedAndCannotUseStatistics) {
+    timeChunkMetadata.setDataTypeModifiedAndCannotUseStatistics(
+        dataTypeModifiedAndCannotUseStatistics);
+  }
+
+  @Override
   public boolean isSeq() {
     return timeChunkMetadata.isSeq();
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/AbstractAlignedTimeSeriesMetadata.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/AbstractAlignedTimeSeriesMetadata.java
@@ -85,6 +85,18 @@ public abstract class AbstractAlignedTimeSeriesMetadata implements ITimeSeriesMe
   }
 
   @Override
+  public boolean isDataTypeModifiedAndCannotUseStatistics() {
+    return timeseriesMetadata.isDataTypeModifiedAndCannotUseStatistics();
+  }
+
+  @Override
+  public void setDataTypeModifiedAndCannotUseStatistics(
+      boolean dataTypeModifiedAndCannotUseStatistics) {
+    timeseriesMetadata.setDataTypeModifiedAndCannotUseStatistics(
+        dataTypeModifiedAndCannotUseStatistics);
+  }
+
+  @Override
   public boolean isSeq() {
     return timeseriesMetadata.isSeq();
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/ChunkMetadata.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/ChunkMetadata.java
@@ -75,6 +75,10 @@ public class ChunkMetadata implements IChunkMetadata {
 
   private boolean modified;
 
+  // data type modified
+  // Unlike the 'modified' property, this property should be passed down to a lower level.
+  private boolean dataTypeModifiedAndCannotUseStatistics;
+
   /** ChunkLoader of metadata, used to create ChunkReaderWrap. */
   private IChunkLoader chunkLoader;
 
@@ -329,12 +333,23 @@ public class ChunkMetadata implements IChunkMetadata {
 
   @Override
   public boolean isModified() {
-    return modified;
+    return modified || dataTypeModifiedAndCannotUseStatistics;
   }
 
   @Override
   public void setModified(boolean modified) {
     this.modified |= modified;
+  }
+
+  @Override
+  public boolean isDataTypeModifiedAndCannotUseStatistics() {
+    return dataTypeModifiedAndCannotUseStatistics;
+  }
+
+  @Override
+  public void setDataTypeModifiedAndCannotUseStatistics(
+      boolean dataTypeModifiedAndCannotUseStatistics) {
+    this.dataTypeModifiedAndCannotUseStatistics |= dataTypeModifiedAndCannotUseStatistics;
   }
 
   public static long calculateRamSize(String measurementId, TSDataType dataType) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/IChunkMetadata.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/IChunkMetadata.java
@@ -33,6 +33,10 @@ public interface IChunkMetadata extends IMetadata {
 
   void setModified(boolean modified);
 
+  boolean isDataTypeModifiedAndCannotUseStatistics();
+
+  void setDataTypeModifiedAndCannotUseStatistics(boolean dataTypeModifiedAndCannotUseStatistics);
+
   boolean isSeq();
 
   void setSeq(boolean seq);

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/ITimeSeriesMetadata.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/ITimeSeriesMetadata.java
@@ -30,6 +30,10 @@ public interface ITimeSeriesMetadata extends IMetadata {
 
   void setModified(boolean modified);
 
+  boolean isDataTypeModifiedAndCannotUseStatistics();
+
+  void setDataTypeModifiedAndCannotUseStatistics(boolean dataTypeModifiedAndCannotUseStatistics);
+
   boolean isSeq();
 
   void setSeq(boolean seq);

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/TimeseriesMetadata.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/TimeseriesMetadata.java
@@ -81,6 +81,10 @@ public class TimeseriesMetadata implements ITimeSeriesMetadata {
   // modified is true when there are modifications of the series, or from unseq file
   private boolean modified;
 
+  // data type modified
+  // Unlike the 'modified' property, this property should be passed down to a lower level.
+  private boolean dataTypeModifiedAndCannotUseStatistics;
+
   private IChunkMetadataLoader chunkMetadataLoader;
 
   // used for SeriesReader to indicate whether it is a seq/unseq timeseries metadata
@@ -343,19 +347,31 @@ public class TimeseriesMetadata implements ITimeSeriesMetadata {
   public List<IChunkMetadata> getCopiedChunkMetadataList() {
     List<IChunkMetadata> res = new ArrayList<>(chunkMetadataList.size());
     for (IChunkMetadata chunkMetadata : chunkMetadataList) {
-      res.add(new ChunkMetadata((ChunkMetadata) chunkMetadata));
+      ChunkMetadata copiedChunkMetadata = new ChunkMetadata((ChunkMetadata) chunkMetadata);
+      copiedChunkMetadata.setDataTypeModifiedAndCannotUseStatistics(
+          dataTypeModifiedAndCannotUseStatistics);
+      res.add(copiedChunkMetadata);
     }
     return res;
   }
 
   @Override
   public boolean isModified() {
-    return modified;
+    return modified || dataTypeModifiedAndCannotUseStatistics;
   }
 
   @Override
   public void setModified(boolean modified) {
     this.modified |= modified;
+  }
+
+  public boolean isDataTypeModifiedAndCannotUseStatistics() {
+    return dataTypeModifiedAndCannotUseStatistics;
+  }
+
+  public void setDataTypeModifiedAndCannotUseStatistics(
+      boolean dataTypeModifiedAndCannotUseStatistics) {
+    this.dataTypeModifiedAndCannotUseStatistics |= dataTypeModifiedAndCannotUseStatistics;
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/reader/IChunkReader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/reader/IChunkReader.java
@@ -32,5 +32,7 @@ public interface IChunkReader {
 
   void close() throws IOException;
 
+  void markDataTypeModifiedAndCannotUseStatistics();
+
   List<IPageReader> loadPageReaderList() throws IOException;
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/reader/IPageReader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/reader/IPageReader.java
@@ -41,7 +41,8 @@ public interface IPageReader extends IMetadata {
 
   void addRecordFilter(Filter filter);
 
-  // The 'modified' property is also true when a data type need to be modified in query and statistics are no longer available.
+  // The 'modified' property is also true when a data type need to be modified in query and
+  // statistics are no longer available.
   boolean isModified();
 
   void setModified(boolean modified);

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/reader/IPageReader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/reader/IPageReader.java
@@ -41,6 +41,7 @@ public interface IPageReader extends IMetadata {
 
   void addRecordFilter(Filter filter);
 
+  // The 'modified' property is also true when a data type need to be modified in query and statistics are no longer available.
   boolean isModified();
 
   void setModified(boolean modified);

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/reader/chunk/AbstractChunkReader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/reader/chunk/AbstractChunkReader.java
@@ -80,4 +80,13 @@ public abstract class AbstractChunkReader implements IChunkReader {
   public List<IPageReader> loadPageReaderList() {
     return pageReaderList;
   }
+
+  @Override
+  public void markDataTypeModifiedAndCannotUseStatistics() {
+    // In all implementations for now, pageReaderList is completed during construction.
+    // In other cases, this method should be overridden.
+    for (IPageReader iPageReader : pageReaderList) {
+      iPageReader.setModified(true);
+    }
+  }
 }


### PR DESCRIPTION
### Purpose

* Ensure the "data type modified" state that prevents using statistics is propagated from time series metadata down to chunk metadata and is considered when deciding whether metadata is "modified".
* Fix lost/ignored data-type-modified information when metadata is copied or passed down, so downstream consumers correctly treat metadata as modified when statistics cannot be used.
### What changed

* Added a new boolean field dataTypeModifiedAndCannotUseStatistics to:
	* TimeseriesMetadata
	* ChunkMetadata
* Added accessor/mutator methods for the new flag to:
	* ITimeSeriesMetadata (interface)
	* IChunkMetadata (interface)
* Implemented propagation and usage:
	* TimeseriesMetadata.getCopiedChunkMetadataList now copies the dataTypeModifiedAndCannotUseStatistics flag into copied ChunkMetadata instances.
	* TimeseriesMetadata.isModified and ChunkMetadata.isModified now return true if either the existing modified flag or dataTypeModifiedAndCannotUseStatistics is true.
	* ChunkMetadata.setDataTypeModifiedAndCannotUseStatistics and TimeseriesMetadata.setDataTypeModifiedAndCannotUseStatistics use |= semantics to accumulate the flag (preserve any previous true).
	* AbstractAlignedChunkMetadata and AbstractAlignedTimeSeriesMetadata delegate the new getter/setter to their underlying time/timeseries metadata objects so aligned metadata also exposes and propagates the flag.
