### PR TITLE
fix cpp device_id parser

### DIFF
--- a/cpp/src/common/CMakeLists.txt
+++ b/cpp/src/common/CMakeLists.txt
@@ -33,6 +33,10 @@ add_library(common_obj OBJECT ${common_SRC_LIST}
     ${common_mutex_SRC_LIST} 
     ${common_datatype_SRC_LIST})
 
+if (ENABLE_ANTLR4)
+    target_compile_definitions(common_obj PRIVATE ENABLE_ANTLR4)
+endif()
+
 # install header files recursively
 file(GLOB_RECURSE HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
 copy_to_dir(${HEADERS} "common_obj")

--- a/cpp/src/common/device_id.cc
+++ b/cpp/src/common/device_id.cc
@@ -211,7 +211,8 @@ std::vector<std::string> StringArrayDeviceID::split_device_id_string(
     auto splits = storage::PathNodesGenerator::invokeParser(device_id_string);
     return split_device_id_string(splits);
 #else
-    return split_string(device_id_string, '.');
+    auto splits = split_string(device_id_string, '.');
+    return split_device_id_string(splits);
 #endif
 }
 

--- a/cpp/src/common/path.cc
+++ b/cpp/src/common/path.cc
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "common/path.h"
+
+#ifdef ENABLE_ANTLR4
+#include "parser/path_nodes_generator.h"
+#endif
+
+namespace storage {
+
+Path::Path() = default;
+
+Path::Path(std::string& device, std::string& measurement)
+    : measurement_(measurement),
+      device_id_(std::make_shared<StringArrayDeviceID>(device)) {
+    full_path_ = device + "." + measurement;
+}
+
+Path::Path(const std::string& path_sc, bool if_split) {
+    if (!path_sc.empty()) {
+        if (!if_split) {
+            full_path_ = path_sc;
+            device_id_ = std::make_shared<StringArrayDeviceID>(path_sc);
+        } else {
+#ifdef ENABLE_ANTLR4
+            std::vector<std::string> nodes =
+                PathNodesGenerator::invokeParser(path_sc);
+#else
+            std::vector<std::string> nodes =
+                IDeviceID::split_string(path_sc, '.');
+#endif
+            if (nodes.size() > 1) {
+                device_id_ = std::make_shared<StringArrayDeviceID>(
+                    std::vector<std::string>(nodes.begin(), nodes.end() - 1));
+                measurement_ = nodes[nodes.size() - 1];
+                full_path_ = device_id_->get_device_name() + "." + measurement_;
+            } else {
+                full_path_ = path_sc;
+                device_id_ = std::make_shared<StringArrayDeviceID>();
+                measurement_ = path_sc;
+            }
+        }
+    } else {
+        full_path_ = "";
+        device_id_ = std::make_shared<StringArrayDeviceID>();
+        measurement_ = "";
+    }
+}
+
+}  // namespace storage

--- a/cpp/src/common/path.h
+++ b/cpp/src/common/path.h
@@ -22,10 +22,6 @@
 #include <string>
 
 #include "common/device_id.h"
-#ifdef ENABLE_ANTLR4
-#include "parser/generated/PathParser.h"
-#include "parser/path_nodes_generator.h"
-#endif
 #include "utils/errno_define.h"
 
 namespace storage {
@@ -35,46 +31,9 @@ struct Path {
     std::shared_ptr<IDeviceID> device_id_;
     std::string full_path_;
 
-    Path() {}
-
-    Path(std::string& device, std::string& measurement)
-        : measurement_(measurement),
-          device_id_(std::make_shared<StringArrayDeviceID>(device)) {
-        full_path_ = device + "." + measurement;
-    }
-
-    Path(const std::string& path_sc, bool if_split = true) {
-        if (!path_sc.empty()) {
-            if (!if_split) {
-                full_path_ = path_sc;
-                device_id_ = std::make_shared<StringArrayDeviceID>(path_sc);
-            } else {
-#ifdef ENABLE_ANTLR4
-                std::vector<std::string> nodes =
-                    PathNodesGenerator::invokeParser(path_sc);
-#else
-                std::vector<std::string> nodes =
-                    IDeviceID::split_string(path_sc, '.');
-#endif
-                if (nodes.size() > 1) {
-                    device_id_ = std::make_shared<StringArrayDeviceID>(
-                        std::vector<std::string>(nodes.begin(),
-                                                 nodes.end() - 1));
-                    measurement_ = nodes[nodes.size() - 1];
-                    full_path_ =
-                        device_id_->get_device_name() + "." + measurement_;
-                } else {
-                    full_path_ = path_sc;
-                    device_id_ = std::make_shared<StringArrayDeviceID>();
-                    measurement_ = path_sc;
-                }
-            }
-        } else {
-            full_path_ = "";
-            device_id_ = std::make_shared<StringArrayDeviceID>();
-            measurement_ = "";
-        }
-    }
+    Path();
+    Path(std::string& device, std::string& measurement);
+    Path(const std::string& path_sc, bool if_split = true);
 
     bool operator==(const Path& path) {
         if (measurement_.compare(path.measurement_) == 0 &&

--- a/cpp/test/common/device_id_test.cc
+++ b/cpp/test/common/device_id_test.cc
@@ -31,6 +31,16 @@ TEST(DeviceIdTest, NormalTest) {
     ASSERT_EQ("root.db.tb.device1", device_id.get_device_name());
 }
 
+TEST(DeviceIdTest, DeviceIdStringFallbackSemantic) {
+    std::string device_id_string = "root.sg1.FeederA";
+    StringArrayDeviceID device_id = StringArrayDeviceID(device_id_string);
+
+    // For a 3-level identifier, table name should be merged as "root.sg1".
+    ASSERT_EQ("root.sg1", device_id.get_table_name());
+    ASSERT_EQ(2, device_id.segment_num());
+    ASSERT_EQ("root.sg1.FeederA", device_id.get_device_name());
+}
+
 TEST(DeviceIdTest, TabletDeviceId) {
     std::vector<TSDataType> measurement_types{
         TSDataType::STRING, TSDataType::STRING, TSDataType::STRING,


### PR DESCRIPTION
### **Summary**
Fix path parsing inconsistency between ANTLR4 and fallback flows.

### **What changed**
Moved Path parsing into library .cc (library-controlled behavior).
Fixed fallback split_device_id_string to normalize split results instead of returning raw token splits.
Added unit test for root.sg1.FeederA fallback semantics.
**_Previously, ENABLE_ANTLR4 was checked in headers, so it depended on user-side compile flags and could be ignored in real usage._**

### **Impact**
Prevents device/measurement path mismatches that could make IoTDB queries return empty results even when TsFile content is valid.