### PR TITLE
[Python] Fix Linux Py3.14 wheel CI and dataframe edge cases

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -268,8 +268,13 @@ jobs:
           # Build wheel via Maven (no clean — keep C++ artifacts from previous job)
           chmod +x mvnw || true
           cd python
+          BLACK_VER_PROP=""
+          case "${{ matrix.python-version }}" in
+            3.9) BLACK_VER_PROP="-Dblack.version=25.11.0" ;;
+          esac
           ../mvnw package -DskipTests \
-            -Dspotless.check.skip=true -Dspotless.apply.skip=true
+            -Dspotless.check.skip=true -Dspotless.apply.skip=true \
+            ${BLACK_VER_PROP}
           ls -la dist/
 
       - name: Verify wheel

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install build tools
         run: |
           python -m pip install -U pip wheel
-          python -m pip install cibuildwheel==2.21.3
+          python -m pip install cibuildwheel==3.4.1
 
       - name: Pre-download virtualenv for cibuildwheel
         run: |
@@ -222,7 +222,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -108,8 +108,8 @@ jobs:
           CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
           CIBW_SKIP: "pp* *-musllinux*"
 
-          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2014"
-          CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux2014"
+          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_28"
+          CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux_2_28"
 
           MACOSX_DEPLOYMENT_TARGET: "12.0"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -39,7 +39,8 @@ dependencies = [
     "numpy>=2.0.0,<3",
     "pandas>=2.0",
     "pyarrow>=16.0,<18; python_version<'3.10'",
-    "pyarrow>=18.0,<20; python_version>='3.10'"
+    "pyarrow>=18.0,<20; python_version>='3.10' and python_version<'3.14'",
+    "pyarrow>=22.0,<24; python_version>='3.14'"
 ]
 
 [project.urls]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -37,7 +37,8 @@ maintainers = [
 ]
 dependencies = [
     "numpy>=2.0.0,<3",
-    "pandas>=2.0",
+    "pandas>=2.0,<2.3; python_version<'3.14'",
+    "pandas>=2.3.3; python_version>='3.14'",
     "pyarrow>=16.0,<18; python_version<'3.10'",
     "pyarrow>=18.0,<20; python_version>='3.10' and python_version<'3.14'",
     "pyarrow>=22.0,<24; python_version>='3.14'"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "pandas>=2.3.3; python_full_version >= '3.14.0'",
     "pyarrow>=16.0,<18; python_version<'3.10'",
     "pyarrow>=18.0,<20; python_version>='3.10' and python_version<'3.14'",
-    "pyarrow>=22.0,<24; python_version>='3.14'"
+    "pyarrow>=23.0.0,<24; python_version>='3.14'"
 ]
 
 [project.urls]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -37,8 +37,8 @@ maintainers = [
 ]
 dependencies = [
     "numpy>=2.0.0,<3",
-    "pandas>=2.0,<2.3; python_version<'3.14'",
-    "pandas>=2.3.3; python_version>='3.14'",
+    "pandas>=2.0,<2.3; python_full_version < '3.14.0'",
+    "pandas>=2.3.3; python_full_version >= '3.14.0'",
     "pyarrow>=16.0,<18; python_version<'3.10'",
     "pyarrow>=18.0,<20; python_version>='3.10' and python_version<'3.14'",
     "pyarrow>=22.0,<24; python_version>='3.14'"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "pandas>=2.3.3; python_full_version >= '3.14.0'",
     "pyarrow>=16.0,<18; python_version<'3.10'",
     "pyarrow>=18.0,<20; python_version>='3.10' and python_version<'3.14'",
-    "pyarrow>=23.0.0,<24; python_version>='3.14'"
+    "pyarrow>=22.0,<24; python_version>='3.14'"
 ]
 
 [project.urls]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -21,8 +21,8 @@ cython==3.0.10
 black==25.11.0; python_version < "3.10"
 black==26.3.1; python_version >= "3.10"
 numpy>=2.0.0,<3
-pandas==2.2.2; python_version < "3.14"
-pandas>=2.3.3; python_version >= "3.14"
+pandas==2.2.2; python_full_version < "3.14.0"
+pandas>=2.3.3; python_full_version >= "3.14.0"
 setuptools==78.1.1
 wheel==0.46.2
 pyarrow>=8.0.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -21,7 +21,8 @@ cython==3.0.10
 black==25.11.0; python_version < "3.10"
 black==26.3.1; python_version >= "3.10"
 numpy>=2.0.0,<3
