### PR TITLE
fix readme logo

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -28,7 +28,7 @@
 </p>
 
 [![codecov](https://codecov.io/github/apache/tsfile/graph/badge.svg?token=0Y8MVAB3K1)](https://codecov.io/github/apache/tsfile)
-[![Maven Version](https://maven-badges.herokuapp.com/maven-central/org.apache.tsfile/tsfile-parent/badge.svg)](http://search.maven.org/#search|gav|1|g:"org.apache.tsfile")
+[![Maven Central](https://img.shields.io/maven-central/v/org.apache.tsfile/tsfile-parent.svg)](https://central.sonatype.com/artifact/org.apache.tsfile/tsfile-parent)
 
 ## 简介
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -21,14 +21,12 @@
 
 [English](./README.md) | [中文](./README-zh.md)
 # TsFile Document
-<pre>
-___________    ___________.__.__          
-\__    ___/____\_   _____/|__|  |   ____  
-  |    | /  ___/|    __)  |  |  | _/ __ \ 
-  |    | \___ \ |     \   |  |  |_\  ___/ 
-  |____|/____  >\___  /   |__|____/\___  >  version 2.1.0
-             \/     \/                 \/  
-</pre>
+<p align="center">
+  <img src="https://www.apache.org/logos/originals/tsfile.svg"
+       alt="TsFile Logo"
+       width="400"/>
+</p>
+
 [![codecov](https://codecov.io/github/apache/tsfile/graph/badge.svg?token=0Y8MVAB3K1)](https://codecov.io/github/apache/tsfile)
 [![Maven Version](https://maven-badges.herokuapp.com/maven-central/org.apache.tsfile/tsfile-parent/badge.svg)](http://search.maven.org/#search|gav|1|g:"org.apache.tsfile")
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,13 @@
 
 [English](./README.md) | [中文](./README-zh.md)
 # TsFile Document
-<pre>
-___________    ___________.__.__          
-\__    ___/____\_   _____/|__|  |   ____  
-  |    | /  ___/|    __)  |  |  | _/ __ \ 
-  |    | \___ \ |     \   |  |  |_\  ___/ 
-  |____|/____  >\___  /   |__|____/\___  >  version 2.1.0
-             \/     \/                 \/  
-</pre>
+
+<p align="center">
+  <img src="https://www.apache.org/logos/originals/tsfile.svg"
+       alt="TsFile Logo"
+       width="400"/>
+</p>
+
 [![codecov](https://codecov.io/github/apache/tsfile/graph/badge.svg?token=0Y8MVAB3K1)](https://codecov.io/github/apache/tsfile)
 [![Maven Version](https://maven-badges.herokuapp.com/maven-central/org.apache.tsfile/tsfile-parent/badge.svg)](http://search.maven.org/#search|gav|1|g:"org.apache.tsfile")
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@
 </p>
 
 [![codecov](https://codecov.io/github/apache/tsfile/graph/badge.svg?token=0Y8MVAB3K1)](https://codecov.io/github/apache/tsfile)
-[![Maven Version](https://maven-badges.herokuapp.com/maven-central/org.apache.tsfile/tsfile-parent/badge.svg)](http://search.maven.org/#search|gav|1|g:"org.apache.tsfile")
-
+[![Maven Central](https://img.shields.io/maven-central/v/org.apache.tsfile/tsfile-parent.svg)](https://central.sonatype.com/artifact/org.apache.tsfile/tsfile-parent)
 ## Introduction
 
 TsFile is a columnar storage file format designed for time series data, which supports efficient compression, high throughput of read and write, and compatibility with various frameworks, such as Spark and Flink. It is easy to integrate TsFile into IoT big data processing frameworks.

--- a/cpp/README-zh.md
+++ b/cpp/README-zh.md
@@ -19,16 +19,102 @@
 
 -->
 
-# TsFile C++ Document
-<pre>
-___________    ___________.__.__          
-\__    ___/____\_   _____/|__|  |   ____  
-  |    | /  ___/|    __)  |  |  | _/ __ \ 
-  |    | \___ \ |     \   |  |  |_\  ___/ 
-  |____|/____  >\___  /   |__|____/\___  >  version 2.1.0
-             \/     \/                 \/  
-</pre>
+# TsFile C++ 文档
 
-## 使用
+<p align="center">
+  <img src="https://www.apache.org/logos/originals/tsfile.svg"
+       alt="TsFile Logo"
+       width="400"/>
+</p>
 
-## 开发
+## 简介
+
+本目录包含 TsFile 的 C++ 实现版本。目前，C++ 版本支持 TsFile 的查询与写入功能，包括基于时间过滤的查询。
+
+源代码位于 `./src` 目录。
+C/C++ 示例代码位于 `./examples` 目录。
+TsFile_cpp 的性能基准测试位于 `./bench_mark` 目录。
+
+此外，在 `./src/cwrapper` 目录中提供了 C 函数封装接口，Python 工具依赖该封装。
+
+---
+
+## 如何贡献
+
+我们使用 `clang-format` 来确保 C++ 代码遵循 `./clang-format` 文件中定义的一致规范（类似于 Google 风格）。
+
+欢迎提交任何 Bug 报告。
+你可以创建一个以 `[CPP]` 开头的 Issue 来描述问题，例如：
+https://github.com/apache/tsfile/issues/94
+
+---
+
+## 构建
+
+### 环境要求
+
+```bash
+sudo apt-get update
+sudo apt-get install -y cmake make g++ clang-format libuuid-dev
+```
+
+构建 tsfile：
+
+```bash
+bash build.sh
+```
+
+如果你安装了 Maven 工具，也可以运行：
+
+```bash
+mvn package -P with-cpp clean verify
+```
+
+构建完成后，可在 `./build` 目录下找到生成的共享库文件。
+
+在向 GitHub 提交代码之前，请确保 `mvn` 编译通过。
+
+---
+
+### Windows 下 MinGW 编译问题
+
+如果你在 Windows 下使用 MinGW 编译时遇到错误，可以尝试使用以下我们验证通过的版本：
+
+- GCC 14.2.0（**POSIX** 线程） + LLVM/Clang/LLD/LLDB 18.1.8 + MinGW-w64 12.0.0 UCRT - release 1
+- GCC 12.2.0 + LLVM/Clang/LLD/LLDB 16.0.0 + MinGW-w64 10.0.0（UCRT）- release 5
+- GCC 12.2.0 + LLVM/Clang/LLD/LLDB 16.0.0 + MinGW-w64 10.0.0（MSVCRT）- release 5
+- GCC 11.2.0 + MinGW-w64 10.0.0（MSVCRT）- release 1
+
+---
+
+## 配置交叉编译工具链
+
+修改工具链文件 `cmake/ToolChain.cmake`，定义以下变量：
+
+- `CMAKE_C_COMPILER`：指定 C 编译器路径。
+- `CMAKE_CXX_COMPILER`：指定 C++ 编译器路径。
+- `CMAKE_FIND_ROOT_PATH`：设置交叉编译环境的根路径（例如交叉编译工具链目录）。
+
+在 `cpp/` 目录下执行以下命令创建构建目录并开始编译：
+
+```bash
+mkdir build && cd build
+cmake .. -DToolChain=ON
+make
+```
+
+---
+
+## 使用 TsFile
+
+你可以在 `./examples/cpp_examples` 目录下的 `demo_read.cpp` 和 `demo_write.cpp` 中查看读写数据的示例。
+
+在 `./examples/c_examples` 目录下，还提供了使用 C 风格 API 在 C 环境中读写数据的示例。
+
+在 `./examples` 目录下执行：
+
+```bash
+bash build.sh
+```
+
+即可在 `./examples/build` 目录下生成可执行文件。

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -21,15 +21,11 @@
 
 # TsFile C++ Document
 
-<pre>
-___________    ___________.__.__          
-\__    ___/____\_   _____/|__|  |   ____  
-  |    | /  ___/|    __)  |  |  | _/ __ \ 
-  |    | \___ \ |     \   |  |  |_\  ___/ 
-  |____|/____  >\___  /   |__|____/\___  >  version 2.1.0
-             \/     \/                 \/  
-</pre>
-
+<p align="center">
+  <img src="https://www.apache.org/logos/originals/tsfile.svg"
+       alt="TsFile Logo"
+       width="400"/>
+</p>
 
 ## Introduction
 

--- a/java/tsfile/README-zh.md
+++ b/java/tsfile/README-zh.md
@@ -21,14 +21,11 @@
 
 [English](./README.md) | [中文](./README-zh.md)
 # TsFile Java Document
-<pre>
-___________    ___________.__.__          
-\__    ___/____\_   _____/|__|  |   ____  
-  |    | /  ___/|    __)  |  |  | _/ __ \ 
-  |    | \___ \ |     \   |  |  |_\  ___/ 
-  |____|/____  >\___  /   |__|____/\___  >  version 2.1.0
-             \/     \/                 \/  
-</pre>
+<p align="center">
+  <img src="https://www.apache.org/logos/originals/tsfile.svg"
+       alt="TsFile Logo"
+       width="400"/>
+</p>
 
 ## 使用
 

--- a/java/tsfile/README.md
+++ b/java/tsfile/README.md
@@ -21,14 +21,11 @@
 
 [English](./README.md) | [中文](./README-zh.md)
 # TsFile Java Document
-<pre>
-___________    ___________.__.__          
-\__    ___/____\_   _____/|__|  |   ____  
-  |    | /  ___/|    __)  |  |  | _/ __ \ 
-  |    | \___ \ |     \   |  |  |_\  ___/ 
-  |____|/____  >\___  /   |__|____/\___  >  version 2.1.0
-             \/     \/                 \/  
-</pre>
+<p align="center">
+  <img src="https://www.apache.org/logos/originals/tsfile.svg"
+       alt="TsFile Logo"
+       width="400"/>
+</p>
 
 ## Use TsFile
 

--- a/python/README-zh.md
+++ b/python/README-zh.md
@@ -19,16 +19,51 @@
 
 -->
 
-# TsFile Python Document
-<pre>
-___________    ___________.__.__          
-\__    ___/____\_   _____/|__|  |   ____  
-  |    | /  ___/|    __)  |  |  | _/ __ \ 
-  |    | \___ \ |     \   |  |  |_\  ___/ 
-  |____|/____  >\___  /   |__|____/\___  >  version 21.0
-             \/     \/                 \/  
-</pre>
+# TsFile Python 文档
 
-## 使用
+<p align="center">
+  <img src="https://www.apache.org/logos/originals/tsfile.svg"
+       alt="TsFile Logo"
+       width="400"/>
+</p>
 
-## 开发
+## 简介
+
+本目录包含 TsFile 的 Python 实现版本。Python 版本基于 C++ 版本构建，并通过 Cython 包将 TsFile 的读写能力集成到 Python 环境中。用户可以像在 Pandas 中使用 read_csv 和 write_csv 一样，方便地读取和写入 TsFile。
+
+源代码位于 `./tsfile` 目录。
+以 `.pyx` 和 `.pyd` 结尾的文件为使用 Cython 编写的封装代码。
+`tsfile/tsfile.py` 中定义了一些对用户开放的接口。
+
+你可以在 `./examples/examples.py` 中找到读写示例。
+
+---
+
+## 如何贡献
+
+建议使用 pylint 对 Python 代码进行检查。
+
+目前尚无合适的 Cython 代码风格检查工具，因此 Cython 部分代码应遵循 pylint 所要求的 Python 代码风格。
+
+**功能列表**
+
+- [ ] 在 pywrapper 中调用 TsFile C++ 版本实现的批量读取接口。
+- [ ] 支持将多个 DataFrame 写入同一个 TsFile 文件。
+
+---
+
+## 构建
+
+在构建 TsFile 的 Python 版本之前，必须先构建 [TsFile C++ 版本](../cpp/README.md)，因为 Python 版本依赖于 C++ 版本生成的共享库文件。
+
+### 使用 Maven 在根目录构建
+
+```sh
+mvn -P with-cpp,with-python clean verify
+```
+
+### 使用 Python 命令构建
+
+```sh
+python setup.py build_ext --inplace
+```

--- a/python/README.md
+++ b/python/README.md
@@ -21,14 +21,11 @@
 
 # TsFile Python Document
 
-<pre>
-___________    ___________.__.__          
-\__    ___/____\_   _____/|__|  |   ____  
-  |    | /  ___/|    __)  |  |  | _/ __ \ 
-  |    | \___ \ |     \   |  |  |_\  ___/ 
-  |____|/____  >\___  /   |__|____/\___  >  version 2.1.0
-             \/     \/                 \/  
-</pre>
+<p align="center">
+  <img src="https://www.apache.org/logos/originals/tsfile.svg"
+       alt="TsFile Logo"
+       width="400"/>
+</p>
 
 
 ## Introduction


### PR DESCRIPTION
Replace the outdated Heroku-based Maven badge with a shields.io badge.

The previous service is no longer maintained and may not render reliably.
shields.io provides a stable and actively maintained alternative.