### PR TITLE
Add PyPI badge to README and README-zh.md

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -29,6 +29,7 @@
 
 [![codecov](https://codecov.io/github/apache/tsfile/graph/badge.svg?token=0Y8MVAB3K1)](https://codecov.io/github/apache/tsfile)
 [![Maven Central](https://img.shields.io/maven-central/v/org.apache.tsfile/tsfile-parent.svg)](https://central.sonatype.com/artifact/org.apache.tsfile/tsfile-parent)
+[![PyPI](https://img.shields.io/pypi/v/tsfile.svg)](https://pypi.org/project/tsfile)
 
 ## 简介
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 
 [![codecov](https://codecov.io/github/apache/tsfile/graph/badge.svg?token=0Y8MVAB3K1)](https://codecov.io/github/apache/tsfile)
 [![Maven Central](https://img.shields.io/maven-central/v/org.apache.tsfile/tsfile-parent.svg)](https://central.sonatype.com/artifact/org.apache.tsfile/tsfile-parent)
+[![PyPI](https://img.shields.io/pypi/v/tsfile.svg)](https://pypi.org/project/tsfile)
+
 ## Introduction
 
 TsFile is a columnar storage file format designed for time series data, which supports efficient compression, high throughput of read and write, and compatibility with various frameworks, such as Spark and Flink. It is easy to integrate TsFile into IoT big data processing frameworks.


### PR DESCRIPTION
This pull request adds a badge to both the English and Chinese README files to indicate the availability of the `tsfile` package on PyPI, making it easier for users to discover and access the Python package.

Documentation updates:

* Added a PyPI version badge with a link to the `tsfile` package on PyPI in both `README.md` and `README-zh.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R33-R34) [[2]](diffhunk://#diff-2b8d2db04fe3277c3a06cbdf5da2ba7659f95e19e31f59d5382b40ac81a1a98dR32)