-pandas==2.2.2
+pandas==2.2.2; python_version < "3.14"
+pandas>=2.3.3; python_version >= "3.14"
 setuptools==78.1.1
 wheel==0.46.2
 pyarrow>=8.0.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -18,7 +18,8 @@
 #
 
 cython==3.0.10
-black==26.3.1
+black==25.11.0; python_version < "3.10"
+black==26.3.1; python_version >= "3.10"
 numpy>=2.0.0,<3
 pandas==2.2.2
 setuptools==78.1.1

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -51,6 +51,10 @@ def convert_to_nullable_types(df):
             df[col] = df[col].astype("Float32")
         elif dtype == "bool":
             df[col] = df[col].astype("boolean")
+        elif dtype == object:
+            non_null = df[col].dropna()
+            if len(non_null) and non_null.map(lambda x: isinstance(x, str)).all():
+                df[col] = df[col].astype("string")
     return df
 
 

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -51,7 +51,7 @@ def convert_to_nullable_types(df):
             df[col] = df[col].astype("Float32")
         elif dtype == "bool":
             df[col] = df[col].astype("boolean")
-        elif dtype == object:
+        elif pd.api.types.is_object_dtype(df[col]):
             non_null = df[col].dropna()
             if len(non_null) and non_null.map(lambda x: isinstance(x, str)).all():
                 df[col] = df[col].astype("string")
@@ -96,6 +96,7 @@ def test_write_dataframe_basic():
         df_sorted = convert_to_nullable_types(
             df.sort_values("time").reset_index(drop=True)
         )
+        df_read = convert_to_nullable_types(df_read)
         assert df_read.shape == (100, 4)
         assert df_read[TIME_COLUMN].equals(df_sorted["time"])
         assert df_read["device"].equals(df_sorted["device"])
@@ -132,6 +133,7 @@ def test_write_dataframe_with_index():
         df_read = df_read.sort_values(TIME_COLUMN).reset_index(drop=True)
         df_sorted = df.sort_index()
         df_sorted = convert_to_nullable_types(df_sorted.reset_index(drop=True))
+        df_read = convert_to_nullable_types(df_read)
         time_series = pd.Series(df.sort_index().index.values, dtype="Int64")
         assert df_read.shape == (50, 3)
         assert df_read[TIME_COLUMN].equals(time_series)
@@ -170,6 +172,7 @@ def test_write_dataframe_case_insensitive():
         df_sorted = convert_to_nullable_types(
             df.sort_values("Time").reset_index(drop=True)
         )
+        df_read = convert_to_nullable_types(df_read)
         assert df_read.shape == (30, 3)
         assert df_read[TIME_COLUMN].equals(df_sorted["Time"])
         assert df_read["device"].equals(df_sorted["Device"])
@@ -274,6 +277,7 @@ def test_write_dataframe_all_datatypes():
         df_sorted = convert_to_nullable_types(
             df.sort_values("time").reset_index(drop=True)
         )
+        df_read = convert_to_nullable_types(df_read)
         assert df_read.shape == (50, 11)
         assert df_read["bool_col"].equals(df_sorted["bool_col"])
         assert df_read["int32_col"].equals(df_sorted["int32_col"])
@@ -321,6 +325,7 @@ def test_write_dataframe_schema_time_column():
         df_sorted = convert_to_nullable_types(
             df.sort_values("time").reset_index(drop=True)
         )
+        df_read = convert_to_nullable_types(df_read)
         assert df_read.shape == (50, 3)
         assert df_read[TIME_COLUMN].equals(df_sorted[TIME_COLUMN])
         assert df_read["device"].equals(df_sorted["device"])
@@ -358,6 +363,7 @@ def test_write_dataframe_schema_time_and_dataframe_time():
         df_sorted = convert_to_nullable_types(
             df.sort_values("Time").rename(columns=str.lower).reset_index(drop=True)
         )
