### PR TITLE
fix disable QueryByRowFasterThanManualNext tests

### DIFF
--- a/cpp/test/reader/table_view/tsfile_table_query_by_row_test.cc
+++ b/cpp/test/reader/table_view/tsfile_table_query_by_row_test.cc
@@ -652,7 +652,7 @@ TEST_F(TableQueryByRowTest, DenseSingleDeviceSsiLevelPushdown) {
 // Pushdown is faster than full query + manual next: queryByRow(offset, limit)
 // skips at device/SSI/Chunk level; old query then manual next decodes every
 // row. Timing tolerance 20% to allow measurement noise.
-TEST_F(TableQueryByRowTest, QueryByRowFasterThanManualNext) {
+TEST_F(TableQueryByRowTest, DISABLED_QueryByRowFasterThanManualNext) {
     const int num_rows = 8000;
     const int offset = 3000;
     const int limit = 1000;

--- a/cpp/test/reader/tree_view/tsfile_tree_query_by_row_test.cc
+++ b/cpp/test/reader/tree_view/tsfile_tree_query_by_row_test.cc
@@ -1103,7 +1103,7 @@ TEST_F(TreeQueryByRowTest, MultiPath_TimeHint_SkipsStaleChunk_WithOffset) {
 // Pushdown is faster than full query + manual next: queryByRow(offset, limit)
 // skips at Chunk/Page level; old query then manual next decodes every row.
 // Timing tolerance 20% to allow measurement noise.
-TEST_F(TreeQueryByRowTest, QueryByRowFasterThanManualNext) {
+TEST_F(TreeQueryByRowTest, DISABLED_QueryByRowFasterThanManualNext) {
     std::vector<std::string> devices = {"d1"};
     std::vector<std::string> measurements = {"s1"};
     const int num_rows = 8000;


### PR DESCRIPTION
Disable the  QueryByRowFasterThanManualNext performance tests (tree and table models), which occasionally fail due to timing noise.