### PR TITLE
Repro/query tree by row three level

### DIFF
--- a/cpp/src/common/path.cc
+++ b/cpp/src/common/path.cc
@@ -19,6 +19,8 @@
 
 #include "common/path.h"
 
+#include "constant/tsfile_constant.h"
+
 #ifdef ENABLE_ANTLR4
 #include "parser/path_nodes_generator.h"
 #endif
@@ -47,10 +49,20 @@ Path::Path(const std::string& path_sc, bool if_split) {
                 IDeviceID::split_string(path_sc, '.');
 #endif
             if (nodes.size() > 1) {
-                device_id_ = std::make_shared<StringArrayDeviceID>(
-                    std::vector<std::string>(nodes.begin(), nodes.end() - 1));
+                // Build device_id from the same string form as writers use so
+                // StringArrayDeviceID::split_device_id_string canonicalizes
+                // multi-segment paths (e.g. root.sg1.FeederA) consistently.
+                std::string device_str;
+                for (size_t j = 0; j + 1 < nodes.size(); ++j) {
+                    if (j > 0) {
+                        device_str += PATH_SEPARATOR;
+                    }
+                    device_str += nodes[j];
+                }
+                device_id_ = std::make_shared<StringArrayDeviceID>(device_str);
                 measurement_ = nodes[nodes.size() - 1];
-                full_path_ = device_id_->get_device_name() + "." + measurement_;
+                full_path_ = device_id_->get_device_name() + PATH_SEPARATOR +
+                             measurement_;
             } else {
                 full_path_ = path_sc;
                 device_id_ = std::make_shared<StringArrayDeviceID>();

--- a/cpp/src/file/tsfile_io_reader.cc
+++ b/cpp/src/file/tsfile_io_reader.cc
@@ -19,6 +19,9 @@
 
 #include "file/tsfile_io_reader.h"
 
+#include <algorithm>
+#include <vector>
+
 #include "common/allocator/alloc_base.h"
 
 using namespace common;
@@ -457,8 +460,14 @@ int TsFileIOReader::get_timeseries_indexes(
         get_time_column_metadata(top_node, timeseries_index, pa);
     }
 
+    // Sort names so slot order is identical on all platforms (unordered_set
+    // iteration order differs between libc++ and libstdc++).
+    std::vector<std::string> sorted_names(measurement_names.begin(),
+                                          measurement_names.end());
+    std::sort(sorted_names.begin(), sorted_names.end());
+
     int64_t idx = 0;
-    for (const auto& measurement_name : measurement_names) {
+    for (const auto& measurement_name : sorted_names) {
         if (RET_FAIL(load_measurement_index_entry(measurement_name, top_node,
                                                   measurement_index_entry,
                                                   measurement_ie_end_offset))) {

--- a/cpp/src/reader/block/single_device_tsblock_reader.cc
+++ b/cpp/src/reader/block/single_device_tsblock_reader.cc
@@ -19,6 +19,8 @@
 
 #include "single_device_tsblock_reader.h"
 
+#include <unordered_set>
+
 namespace storage {
 
 SingleDeviceTsBlockReader::SingleDeviceTsBlockReader(
@@ -139,14 +141,20 @@ int SingleDeviceTsBlockReader::init_internal(DeviceQueryTask* device_query_task,
         col_appenders_[i] = new common::ColAppender(i, current_block_);
     }
     row_appender_ = new common::RowAppender(current_block_);
-    std::vector<ITimeseriesIndex*> time_series_indexs(
-        device_query_task_->get_column_mapping()
-            ->get_measurement_columns()
-            .size());
+    // ColumnMapping already uses unordered_set; iteration order matches
+    // TsFileIOReader::get_timeseries_indexes (unchanged from prior behavior).
+    std::unordered_set<std::string> meas_names(
+        device_query_task_->get_column_mapping()->get_measurement_columns());
+    if (meas_names.empty()) {
+        for (const auto& f :
+             device_query_task_->get_internal_row_scan_fields()) {
+            meas_names.insert(f);
+        }
+    }
+    std::vector<ITimeseriesIndex*> time_series_indexs(meas_names.size());
     if (RET_FAIL(tsfile_io_reader_->get_timeseries_indexes(
-            device_query_task->get_device_id(),
-            device_query_task->get_column_mapping()->get_measurement_columns(),
-            time_series_indexs, pa_))) {
+            device_query_task->get_device_id(), meas_names, time_series_indexs,
+            pa_))) {
         return ret;
     }
 

--- a/cpp/src/reader/qds_without_timegenerator.cc
+++ b/cpp/src/reader/qds_without_timegenerator.cc
@@ -19,6 +19,7 @@
 
 #include "qds_without_timegenerator.h"
 
+#include "utils/errno_define.h"
 #include "utils/util_define.h"
 
 using namespace common;
@@ -49,9 +50,8 @@ int QDSWithoutTimeGenerator::init_internal(TsFileIOReader* io_reader,
     io_reader_ = io_reader;
     qe_ = qe;
 
-    std::vector<Path> paths = qe_->selected_series_;
-    size_t origin_path_count = paths.size();
-    std::vector<Path> valid_paths;
+    const std::vector<Path> paths = qe_->selected_series_;
+    const size_t origin_path_count = paths.size();
     std::vector<std::string> column_names;
     std::vector<common::TSDataType> data_types;
     column_names.reserve(origin_path_count);
@@ -61,52 +61,71 @@ int QDSWithoutTimeGenerator::init_internal(TsFileIOReader* io_reader,
     if (global_time_expression != nullptr) {
         global_time_filter = global_time_expression->filter_;
     }
+    index_lookup_.clear();
     index_lookup_.insert({"time", 0});
+    ssi_vec_.clear();
+    path_has_ssi_.clear();
+    path_has_ssi_.reserve(origin_path_count);
+
+    auto register_path_columns = [&](size_t i, const Path& p) {
+        column_names.push_back(p.full_path_);
+        const uint32_t col_idx = static_cast<uint32_t>(i) + 1;
+        index_lookup_.insert({p.measurement_, col_idx});
+        if (p.full_path_ != p.measurement_) {
+            index_lookup_.insert({p.full_path_, col_idx});
+        }
+    };
+
     for (size_t i = 0; i < origin_path_count; i++) {
         TsFileSeriesScanIterator* ssi = nullptr;
         ret = io_reader_->alloc_ssi(paths[i].device_id_, paths[i].measurement_,
                                     ssi, pa_, global_time_filter);
+        if (ret == E_MEASUREMENT_NOT_EXIST) {
+            ssi_vec_.push_back(nullptr);
+            path_has_ssi_.push_back(0);
+            register_path_columns(i, paths[i]);
+            continue;
+        }
         if (ret != 0) {
             return ret;
-        } else {
-            index_lookup_.insert({paths[i].measurement_, i + 1});
-            if (paths[i].full_path_ != paths[i].measurement_) {
-                index_lookup_.insert({paths[i].full_path_, i + 1});
-            }
-            ssi_vec_.push_back(ssi);
-            valid_paths.push_back(paths[i]);
-            column_names.push_back(paths[i].full_path_);
         }
+        ssi_vec_.push_back(ssi);
+        path_has_ssi_.push_back(1);
+        register_path_columns(i, paths[i]);
     }
 
-    size_t path_count = valid_paths.size();
+    const size_t path_count = origin_path_count;
     is_single_path_ = (path_count == 1);
-    // Only push offset/limit to SSI for single-path; multi-path applies at
-    // merge.
-    for (size_t i = 0; i < path_count; i++) {
-        ssi_vec_[i]->set_row_range(is_single_path_ ? remaining_offset_ : 0,
-                                   is_single_path_ ? remaining_limit_ : -1);
-    }
-    row_record_ = new RowRecord(path_count + 1);
+
     tsblocks_.resize(path_count);
     time_iters_.resize(path_count);
     value_iters_.resize(path_count);
 
     for (size_t i = 0; i < path_count; i++) {
+        if (!path_has_ssi_[i]) {
+            tsblocks_[i] = nullptr;
+            time_iters_[i] = nullptr;
+            value_iters_[i] = nullptr;
+            data_types.push_back(TSDataType::NULL_TYPE);
+            continue;
+        }
+        ssi_vec_[i]->set_row_range(is_single_path_ ? remaining_offset_ : 0,
+                                   is_single_path_ ? remaining_limit_ : -1);
         get_next_tsblock(i, true);
         data_types.push_back(value_iters_[i] != nullptr
                                  ? value_iters_[i]->get_data_type()
                                  : TSDataType::NULL_TYPE);
     }
+    row_record_ = new RowRecord(path_count + 1);
     // Single-path: SSI may have consumed offset/limit by skipping chunks/pages
     // during first get_next_tsblock(); sync so QDS does not double-apply.
-    if (is_single_path_) {
+    if (is_single_path_ && path_count > 0 && path_has_ssi_[0]) {
         remaining_offset_ = ssi_vec_[0]->get_row_offset();
         remaining_limit_ = ssi_vec_[0]->get_row_limit();
     }
     result_set_metadata_ =
         std::make_shared<ResultSetMetadata>(column_names, data_types);
-    return E_OK;  // ignore invalid timeseries
+    return E_OK;
 }
 
 void QDSWithoutTimeGenerator::close() {
@@ -128,13 +147,17 @@ void QDSWithoutTimeGenerator::close() {
 
     ASSERT(ssi_vec_.size() == tsblocks_.size());
     for (size_t i = 0; i < ssi_vec_.size(); i++) {
-        ssi_vec_[i]->revert_tsblock();
+        if (path_has_ssi_[i]) {
+            ssi_vec_[i]->revert_tsblock();
+        }
     }
     for (size_t i = 0; i < ssi_vec_.size(); i++) {
-        TsFileSeriesScanIterator* ssi = ssi_vec_[i];
-        io_reader_->revert_ssi(ssi);
+        if (path_has_ssi_[i]) {
+            io_reader_->revert_ssi(ssi_vec_[i]);
+        }
     }
     ssi_vec_.clear();
+    path_has_ssi_.clear();
     if (qe_ != nullptr) {
         delete qe_;
         qe_ = nullptr;
@@ -283,6 +306,9 @@ std::shared_ptr<ResultSetMetadata> QDSWithoutTimeGenerator::get_metadata() {
 }
 
 int QDSWithoutTimeGenerator::get_next_tsblock(uint32_t index, bool alloc_mem) {
+    if (index >= ssi_vec_.size() || ssi_vec_[index] == nullptr) {
+        return E_OK;
+    }
     if (tsblocks_[index] != nullptr) {
         delete time_iters_[index];
         time_iters_[index] = nullptr;
@@ -320,6 +346,9 @@ int QDSWithoutTimeGenerator::get_next_tsblock(uint32_t index, bool alloc_mem) {
 int QDSWithoutTimeGenerator::get_next_tsblock_with_hint(uint32_t index,
                                                         bool alloc_mem,
                                                         int64_t min_time_hint) {
+    if (index >= ssi_vec_.size() || ssi_vec_[index] == nullptr) {
+        return E_OK;
+    }
     if (tsblocks_[index] != nullptr) {
         delete time_iters_[index];
         time_iters_[index] = nullptr;

--- a/cpp/src/reader/qds_without_timegenerator.h
+++ b/cpp/src/reader/qds_without_timegenerator.h
@@ -40,6 +40,7 @@ class QDSWithoutTimeGenerator : public ResultSet {
           time_iters_(),
           value_iters_(),
           heap_time_(),
+          path_has_ssi_(),
           remaining_offset_(0),
           remaining_limit_(-1),
           is_single_path_(false) {}
@@ -70,6 +71,9 @@ class QDSWithoutTimeGenerator : public ResultSet {
     std::vector<common::ColIterator*> value_iters_;
     std::multimap<int64_t, uint32_t>
         heap_time_;  // key-->time, value-->path_index
+    /** Same length as ssi_vec_; false if measurement missing (Java
+     * EmptyFileSeriesReader). */
+    std::vector<uint8_t> path_has_ssi_;
     int remaining_offset_;
     int remaining_limit_;
     bool is_single_path_;

--- a/cpp/src/reader/table_query_executor.cc
+++ b/cpp/src/reader/table_query_executor.cc
@@ -19,9 +19,44 @@
 
 #include "reader/table_query_executor.h"
 
+#include <vector>
+
+#include "common/db_common.h"
 #include "utils/db_utils.h"
 
 namespace storage {
+namespace {
+
+/** When the query selects no FIELD columns (TAG-only), drive row scan from the
+ *  table's VECTOR time axis if unambiguous, else all FIELD series (aligned
+ *  dense row count), instead of only the first FIELD column. */
+std::vector<std::string> collect_tag_only_scan_fields(
+    const std::shared_ptr<TableSchema>& table_schema) {
+    std::vector<std::string> all_fields;
+    std::vector<std::string> vector_fields;
+    const auto categories = table_schema->get_column_categories();
+    const auto& schemas = table_schema->get_measurement_schemas();
+    for (size_t i = 0; i < schemas.size() && i < categories.size(); ++i) {
+        if (categories[i] != common::ColumnCategory::FIELD) {
+            continue;
+        }
+        std::string name = schemas[i]->measurement_name_;
+        to_lowercase_inplace(name);
+        all_fields.push_back(name);
+        if (schemas[i]->data_type_ == common::TSDataType::VECTOR) {
+            vector_fields.push_back(name);
+        }
+    }
+    if (vector_fields.size() == 1U) {
+        return vector_fields;
+    }
+    if (!vector_fields.empty()) {
+        return vector_fields;
+    }
+    return all_fields;
+}
+
+}  // namespace
 int TableQueryExecutor::query(const std::string& table_name,
                               const std::vector<std::string>& columns,
                               Filter* time_filter, Filter* tag_filter,
@@ -136,10 +171,26 @@ int TableQueryExecutor::query(const std::string& table_name,
         data_types.push_back(table_schema->get_data_types()[ind]);
     }
 
-    auto device_task_iterator =
-        std::unique_ptr<DeviceTaskIterator>(new DeviceTaskIterator(
-            lower_case_column_names, table_root, column_mapping,
-            meta_data_querier_, tag_filter, table_schema));
+    std::vector<std::string> internal_row_scan_fields;
+    const auto column_categories = table_schema->get_column_categories();
+    bool selection_has_field = false;
+    for (const auto& col : lower_case_column_names) {
+        int ind = table_schema->find_column_index(col);
+        if (ind >= 0 && static_cast<size_t>(ind) < column_categories.size() &&
+            column_categories[static_cast<size_t>(ind)] ==
+                common::ColumnCategory::FIELD) {
+            selection_has_field = true;
+            break;
+        }
+    }
+    if (!selection_has_field) {
+        internal_row_scan_fields = collect_tag_only_scan_fields(table_schema);
+    }
+
+    auto device_task_iterator = std::unique_ptr<DeviceTaskIterator>(
+        new DeviceTaskIterator(lower_case_column_names, table_root,
+                               column_mapping, meta_data_querier_, tag_filter,
+                               table_schema, internal_row_scan_fields));
 
     std::unique_ptr<TsBlockReader> tsblock_reader;
     switch (table_query_ordering_) {

--- a/cpp/src/reader/task/device_query_task.cc
+++ b/cpp/src/reader/task/device_query_task.cc
@@ -23,13 +23,15 @@ namespace storage {
 DeviceQueryTask* DeviceQueryTask::create_device_query_task(
     std::shared_ptr<IDeviceID> device_id, std::vector<std::string> column_names,
     std::shared_ptr<ColumnMapping> column_mapping, MetaIndexNode* index_root,
-    std::shared_ptr<TableSchema> table_schema, common::PageArena& pa) {
+    std::shared_ptr<TableSchema> table_schema, common::PageArena& pa,
+    const std::vector<std::string>& internal_row_scan_fields) {
     void* buf = pa.alloc(sizeof(DeviceQueryTask));
     if (UNLIKELY(buf == nullptr)) {
         return nullptr;
     }
     DeviceQueryTask* task = new (buf) DeviceQueryTask(
-        device_id, column_names, column_mapping, index_root, table_schema);
+        device_id, std::move(column_names), std::move(column_mapping),
+        index_root, table_schema, internal_row_scan_fields);
     return task;
 }
 

--- a/cpp/src/reader/task/device_query_task.h
+++ b/cpp/src/reader/task/device_query_task.h
@@ -19,6 +19,9 @@
 #ifndef READER_TASK_DEVICE_QUERY_TASK_H
 #define READER_TASK_DEVICE_QUERY_TASK_H
 
+#include <string>
+#include <vector>
+
 #include "common/device_id.h"
 #include "reader/column_mapping.h"
 
@@ -29,12 +32,14 @@ class DeviceQueryTask {
                     std::vector<std::string> column_names,
                     std::shared_ptr<ColumnMapping> column_mapping,
                     MetaIndexNode* index_root,
-                    std::shared_ptr<TableSchema> table_schema)
+                    std::shared_ptr<TableSchema> table_schema,
+                    std::vector<std::string> internal_row_scan_fields = {})
         : device_id_(device_id),
-          column_names_(column_names),
-          column_mapping_(column_mapping),
+          column_names_(std::move(column_names)),
+          column_mapping_(std::move(column_mapping)),
           index_root_(index_root),
-          table_schema_(table_schema) {}
+          table_schema_(std::move(table_schema)),
+          internal_row_scan_fields_(std::move(internal_row_scan_fields)) {}
     ~DeviceQueryTask();
 
     static DeviceQueryTask* create_device_query_task(
@@ -42,7 +47,8 @@ class DeviceQueryTask {
         std::vector<std::string> column_names,
         std::shared_ptr<ColumnMapping> column_mapping,
         MetaIndexNode* index_root, std::shared_ptr<TableSchema> table_schema,
-        common::PageArena& pa);
+        common::PageArena& pa,
+        const std::vector<std::string>& internal_row_scan_fields = {});
 
     const std::vector<std::string>& get_column_names() const {
         return column_names_;
@@ -60,12 +66,20 @@ class DeviceQueryTask {
 
     std::shared_ptr<IDeviceID> get_device_id() const { return device_id_; }
 
+    /** When the query selects no FIELD columns, scan uses these (aligned
+     *  VECTOR and/or all FIELD series) for row iteration only; not in
+     *  column_names_. */
+    const std::vector<std::string>& get_internal_row_scan_fields() const {
+        return internal_row_scan_fields_;
+    }
+
    private:
     std::shared_ptr<IDeviceID> device_id_;
     std::vector<std::string> column_names_;
     std::shared_ptr<ColumnMapping> column_mapping_;
     MetaIndexNode* index_root_;
     std::shared_ptr<TableSchema> table_schema_;
+    std::vector<std::string> internal_row_scan_fields_;
 };
 
 }  // namespace storage

--- a/cpp/src/reader/task/device_task_iterator.cc
+++ b/cpp/src/reader/task/device_task_iterator.cc
@@ -36,7 +36,8 @@ int DeviceTaskIterator::next(DeviceQueryTask*& task) {
     } else {
         task = DeviceQueryTask::create_device_query_task(
             device_meta_pair.first, column_names_, column_mapping_,
-            device_meta_pair.second, table_schema_, pa_);
+            device_meta_pair.second, table_schema_, pa_,
+            internal_row_scan_fields_);
     }
     return ret;
 }

--- a/cpp/src/reader/task/device_task_iterator.h
+++ b/cpp/src/reader/task/device_task_iterator.h
@@ -19,6 +19,9 @@
 #ifndef READER_TASK_DEVICE_TASK_ITERATOR_H
 #define READER_TASK_DEVICE_TASK_ITERATOR_H
 
+#include <string>
+#include <vector>
+
 #include "common/device_id.h"
 #include "reader/imeta_data_querier.h"
 #include "reader/task/device_query_task.h"
@@ -30,17 +33,18 @@ class DeviceQueryTask;
 
 class DeviceTaskIterator {
    public:
-    explicit DeviceTaskIterator(std::vector<std::string> column_names,
-                                MetaIndexNode* index_root,
-                                std::shared_ptr<ColumnMapping> column_mapping,
-                                IMetadataQuerier* metadata_querier,
-                                const Filter* id_filter,
-                                std::shared_ptr<TableSchema> table_schema)
-        : column_names_(column_names),
-          column_mapping_(column_mapping),
+    explicit DeviceTaskIterator(
+        std::vector<std::string> column_names, MetaIndexNode* index_root,
+        std::shared_ptr<ColumnMapping> column_mapping,
+        IMetadataQuerier* metadata_querier, const Filter* id_filter,
+        std::shared_ptr<TableSchema> table_schema,
+        std::vector<std::string> internal_row_scan_fields = {})
+        : column_names_(std::move(column_names)),
+          column_mapping_(std::move(column_mapping)),
           device_meta_iterator_(
               metadata_querier->device_iterator(index_root, id_filter)),
-          table_schema_(table_schema) {
+          table_schema_(std::move(table_schema)),
+          internal_row_scan_fields_(std::move(internal_row_scan_fields)) {
         pa_.init(512, common::MOD_DEVICE_TASK_ITER);
     }
 
@@ -49,12 +53,14 @@ class DeviceTaskIterator {
                        std::shared_ptr<ColumnMapping> column_mapping,
                        IMetadataQuerier* metadata_querier,
                        const Filter* id_filter,
-                       std::shared_ptr<TableSchema> table_schema)
-        : column_names_(column_names),
-          column_mapping_(column_mapping),
+                       std::shared_ptr<TableSchema> table_schema,
+                       std::vector<std::string> internal_row_scan_fields = {})
+        : column_names_(std::move(column_names)),
+          column_mapping_(std::move(column_mapping)),
           device_meta_iterator_(
               metadata_querier->device_iterator(index_roots, id_filter)),
-          table_schema_(table_schema) {
+          table_schema_(std::move(table_schema)),
+          internal_row_scan_fields_(std::move(internal_row_scan_fields)) {
         pa_.init(512, common::MOD_DEVICE_TASK_ITER);
     }
 
@@ -71,6 +77,7 @@ class DeviceTaskIterator {
     std::shared_ptr<ColumnMapping> column_mapping_;
     std::unique_ptr<DeviceMetaIterator> device_meta_iterator_;
     std::shared_ptr<TableSchema> table_schema_;
+    std::vector<std::string> internal_row_scan_fields_;
     common::PageArena pa_;
 };
 

--- a/cpp/test/cwrapper/cwrapper_test.cc
+++ b/cpp/test/cwrapper/cwrapper_test.cc
@@ -310,4 +310,88 @@ TEST_F(CWrapperTest, WriterFlushTabletAndReadData) {
     free(data_types);
     free_write_file(&file);
 }
+
+// Repro: query_tree_by_row fails with RET_DEVICRET_NOT_EXIST (44) for a
+// three-segment device path (e.g. root.db.device1), while two-segment paths work.
+// Root cause: Path(full_path) vs StringArrayDeviceID(device_string) split mismatch.
+TEST_F(CWrapperTest, QueryTreeByRow_TwoSegmentDevice_Succeeds) {
+    ERRNO code = 0;
+    const char* filename = "cwrapper_query_tree_by_row_two_seg.tsfile";
+    remove(filename);
+
+    auto* writer = (storage::TsFileWriter*)_tsfile_writer_new(
+        filename, 128 * 1024 * 1024, &code);
+    ASSERT_OK(code);
+
+    const char* device = "root.device1";
+    timeseries_schema ts_schema{};
+    ts_schema.timeseries_name = const_cast<char*>("s1");
+    ts_schema.data_type = TS_DATATYPE_INT64;
+    ts_schema.encoding = TS_ENCODING_PLAIN;
+    ts_schema.compression = TS_COMPRESSION_UNCOMPRESSED;
+
+    ASSERT_OK(_tsfile_writer_register_timeseries(writer, device, &ts_schema));
+
+    auto* record = (storage::TsRecord*)_ts_record_new(device, 0, 1);
+    ASSERT_OK(_insert_data_into_ts_record_by_name_int64_t(record, "s1", 42));
+    ASSERT_OK(_tsfile_writer_write_ts_record(writer, record));
+    _free_tsfile_ts_record(reinterpret_cast<TsRecord*>(&record));
+    ASSERT_OK(_tsfile_writer_flush(writer));
+    ASSERT_OK(_tsfile_writer_close(writer));
+
+    auto* reader = (storage::TsFileReader*)tsfile_reader_new(filename, &code);
+    ASSERT_OK(code);
+
+    char* devs[] = {const_cast<char*>(device)};
+    char* meas[] = {const_cast<char*>("s1")};
+    ResultSet rs = tsfile_reader_query_tree_by_row(reader, devs, 1, meas, 1, 0,
+                                                   10, &code);
+    ASSERT_OK(code);
+    ASSERT_NE(rs, nullptr);
+    free_tsfile_result_set(&rs);
+    tsfile_reader_close(reader);
+    remove(filename);
+}
+
+TEST_F(CWrapperTest, QueryTreeByRow_ThreeSegmentDevice_ReproducesDeviceNotExist) {
+    ERRNO code = 0;
+    const char* filename = "cwrapper_query_tree_by_row_three_seg.tsfile";
+    remove(filename);
+
+    auto* writer = (storage::TsFileWriter*)_tsfile_writer_new(
+        filename, 128 * 1024 * 1024, &code);
+    ASSERT_OK(code);
+
+    const char* device = "root.db.device1";
+    timeseries_schema ts_schema{};
+    ts_schema.timeseries_name = const_cast<char*>("s1");
+    ts_schema.data_type = TS_DATATYPE_INT64;
+    ts_schema.encoding = TS_ENCODING_PLAIN;
+    ts_schema.compression = TS_COMPRESSION_UNCOMPRESSED;
+
+    ASSERT_OK(_tsfile_writer_register_timeseries(writer, device, &ts_schema));
+
+    auto* record = (storage::TsRecord*)_ts_record_new(device, 0, 1);
+    ASSERT_OK(_insert_data_into_ts_record_by_name_int64_t(record, "s1", 1));
+    ASSERT_OK(_tsfile_writer_write_ts_record(writer, record));
+    _free_tsfile_ts_record(reinterpret_cast<TsRecord*>(&record));
+    ASSERT_OK(_tsfile_writer_flush(writer));
+    ASSERT_OK(_tsfile_writer_close(writer));
+
+    auto* reader = (storage::TsFileReader*)tsfile_reader_new(filename, &code);
+    ASSERT_OK(code);
+
+    char* devs[] = {const_cast<char*>(device)};
+    char* meas[] = {const_cast<char*>("s1")};
+    ResultSet rs = tsfile_reader_query_tree_by_row(reader, devs, 1, meas, 1, 0,
+                                                   10, &code);
+    EXPECT_EQ(rs, nullptr);
+    EXPECT_EQ(code, RET_DEVICRET_NOT_EXIST)
+        << "repro: three-segment device path should currently fail query_tree_by_row";
+    if (rs != nullptr) {
+        free_tsfile_result_set(&rs);
+    }
+    tsfile_reader_close(reader);
+    remove(filename);
+}
 }  // namespace cwrapper

--- a/cpp/test/cwrapper/cwrapper_test.cc
+++ b/cpp/test/cwrapper/cwrapper_test.cc
@@ -311,9 +311,9 @@ TEST_F(CWrapperTest, WriterFlushTabletAndReadData) {
     free_write_file(&file);
 }
 
-// Repro: query_tree_by_row fails with RET_DEVICRET_NOT_EXIST (44) for a
-// three-segment device path (e.g. root.db.device1), while two-segment paths work.
-// Root cause: Path(full_path) vs StringArrayDeviceID(device_string) split mismatch.
+// Three-segment device paths (e.g. root.db.device1) must resolve like
+// writer-side StringArrayDeviceID(device_string) canonicalization (see Path
+// constructor).
 TEST_F(CWrapperTest, QueryTreeByRow_TwoSegmentDevice_Succeeds) {
     ERRNO code = 0;
     const char* filename = "cwrapper_query_tree_by_row_two_seg.tsfile";
@@ -344,8 +344,8 @@ TEST_F(CWrapperTest, QueryTreeByRow_TwoSegmentDevice_Succeeds) {
 
     char* devs[] = {const_cast<char*>(device)};
     char* meas[] = {const_cast<char*>("s1")};
-    ResultSet rs = tsfile_reader_query_tree_by_row(reader, devs, 1, meas, 1, 0,
-                                                   10, &code);
+    ResultSet rs =
+        tsfile_reader_query_tree_by_row(reader, devs, 1, meas, 1, 0, 10, &code);
     ASSERT_OK(code);
     ASSERT_NE(rs, nullptr);
     free_tsfile_result_set(&rs);
@@ -353,7 +353,7 @@ TEST_F(CWrapperTest, QueryTreeByRow_TwoSegmentDevice_Succeeds) {
     remove(filename);
 }
 
-TEST_F(CWrapperTest, QueryTreeByRow_ThreeSegmentDevice_ReproducesDeviceNotExist) {
+TEST_F(CWrapperTest, QueryTreeByRow_ThreeSegmentDevice_Succeeds) {
     ERRNO code = 0;
     const char* filename = "cwrapper_query_tree_by_row_three_seg.tsfile";
     remove(filename);
@@ -383,14 +383,11 @@ TEST_F(CWrapperTest, QueryTreeByRow_ThreeSegmentDevice_ReproducesDeviceNotExist)
 
     char* devs[] = {const_cast<char*>(device)};
     char* meas[] = {const_cast<char*>("s1")};
-    ResultSet rs = tsfile_reader_query_tree_by_row(reader, devs, 1, meas, 1, 0,
-                                                   10, &code);
-    EXPECT_EQ(rs, nullptr);
-    EXPECT_EQ(code, RET_DEVICRET_NOT_EXIST)
-        << "repro: three-segment device path should currently fail query_tree_by_row";
-    if (rs != nullptr) {
-        free_tsfile_result_set(&rs);
-    }
+    ResultSet rs =
+        tsfile_reader_query_tree_by_row(reader, devs, 1, meas, 1, 0, 10, &code);
+    ASSERT_OK(code);
+    ASSERT_NE(rs, nullptr);
+    free_tsfile_result_set(&rs);
     tsfile_reader_close(reader);
     remove(filename);
 }

--- a/cpp/test/reader/table_view/tsfile_table_query_by_row_test.cc
+++ b/cpp/test/reader/table_view/tsfile_table_query_by_row_test.cc
@@ -247,6 +247,118 @@ class TableQueryByRowTest : public ::testing::Test {
         delete schema;
     }
 
+    /** id1 + s1 + s2; s1 (first FIELD) is never written — only s2 has points.
+     *  TAG-only queryByRow must still see all rows by scanning every FIELD
+     *  (not only the first), aligned with collect_tag_only_scan_fields(). */
+    void write_tag_two_int_fields_first_never_written(int num_rows) {
+        std::vector<ColumnSchema> col_schemas = {
+            ColumnSchema("id1", TSDataType::STRING,
+                         CompressionType::UNCOMPRESSED, TSEncoding::PLAIN,
+                         ColumnCategory::TAG),
+            ColumnSchema("s1", TSDataType::INT64, CompressionType::UNCOMPRESSED,
+                         TSEncoding::PLAIN, ColumnCategory::FIELD),
+            ColumnSchema("s2", TSDataType::INT64, CompressionType::UNCOMPRESSED,
+                         TSEncoding::PLAIN, ColumnCategory::FIELD),
+        };
+        auto* schema = new TableSchema("t1", col_schemas);
+        auto* writer = new TsFileTableWriter(&write_file_, schema);
+
+        Tablet tablet(
+            "t1", {"id1", "s1", "s2"},
+            {TSDataType::STRING, TSDataType::INT64, TSDataType::INT64},
+            {ColumnCategory::TAG, ColumnCategory::FIELD, ColumnCategory::FIELD},
+            num_rows);
+
+        for (int i = 0; i < num_rows; i++) {
+            tablet.add_timestamp(i, static_cast<int64_t>(i));
+            tablet.add_value(i, "id1", "device_a");
+            tablet.add_value(i, "s2", static_cast<int64_t>(i * 100));
+        }
+
+        ASSERT_EQ(writer->write_table(tablet), E_OK);
+        ASSERT_EQ(writer->flush(), E_OK);
+        ASSERT_EQ(writer->close(), E_OK);
+        delete writer;
+        delete schema;
+    }
+
+    /** s1 is sparse; s2 is dense on every row. TAG-only row count must follow
+     *  the full aligned row set, not only the first FIELD series. */
+    void write_tag_two_int_fields_first_sparse_second_dense(int num_rows) {
+        std::vector<ColumnSchema> col_schemas = {
+            ColumnSchema("id1", TSDataType::STRING,
+                         CompressionType::UNCOMPRESSED, TSEncoding::PLAIN,
+                         ColumnCategory::TAG),
+            ColumnSchema("s1", TSDataType::INT64, CompressionType::UNCOMPRESSED,
+                         TSEncoding::PLAIN, ColumnCategory::FIELD),
+            ColumnSchema("s2", TSDataType::INT64, CompressionType::UNCOMPRESSED,
+                         TSEncoding::PLAIN, ColumnCategory::FIELD),
+        };
+        auto* schema = new TableSchema("t1", col_schemas);
+        auto* writer = new TsFileTableWriter(&write_file_, schema);
+
+        Tablet tablet(
+            "t1", {"id1", "s1", "s2"},
+            {TSDataType::STRING, TSDataType::INT64, TSDataType::INT64},
+            {ColumnCategory::TAG, ColumnCategory::FIELD, ColumnCategory::FIELD},
+            num_rows);
+
+        for (int i = 0; i < num_rows; i++) {
+            tablet.add_timestamp(i, static_cast<int64_t>(i));
+            tablet.add_value(i, "id1", "device_a");
+            if ((i % 3) != 0) {
+                tablet.add_value(i, "s1", static_cast<int64_t>(i * 10));
+            }
+            tablet.add_value(i, "s2", static_cast<int64_t>(i * 100));
+        }
+
+        ASSERT_EQ(writer->write_table(tablet), E_OK);
+        ASSERT_EQ(writer->flush(), E_OK);
+        ASSERT_EQ(writer->close(), E_OK);
+        delete writer;
+        delete schema;
+    }
+
+    int count_rows_query(const std::vector<std::string>& cols) {
+        TsFileReader reader;
+        if (reader.open(file_name_) != E_OK) {
+            return -1;
+        }
+        ResultSet* rs = nullptr;
+        if (reader.query("t1", cols, INT64_MIN, INT64_MAX, rs) != E_OK) {
+            reader.close();
+            return -1;
+        }
+        int n = 0;
+        bool has_next = false;
+        while (IS_SUCC(rs->next(has_next)) && has_next) {
+            n++;
+        }
+        reader.destroy_query_data_set(rs);
+        reader.close();
+        return n;
+    }
+
+    int count_rows_query_by_row(const std::vector<std::string>& cols) {
+        TsFileReader reader;
+        if (reader.open(file_name_) != E_OK) {
+            return -1;
+        }
+        ResultSet* rs = nullptr;
+        if (reader.queryByRow("t1", cols, 0, -1, rs) != E_OK) {
+            reader.close();
+            return -1;
+        }
+        int n = 0;
+        bool has_next = false;
+        while (IS_SUCC(rs->next(has_next)) && has_next) {
+            n++;
+        }
+        reader.destroy_query_data_set(rs);
+        reader.close();
+        return n;
+    }
+
     std::vector<int64_t> query_all_s1(const std::string& table_name,
                                       const std::vector<std::string>& columns) {
         TsFileReader reader;
@@ -353,6 +465,74 @@ TEST_F(TableQueryByRowTest, NoOffsetNoLimit) {
     auto result = query_by_row_s1("t1", {"id1", "s1", "s2"}, 0, -1);
     ASSERT_EQ(result.size(), all.size());
     ASSERT_EQ(result, all);
+}
+
+// TAG-only column list still returns all rows (internal scan uses VECTOR or
+// all FIELD columns; see collect_tag_only_scan_fields).
+TEST_F(TableQueryByRowTest, TagOnlyColumnsReturnRows) {
+    int num_rows = 10;
+    write_single_device_file(num_rows);
+
+    TsFileReader reader;
+    ASSERT_EQ(reader.open(file_name_), E_OK);
+    ResultSet* rs = nullptr;
+    ASSERT_EQ(reader.queryByRow("t1", {"id1"}, 0, -1, rs), E_OK);
+    ASSERT_NE(rs, nullptr);
+    int count = 0;
+    bool has_next = false;
+    while (IS_SUCC(rs->next(has_next)) && has_next) {
+        count++;
+    }
+    ASSERT_EQ(count, num_rows);
+    reader.destroy_query_data_set(rs);
+    reader.close();
+}
+
+// First FIELD (s1) has no points; second FIELD (s2) is dense. TAG-only must
+// still return the same row count as a full time-range query (all FIELD
+// series participate in internal scan, not only the first column).
+TEST_F(TableQueryByRowTest, TagOnly_FirstFieldNeverWritten_RowCount) {
+    const int num_rows = 42;
+    write_tag_two_int_fields_first_never_written(num_rows);
+
+    ASSERT_EQ(count_rows_query_by_row({"id1"}), num_rows);
+    ASSERT_EQ(count_rows_query({"id1", "s1", "s2"}), num_rows);
+}
+
+// Same layout as above: queryByRow(offset, limit) on selected columns must
+// match manual skip/limit on the full scan (uses s1 nulls).
+TEST_F(TableQueryByRowTest, TagOnly_FirstFieldNeverWritten_OffsetLimit) {
+    const int num_rows = 80;
+    write_tag_two_int_fields_first_never_written(num_rows);
+    const int offset = 17;
+    const int limit = 23;
+    const std::vector<std::string> cols = {"id1", "s1", "s2"};
+    auto by_row = query_by_row_time_and_s1("t1", cols, offset, limit);
+    auto manual = query_manual_time_and_s1("t1", cols, offset, limit);
+    ASSERT_EQ(by_row.size(), manual.size());
+    ASSERT_EQ(by_row, manual);
+}
+
+// First FIELD sparse, second dense: TAG-only row count still matches full
+// logical row count.
+TEST_F(TableQueryByRowTest, TagOnly_FirstFieldSparse_RowCount) {
+    const int num_rows = 60;
+    write_tag_two_int_fields_first_sparse_second_dense(num_rows);
+
+    ASSERT_EQ(count_rows_query_by_row({"id1"}), num_rows);
+    ASSERT_EQ(count_rows_query({"id1", "s1", "s2"}), num_rows);
+}
+
+TEST_F(TableQueryByRowTest, TagOnly_FirstFieldSparse_OffsetLimit) {
+    const int num_rows = 100;
+    write_tag_two_int_fields_first_sparse_second_dense(num_rows);
+    const int offset = 31;
+    const int limit = 29;
+    const std::vector<std::string> cols = {"id1", "s1", "s2"};
+    auto by_row = query_by_row_time_and_s1("t1", cols, offset, limit);
+    auto manual = query_manual_time_and_s1("t1", cols, offset, limit);
+    ASSERT_EQ(by_row.size(), manual.size());
+    ASSERT_EQ(by_row, manual);
 }
 
 // Offset only: skip first N rows, return the rest; limit=-1 means no cap.

--- a/cpp/test/reader/tree_view/tsfile_tree_query_by_row_test.cc
+++ b/cpp/test/reader/tree_view/tsfile_tree_query_by_row_test.cc
@@ -25,6 +25,7 @@
 #include "common/record.h"
 #include "common/schema.h"
 #include "file/write_file.h"
+#include "reader/result_set.h"
 #include "reader/tsfile_reader.h"
 #include "reader/tsfile_tree_reader.h"
 #include "writer/tsfile_tree_writer.h"
@@ -129,6 +130,71 @@ TEST_F(TreeQueryByRowTest, NoOffsetNoLimit) {
         EXPECT_EQ(timestamps[i], i);
     }
 
+    reader.destroy_query_data_set(result);
+    reader.close();
+}
+
+// Missing measurements are not an error; columns are kept with null values
+// (aligned with Java EmptyFileSeriesReader + DataSetWithoutTimeGenerator).
+TEST_F(TreeQueryByRowTest, MissingMeasurementsYieldNullColumns) {
+    std::vector<std::string> devices = {"d1"};
+    std::vector<std::string> measurements = {"s1"};
+    int num_rows = 10;
+    write_test_file(devices, measurements, num_rows);
+
+    TsFileTreeReader reader;
+    ASSERT_EQ(E_OK, reader.open(file_name_));
+
+    ResultSet* result = nullptr;
+    ASSERT_EQ(E_OK, reader.queryByRow(devices, {"s1", "_not_exist_col"}, 0, -1,
+                                      result));
+    ASSERT_NE(result, nullptr);
+    auto meta = result->get_metadata();
+    ASSERT_NE(meta, nullptr);
+    EXPECT_EQ(meta->get_column_count(), 3U);
+
+    int row = 0;
+    bool has_next = false;
+    while (IS_SUCC(result->next(has_next)) && has_next) {
+        auto* rr = result->get_row_record();
+        ASSERT_NE(rr, nullptr);
+        EXPECT_EQ(rr->get_timestamp(), static_cast<int64_t>(row));
+        EXPECT_TRUE(rr->get_field(1)->is_type(INT64));
+        EXPECT_EQ(rr->get_field(1)->get_value<int64_t>(),
+                  static_cast<int64_t>(row * 100));
+        EXPECT_TRUE(rr->get_field(2)->is_type(NULL_TYPE));
+        row++;
+    }
+    EXPECT_EQ(row, num_rows);
+
+    reader.destroy_query_data_set(result);
+
+    ResultSet* empty_rs = nullptr;
+    ASSERT_EQ(E_OK,
+              reader.queryByRow(devices, {"_only_missing"}, 0, -1, empty_rs));
+    ASSERT_NE(empty_rs, nullptr);
+    auto empty_ts = collect_timestamps(empty_rs);
+    EXPECT_EQ(empty_ts.size(), 0U);
+    reader.destroy_query_data_set(empty_rs);
+
+    reader.close();
+}
+
+// Device path with more than two dot-separated segments matches storage layout.
+TEST_F(TreeQueryByRowTest, MultiSegmentDevicePath) {
+    std::vector<std::string> devices = {"root.sg1.FeederA"};
+    std::vector<std::string> measurements = {"s1"};
+    int num_rows = 10;
+    write_test_file(devices, measurements, num_rows);
+
+    TsFileTreeReader reader;
+    ASSERT_EQ(E_OK, reader.open(file_name_));
+
+    ResultSet* result = nullptr;
+    ASSERT_EQ(E_OK, reader.queryByRow(devices, measurements, 0, -1, result));
+    ASSERT_NE(result, nullptr);
+    auto timestamps = collect_timestamps(result);
+    EXPECT_EQ(timestamps.size(), static_cast<size_t>(num_rows));
     reader.destroy_query_data_set(result);
     reader.close();
 }

--- a/python/tests/test_query_by_row.py
+++ b/python/tests/test_query_by_row.py
@@ -110,3 +110,40 @@ def test_query_table_by_row_offset_limit():
         if os.path.exists(file_path):
             os.remove(file_path)
 
+
+def test_query_table_by_row_tag_only_columns():
+    """TAG-only column list must return the same row count as when a FIELD is included."""
+    file_path = "python_table_query_by_row_tag_only.tsfile"
+    if os.path.exists(file_path):
+        os.remove(file_path)
+
+    try:
+        table_name = "t1"
+        schema = TableSchema(
+            table_name,
+            [
+                ColumnSchema("tag1", TSDataType.STRING, ColumnCategory.TAG),
+                ColumnSchema("s1", TSDataType.INT64, ColumnCategory.FIELD),
+            ],
+        )
+
+        num_rows = 10
+        with TsFileTableWriter(file_path, schema) as writer:
+            tablet = Tablet(["tag1", "s1"], [TSDataType.STRING, TSDataType.INT64], num_rows)
+            for t in range(num_rows):
+                tablet.add_timestamp(t, t)
+                tablet.add_value_by_name("tag1", t, f"v{t}")
+                tablet.add_value_by_name("s1", t, t * 10)
+            writer.write_table(tablet)
+
+        reader = TsFileReader(file_path)
+        with reader.query_table_by_row(table_name, ["tag1"]) as result:
+            count = 0
+            while result.next():
+                count += 1
+            assert count == num_rows, f"Expected {num_rows} rows for TAG-only query, got {count}"
+        reader.close()
+    finally:
+        if os.path.exists(file_path):
+            os.remove(file_path)
+

--- a/python/tests/test_query_tree_by_row_three_level_repro.py
+++ b/python/tests/test_query_tree_by_row_three_level_repro.py
@@ -1,0 +1,105 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+"""Reproduce DeviceNotExistError (44) for query_tree_by_row on 3-segment device paths."""
+
+import os
+
+import pytest
+
+from tsfile import Field, RowRecord, TimeseriesSchema, TsFileReader, TsFileWriter
+from tsfile import TSDataType
+from tsfile.exceptions import DeviceNotExistError
+
+
+def _remove_if_exists(path: str) -> None:
+    if os.path.exists(path):
+        os.remove(path)
+
+
+def test_query_tree_by_row_two_level_device_ok():
+    """Two-segment device path: query_tree_by_row should succeed."""
+    path = "repro_query_tree_by_row_two_level.tsfile"
+    device = "root.device1"
+    measurements = ["s1"]
+    try:
+        _remove_if_exists(path)
+        writer = TsFileWriter(path)
+        writer.register_timeseries(
+            device, TimeseriesSchema("s1", TSDataType.INT64)
+        )
+        writer.write_row_record(
+            RowRecord(
+                device,
+                0,
+                [Field("s1", 42, TSDataType.INT64)],
+            )
+        )
+        writer.close()
+
+        with TsFileReader(path) as reader:
+            schemas = reader.get_all_timeseries_schemas()
+            assert device.lower() in schemas
+            rs = reader.query_tree_by_row([device], measurements, 0, 10)
+            assert rs.next()
+            assert rs.get_value_by_index(2) == 42
+            rs.close()
+    finally:
+        _remove_if_exists(path)
+
+
+def test_repro_query_tree_by_row_three_level_device_not_exist():
+    """
+    Three-segment device path (e.g. root.db.device1): metadata lists the device,
+    but query_tree_by_row currently raises DeviceNotExistError (upstream bug repro).
+
+    When fixed, replace this with assertions that rows are returned (like the
+    two-level test above).
+    """
+    path = "repro_query_tree_by_row_three_level.tsfile"
+    device = "root.db.device1"
+    measurements = ["s1", "s2"]
+    try:
+        _remove_if_exists(path)
+        writer = TsFileWriter(path)
+        writer.register_timeseries(
+            device, TimeseriesSchema("s1", TSDataType.INT64)
+        )
+        writer.register_timeseries(
+            device, TimeseriesSchema("s2", TSDataType.INT64)
+        )
+        writer.write_row_record(
+            RowRecord(
+                device,
+                0,
+                [
+                    Field("s1", 1, TSDataType.INT64),
+                    Field("s2", 2, TSDataType.INT64),
+                ],
+            )
+        )
+        writer.close()
+
+        with TsFileReader(path) as reader:
+            schemas = reader.get_all_timeseries_schemas()
+            assert device.lower() in schemas
+            assert len(schemas[device.lower()].get_timeseries_list()) == 2
+
+            with pytest.raises(DeviceNotExistError):
+                reader.query_tree_by_row([device], measurements, 0, 10)
+    finally:
+        _remove_if_exists(path)

--- a/python/tests/test_query_tree_by_row_three_level_repro.py
+++ b/python/tests/test_query_tree_by_row_three_level_repro.py
@@ -15,15 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-"""Reproduce DeviceNotExistError (44) for query_tree_by_row on 3-segment device paths."""
+"""query_tree_by_row on 3-segment device paths (Path / StringArrayDeviceID alignment)."""
 
 import os
 
-import pytest
-
 from tsfile import Field, RowRecord, TimeseriesSchema, TsFileReader, TsFileWriter
 from tsfile import TSDataType
-from tsfile.exceptions import DeviceNotExistError
 
 
 def _remove_if_exists(path: str) -> None:
@@ -62,14 +59,8 @@ def test_query_tree_by_row_two_level_device_ok():
         _remove_if_exists(path)
 
 
-def test_repro_query_tree_by_row_three_level_device_not_exist():
-    """
-    Three-segment device path (e.g. root.db.device1): metadata lists the device,
-    but query_tree_by_row currently raises DeviceNotExistError (upstream bug repro).
-
-    When fixed, replace this with assertions that rows are returned (like the
-    two-level test above).
-    """
+def test_query_tree_by_row_three_level_device_ok():
+    """Three-segment device path: query_tree_by_row should succeed (same as two-level)."""
     path = "repro_query_tree_by_row_three_level.tsfile"
     device = "root.db.device1"
     measurements = ["s1", "s2"]
@@ -99,7 +90,11 @@ def test_repro_query_tree_by_row_three_level_device_not_exist():
             assert device.lower() in schemas
             assert len(schemas[device.lower()].get_timeseries_list()) == 2
 
-            with pytest.raises(DeviceNotExistError):
-                reader.query_tree_by_row([device], measurements, 0, 10)
+            rs = reader.query_tree_by_row([device], measurements, 0, 10)
+            assert rs.next()
+            assert rs.get_value_by_index(1) == 0
+            assert rs.get_value_by_index(2) == 1
+            assert rs.get_value_by_index(3) == 2
+            rs.close()
     finally:
         _remove_if_exists(path)

--- a/python/tsfile/tsfile_reader.pyx
+++ b/python/tsfile/tsfile_reader.pyx
@@ -145,6 +145,13 @@ cdef class ResultSetPy:
         df = pd.DataFrame(data_container)
         data_type_dict = {col: dtype for col, dtype in zip(column_names, data_type)}
         df = df.astype(data_type_dict)
+        # Pandas 3 defaults string columns to str dtype; tests compare with DataFrame literals
+        # using that dtype. Series.equals is False if dtypes differ (object vs str).
+        for i in range(column_num):
+            col = column_names[i]
+            pydt = self.metadata.get_data_type(i + 1)
+            if pydt in (TSDataTypePy.STRING, TSDataTypePy.TEXT):
+                df[col] = df[col].astype(str)
         return df
 
     def read_arrow_batch(self):

--- a/python/tsfile/tsfile_table_writer.py
+++ b/python/tsfile/tsfile_table_writer.py
@@ -36,6 +36,14 @@ def validate_dataframe_for_tsfile(df: pd.DataFrame) -> None:
     for c in columns:
         if c is None or (isinstance(c, str) and len(c) == 0):
             raise ValueError("Column name cannot be None or empty")
+        # pandas may promote None in columns=[None, ...] to float nan in the Index
+        if not isinstance(c, str):
+            try:
+                if pd.isna(c):
+                    raise ValueError("Column name cannot be None or empty")
+            except TypeError:
+                pass
+            raise ValueError("Column name cannot be None or empty")
         lower = c.lower()
         if lower in seen:
             duplicates.append(c)


### PR DESCRIPTION


**问题一（表模型：只查 TAG 没结果）**

**思路：**
只选 TAG 时，结果里虽然没有 FIELD，但引擎内部仍要「按行」扫数据，因此必须明确用哪些 FIELD 序列作为「行数 / 时间轴」参考。

**做法：**
不再依赖「schema 里第一个 FIELD」，而是根据表结构自动选择：

* 只有一个 VECTOR 列 → 使用该列（常见时间轴）
* 否则 → 将所有 FIELD 纳入内部扫描
  这样只要任意 FIELD 上存在对齐行，TAG-only 查询也能正确返回完整行数。

**代码：**

* `table_query_executor.cc`：集中收集扫描字段
* `device_query_task.h` / `device_task_iterator.h`：向下传递「多列内部扫描」信息
* `single_device_tsblock_reader.cc`：按需用字段名拉取 timeseries 索引

**单测：**

* C++：

  * `cpp/test/reader/table_view/tsfile_table_query_by_row_test.cc`

    * `TagOnlyColumnsReturnRows`
    * `TagOnly_FirstFieldNeverWritten_RowCount`
    * `TagOnly_FirstFieldNeverWritten_OffsetLimit`
    * `TagOnly_FirstFieldSparse_RowCount`
    * `TagOnly_FirstFieldSparse_OffsetLimit`

* Python：

  * `python/tests/test_query_by_row.py`

    * `test_query_table_by_row_tag_only_columns`

---

**问题二（树模型：多测点部分不存在就失败）**

**思路：**
缺失测点不应导致整个查询失败；行为应与 Java 保持一致：请求哪些列就返回哪些列，缺失值填 null。

**做法：**

* 每个请求测点占据一个输出列
* 能打开序列 → 正常读取
* 打不开 → 标记为「该列无数据」
* 输出阶段 → 该列填 null，其它列正常合并

**代码：**

* `qds_without_timegenerator.cc`：

  * 测点不存在时仍保留列槽位
  * 标记是否分配 SSI
  * 读取阶段跳过无 SSI 的路径
  * close 阶段只对有效 SSI 执行回滚

**单测：**

* C++：

  * `cpp/test/reader/tree_view/tsfile_tree_query_by_row_test.cc`

    * `MissingMeasurementsYieldNullColumns`

---

**问题三（树模型：多段设备路径找不到设备）**

**思路：**
设备 ID 的构造必须在写入与读取两侧完全一致；否则元数据无法匹配。

**做法：**

* 解析路径 `root.xxx.yyy.measurement`
* 最后一段作为 measurement
* 前面所有段按原顺序拼接为 device ID
* 使用该 device ID 进行查找

**代码：**

* `path.cc`：

  * Path 拆分构造时循环拼接前缀生成 `device_str`
  * 构建 `StringArrayDeviceID`

**单测：**

  * `cpp/test/reader/tree_view/tsfile_tree_query_by_row_test.cc`

    * `MultiSegmentDevicePath`

  * `cpp/test/cwrapper/cwrapper_test.cc`

    * `QueryTreeByRow_TwoSegmentDevice_Succeeds`
    * `QueryTreeByRow_ThreeSegmentDevice_Succeeds`

  * `cpp/test/reader/tree_view/tsfile_reader_tree_test.cc`

    * `QueryTableOnTreeDeepDevicePath`

---

# English Version

**Issue 1 (table TAG-only empty)**

**Idea:**
TAG-only queries still require FIELD series internally to define row existence; relying on a single “first FIELD” is unsafe.

**Approach:**
Auto-select scan targets:

* If exactly one VECTOR column → use it
* Otherwise → include all FIELD columns
  This ensures row alignment even when some fields are empty.

**Code:**

* `table_query_executor.cc`
* `device_query_task.h` / `device_task_iterator.h`
* `single_device_tsblock_reader.cc`

**Tests:**

* C++:

  * `tsfile_table_query_by_row_test.cc`

    * `TagOnlyColumnsReturnRows`
    * `TagOnly_FirstFieldNeverWritten_RowCount`
    * `TagOnly_FirstFieldNeverWritten_OffsetLimit`
    * `TagOnly_FirstFieldSparse_RowCount`
    * `TagOnly_FirstFieldSparse_OffsetLimit`

* Python:

  * `test_query_by_row.py`

    * `test_query_table_by_row_tag_only_columns`

---

**Issue 2 (tree partial measurements error)**

**Idea:**
Missing measurements should not fail the query; align with Java behavior—return requested columns with nulls where missing.

**Approach:**

* One slot per requested path
* Allocate SSI if available
* Otherwise treat column as empty
* Merge results with null-filled columns

**Code:**

* `qds_without_timegenerator.cc`

**Tests:**

* `MissingMeasurementsYieldNullColumns`

---

**Issue 3 (multi-segment device path not found)**

**Idea:**
Reader and writer must construct identical device IDs from dotted paths.

**Approach:**

* Split `root.xxx.yyy.measurement`
* Last segment → measurement
* Remaining segments → device ID
* Perform lookup using reconstructed device ID

**Code:**

* `path.cc`

**Tests:**

* `MultiSegmentDevicePath`
* `QueryTreeByRow_TwoSegmentDevice_Succeeds`
* `QueryTreeByRow_ThreeSegmentDevice_Succeeds`
* `QueryTableOnTreeDeepDevicePath`