+        df_read = convert_to_nullable_types(df_read)
         assert df_read.shape == (30, 3)
         assert df_read["time"].equals(df_sorted["time"])
         assert df_read["device"].equals(df_sorted["device"])

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -55,6 +55,9 @@ def convert_to_nullable_types(df):
             non_null = df[col].dropna()
             if len(non_null) and non_null.map(lambda x: isinstance(x, str)).all():
                 df[col] = df[col].astype("string")
+        elif pd.api.types.is_string_dtype(df[col]):
+            # NumPy/pandas str dtype (e.g. Py3.14) vs object: unify for Series.equals
+            df[col] = df[col].astype("string")
     return df
 
 

--- a/python/tests/test_to_tsfile.py
+++ b/python/tests/test_to_tsfile.py
@@ -40,6 +40,10 @@ def convert_to_nullable_types(df):
             df[col] = df[col].astype("Float32")
         elif dtype == "bool":
             df[col] = df[col].astype("boolean")
+        elif dtype == object:
+            non_null = df[col].dropna()
+            if len(non_null) and non_null.map(lambda x: isinstance(x, str)).all():
+                df[col] = df[col].astype("string")
     return df
 
 

--- a/python/tests/test_to_tsfile.py
+++ b/python/tests/test_to_tsfile.py
@@ -44,6 +44,8 @@ def convert_to_nullable_types(df):
             non_null = df[col].dropna()
             if len(non_null) and non_null.map(lambda x: isinstance(x, str)).all():
                 df[col] = df[col].astype("string")
+        elif pd.api.types.is_string_dtype(df[col]):
+            df[col] = df[col].astype("string")
     return df
 
 

--- a/python/tests/test_to_tsfile.py
+++ b/python/tests/test_to_tsfile.py
@@ -40,7 +40,7 @@ def convert_to_nullable_types(df):
             df[col] = df[col].astype("Float32")
         elif dtype == "bool":
             df[col] = df[col].astype("boolean")
-        elif dtype == object:
+        elif pd.api.types.is_object_dtype(df[col]):
             non_null = df[col].dropna()
             if len(non_null) and non_null.map(lambda x: isinstance(x, str)).all():
                 df[col] = df[col].astype("string")
@@ -69,6 +69,7 @@ def test_dataframe_to_tsfile_basic():
         df_sorted = convert_to_nullable_types(
             df.sort_values("time").reset_index(drop=True)
         )
+        df_read = convert_to_nullable_types(df_read)
 
         assert df_read.shape == (100, 4)
         assert df_read["time"].equals(df_sorted["time"])
@@ -113,6 +114,7 @@ def test_dataframe_to_tsfile_with_index():
 
         df_read = to_dataframe(tsfile_path, table_name="test_table")
         df_read = df_read.sort_values("time").reset_index(drop=True)
+        df_read = convert_to_nullable_types(df_read)
         time_expected = pd.Series(df.index.values, dtype="Int64")
         assert df_read.shape == (30, 3)
         assert df_read["time"].equals(time_expected)
@@ -150,6 +152,7 @@ def test_dataframe_to_tsfile_custom_time_column():
         df_sorted = convert_to_nullable_types(
             df.sort_values("timestamp").reset_index(drop=True)
         )
+        df_read = convert_to_nullable_types(df_read)
 
         assert df_read.shape == (30, 3)
         assert df_read["timestamp"].equals(df_sorted["timestamp"])
@@ -173,6 +176,7 @@ def test_dataframe_to_tsfile_case_insensitive_time():
         dataframe_to_tsfile(df, tsfile_path, table_name="test_table")
 
         df_read = to_dataframe(tsfile_path, table_name="test_table")
+        df_read = convert_to_nullable_types(df_read)
         assert df_read.shape == (20, 2)
         assert df_read["time"].equals(pd.Series([i for i in range(20)], dtype="Int64"))
     finally:
@@ -204,6 +208,7 @@ def test_dataframe_to_tsfile_with_tag_columns():
         df_sorted = convert_to_nullable_types(
             df.sort_values("time").reset_index(drop=True)
         )
+        df_read = convert_to_nullable_types(df_read)
 
         assert df_read.shape == (20, 4)
         assert df_read["device"].equals(df_sorted["device"])
