### PR TITLE
Fix/infer object column type bool

### DIFF
--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -26,7 +26,7 @@ from tsfile import ColumnSchema, TableSchema, TSDataType, TIME_COLUMN
 from tsfile import TsFileTableWriter, ColumnCategory
 from tsfile import to_dataframe
 from tsfile.exceptions import ColumnNotExistError, TypeMismatchError
-from tsfile.tsfile_table_writer import validate_dataframe_for_tsfile
+from tsfile.tsfile_table_writer import validate_dataframe_for_tsfile, infer_object_column_type
 
 
 def convert_to_nullable_types(df):
@@ -49,6 +49,14 @@ def convert_to_nullable_types(df):
         elif dtype == 'bool':
             df[col] = df[col].astype('boolean')
     return df
+
+
+def test_infer_object_column_type_bool():
+    """infer_object_column_type should infer BOOLEAN for object column containing bool values."""
+    s_true = pd.Series([True, False], dtype=object)
+    assert infer_object_column_type(s_true) == TSDataType.BOOLEAN
+    s_false = pd.Series([False], dtype=object)
+    assert infer_object_column_type(s_false) == TSDataType.BOOLEAN
 
 
 def test_write_dataframe_basic():

--- a/python/tsfile/tsfile_table_writer.py
+++ b/python/tsfile/tsfile_table_writer.py
@@ -69,10 +69,12 @@ def infer_object_column_type(column_series: pd.Series) -> TSDataType:
         return TSDataType.BLOB
     if isinstance(value, (date, datetime)):
         return TSDataType.DATE
+    if isinstance(value, bool):
+        return TSDataType.BOOLEAN
     if isinstance(value, str):
         return TSDataType.STRING
     raise TypeError(
-        f"Cannot infer type from object column: expected str/bytes/date, got {type(value).__name__}: {value!r}"
+        f"Cannot infer type from object column: expected str/bytes/date/bool, got {type(value).__name__}: {value!r}"
     )
 
 


### PR DESCRIPTION
Fix: Add bool handling in infer_object_column_type so object columns that are effectively bool (e.g. after adding None) infer as TSDataType.BOOLEAN instead of raising TypeError.
