### PR TITLE
[CI] Expand Python unit-test matrix to 3.9/3.11/3.14

### DIFF
--- a/.github/workflows/unit-test-python.yml
+++ b/.github/workflows/unit-test-python.yml
@@ -107,7 +107,11 @@ jobs:
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             export PATH="/c/mingw64/bin:$PATH"
           fi
-          ./mvnw${{ steps.platform_suffix.outputs.platform_suffix }} -P with-python -Denable.asan=OFF -Dbuild.type=Release clean verify
+          BLACK_VER_PROP=""
+          if [[ "${{ matrix.python-version }}" == "3.9" ]]; then
+            BLACK_VER_PROP="-Dblack.version=25.11.0"
+          fi
+          ./mvnw${{ steps.platform_suffix.outputs.platform_suffix }} -P with-python -Denable.asan=OFF -Dbuild.type=Release clean verify ${BLACK_VER_PROP}
 
       - name: Upload whl Artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/unit-test-python.yml
+++ b/.github/workflows/unit-test-python.yml
@@ -44,7 +44,7 @@ jobs:
       max-parallel: 15
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.11", "3.14"]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/unit-test-python.yml
+++ b/.github/workflows/unit-test-python.yml
@@ -44,6 +44,7 @@ jobs:
       max-parallel: 15
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -54,7 +55,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
 
       # Setup caching of the artifacts in the .m2 directory, so they don't have to
       # all be downloaded again for every build.
@@ -111,6 +112,6 @@ jobs:
       - name: Upload whl Artifact
         uses: actions/upload-artifact@v7
         with:
-          name: tsfile-${{ runner.os }}-whl
+          name: tsfile-${{ runner.os }}-py${{ matrix.python-version }}-whl
           path: python/dist/tsfile-*.whl
           retention-days: 1


### PR DESCRIPTION
This PR expands Python PR CI unit tests from a single Python version to a 3-version matrix (3.9, 3.11, 3.14) in .github/workflows/unit-test-python.yml, improving early compatibility coverage across min/current/latest supported Python versions.