@@ -246,6 +251,7 @@ def test_dataframe_to_tsfile_tag_time_unsorted():
         df_read = to_dataframe(tsfile_path, table_name="test_table")
         df_expected = df.sort_values(by=["device", "time"]).reset_index(drop=True)
         df_expected = convert_to_nullable_types(df_expected)
+        df_read = convert_to_nullable_types(df_read)
 
         assert df_read.shape == (10, 3)
         assert df_read["device"].equals(df_expected["device"])
@@ -285,6 +291,7 @@ def test_dataframe_to_tsfile_all_datatypes():
         df_sorted = convert_to_nullable_types(
             df.sort_values("time").reset_index(drop=True)
         )
+        df_read = convert_to_nullable_types(df_read)
 
         assert df_read.shape == (50, 11)
         assert df_read["bool_col"].equals(df_sorted["bool_col"])

--- a/python/tsfile/tsfile_table_writer.py
+++ b/python/tsfile/tsfile_table_writer.py
@@ -36,6 +36,9 @@ def validate_dataframe_for_tsfile(df: pd.DataFrame) -> None:
     for c in columns:
         if c is None or (isinstance(c, str) and len(c) == 0):
             raise ValueError("Column name cannot be None or empty")
+        # pandas may store a None column label as float NaN (see tests with columns=[None, ...])
+        if not isinstance(c, str) and pd.isna(c):
+            raise ValueError("Column name cannot be None or empty")
         lower = c.lower()
         if lower in seen:
             duplicates.append(c)

--- a/python/tsfile/tsfile_table_writer.py
+++ b/python/tsfile/tsfile_table_writer.py
@@ -34,12 +34,19 @@ def validate_dataframe_for_tsfile(df: pd.DataFrame) -> None:
     seen = set()
     duplicates = []
     for c in columns:
-        if c is None or (isinstance(c, str) and len(c) == 0):
+        if isinstance(c, str):
+            if len(c) == 0:
+                raise ValueError("Column name cannot be None or empty")
+            lower = c.lower()
+        elif c is None:
             raise ValueError("Column name cannot be None or empty")
-        # pandas may store a None column label as float NaN (see tests with columns=[None, ...])
-        if not isinstance(c, str) and pd.isna(c):
-            raise ValueError("Column name cannot be None or empty")
-        lower = c.lower()
+        else:
+            try:
+                if pd.isna(c):
+                    raise ValueError("Column name cannot be None or empty")
+            except (TypeError, ValueError):
+                pass
+            lower = str(c).lower()
         if lower in seen:
             duplicates.append(c)
         seen.add(lower)

--- a/python/tsfile/tsfile_table_writer.py
+++ b/python/tsfile/tsfile_table_writer.py
@@ -44,7 +44,7 @@ def validate_dataframe_for_tsfile(df: pd.DataFrame) -> None:
             try:
                 if pd.isna(c):
                     raise ValueError("Column name cannot be None or empty")
-            except (TypeError, ValueError):
+            except TypeError:
                 pass
             lower = str(c).lower()
         if lower in seen:


### PR DESCRIPTION
## Description

This PR fixes Python 3.14 CI failures and improves dataframe test stability.

### Dependency/version updates

- `cibuildwheel`: `3.3.0` -> `3.4.1`  
  Reason: better Python 3.14 wheel build support.   https://github.com/pypa/cibuildwheel/releases/tag/v3.4.1

- `black` (Windows build):  
  - Python 3.9 -> `25.11.0`  
  - Python >=3.10 -> `26.3.1`  
  Reason: newer Black versions no longer support Python 3.9.

- `pandas` (`pyproject.toml` / `requirements.txt`):  
  - `<3.14.0`: constrained to pre-2.3 line  
  - `>=3.14.0`: moved to `>=2.3.3`  
  Reason: keep resolver behavior consistent and ensure Python 3.14 compatibility. https://pandas.pydata.org/docs/whatsnew/v2.3.3.html

- `pyarrow` (Python 3.14): `>=22.0.0,<24`   https://pypi.org/project/pyarrow/22.0.0/#files

### Other fixes

- Fixed dataframe column-name validation for `None`/`NaN`.
- Normalized string dtype handling in dataframe tests to avoid platform-specific false failures.
tested in https://github.com/hongzhi-gao/tsfile/actions/runs/24713013612/job/72282174188