### PR TITLE
Enable Python Spotless check in CI

### DIFF
--- a/.github/workflows/unit-test-python.yml
+++ b/.github/workflows/unit-test-python.yml
@@ -106,7 +106,7 @@ jobs:
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             export PATH="/c/mingw64/bin:$PATH"
           fi
-          ./mvnw${{ steps.platform_suffix.outputs.platform_suffix }} -P with-python -Denable.asan=OFF -Dbuild.type=Release clean verify -Dspotless.skip=true
+          ./mvnw${{ steps.platform_suffix.outputs.platform_suffix }} -P with-python -Denable.asan=OFF -Dbuild.type=Release clean verify
 
       - name: Upload whl Artifact
         uses: actions/upload-artifact@v7

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <spotless.version>2.44.3</spotless.version>
         <google.java.format.version>1.28.0</google.java.format.version>
         <clang.format.version>17.0.6</clang.format.version>
-        <black.version></black.version>
+        <black.version>26.3.1</black.version>
         <drill.freemarker.maven.plugin.version>1.21.1</drill.freemarker.maven.plugin.version>
         <groovy.version>4.0.22</groovy.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <spotless.version>2.44.3</spotless.version>
         <google.java.format.version>1.28.0</google.java.format.version>
         <clang.format.version>17.0.6</clang.format.version>
+        <black.version></black.version>
         <drill.freemarker.maven.plugin.version>1.21.1</drill.freemarker.maven.plugin.version>
         <groovy.version>4.0.22</groovy.version>
     </properties>

--- a/python/pom.xml
+++ b/python/pom.xml
@@ -49,7 +49,7 @@
                             <include>setup.py</include>
                         </includes>
                         <black>
-                            <version>26.3.1</version>
+                            <version>${black.version}</version>
                             <pathToExe>${project.basedir}/${python.venv.bin}black</pathToExe>
                         </black>
                     </python>
@@ -62,7 +62,7 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
-                        <phase>validate</phase>
+                        <phase>verify</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/python/pom.xml
+++ b/python/pom.xml
@@ -62,7 +62,7 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
-                        <phase>verify</phase>
+                        <phase>process-sources</phase>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
This pull request makes several changes to how Python code formatting is handled and when formatting checks are run in the build process. The main updates are to centralize the `black` formatter version configuration, adjust the Maven build phase for formatting checks, and remove a redundant build flag.

**Python code formatting and build process improvements:**

* The `black` formatter version in `python/pom.xml` is now set using the `${black.version}` property, making it configurable from the parent `pom.xml` instead of being hardcoded. (`[python/pom.xmlL52-R52](diffhunk://#diff-88f65e398a60cacc6ad3e0c6e2e7a6b09484e04b0292203c316845844e636b5dL52-R52)`)
* Added a `<black.version>` property to the main `pom.xml` to support centralized configuration of the `black` version. (`[pom.xmlR43](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R43)`)

**Build process changes:**

* The execution phase for the Python formatting check in `python/pom.xml` was changed from `validate` to `verify`, ensuring it runs later in the Maven lifecycle. (`[python/pom.xmlL65-R65](diffhunk://#diff-88f65e398a60cacc6ad3e0c6e2e7a6b09484e04b0292203c316845844e636b5dL65-R65)`)
* The `-Dspotless.skip=true` flag was removed from the Maven command in the GitHub Actions workflow, so code formatting checks are no longer skipped during CI runs. (`[.github/workflows/unit-test-python.ymlL109-R109](diffhunk://#diff-696413eee662eca84080a1c99714fac0aee394fa2c3ea5ba05f841c724b36459L109-R109)`)