### PR TITLE
feat: i18n support for log and exception messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,10 @@ The root `pom.xml` orchestrates all three via Maven profiles:
 ./mvnw spotless:check    # Check formatting without modifying
 ```
 
+## Internationalization
+
+Java logs and exception messages use a runtime `ResourceBundle` approach so the same JAR can emit English or Simplified Chinese based on a JVM startup property. See `java/CLAUDE.md` for the convention. Switch language with `-Dtsfile.locale=zh`.
+
 ## License Header
 
 Every new file must include the Apache License 2.0 header at the top. Use the comment style appropriate for the file type (e.g., `<!-- -->` for Markdown, `/* */` for Java/C++, `#` for Python). See any existing file for the exact wording.

--- a/java/CLAUDE.md
+++ b/java/CLAUDE.md
@@ -92,6 +92,23 @@ Code generation: FreeMarker templates in `tsfile/src/main/codegen/` generate typ
 - Integration tests: `*IT.java` — run via `mvn verify`
 - Tests run in random order with `reuseForks=false`
 
+## Internationalization (i18n)
+
+All user-facing log messages and exception messages in `java/common`, `java/tsfile`, and `java/tools` go through `org.apache.tsfile.i18n.Messages`. Hardcoded English strings in `LOGGER.*` / `LOG.*` / `logger.*` or `throw new XxxException(...)` are not allowed for new code — add an entry to `java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties` and reference it via:
+
+- `Messages.get(key)` for SLF4J patterns (containing `{}` placeholders)
+- `Messages.format(key, args)` for exception patterns (containing `%1$s` positional placeholders)
+
+Locale at runtime is chosen in this order:
+
+1. `-Dtsfile.locale=<tag>` system property (e.g. `zh`, `zh-CN`)
+2. `Locale.getDefault()`
+3. English fallback (root bundle)
+
+When adding a key, mirror it in `messages_zh.properties` with a Simplified Chinese translation. `MessagesTest` enforces key-set alignment between the two bundles — CI fails on drift.
+
+Technical terms (class names, method names, type names, codec names like `TsFile`, `Chunk`, `Page`, `Schema`, `RLE`, `GORILLA`) are kept in English in Chinese translations.
+
 ## License Header
 
 Every new file must include the Apache License 2.0 header at the top. For Java files, use the `/* */` block comment style. See any existing `.java` file for the exact wording.

--- a/java/common/pom.xml
+++ b/java/common/pom.xml
@@ -28,6 +28,13 @@
     </parent>
     <artifactId>common</artifactId>
     <name>TsFile: Java: Common</name>
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
     <profiles>
         <profile>
             <id>get-jar-with-dependencies</id>

--- a/java/common/pom.xml
+++ b/java/common/pom.xml
@@ -35,6 +35,22 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Pin tsfile.locale=en so tests run against the English (root) message
+                         bundle regardless of the JVM default locale. Must be set at JVM
+                         startup because Messages.BUNDLE is initialized once at class load. -->
+                    <systemPropertyVariables>
+                        <tsfile.locale>en</tsfile.locale>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
             <id>get-jar-with-dependencies</id>

--- a/java/common/src/main/java/org/apache/tsfile/block/TsBlockBuilderStatus.java
+++ b/java/common/src/main/java/org/apache/tsfile/block/TsBlockBuilderStatus.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.block;
 
 import org.apache.tsfile.block.column.ColumnBuilderStatus;
+import org.apache.tsfile.i18n.Messages;
 
 public class TsBlockBuilderStatus {
 
@@ -49,7 +50,7 @@ public class TsBlockBuilderStatus {
 
   public void addBytes(int bytes) {
     if (bytes < 0) {
-      throw new IllegalArgumentException("bytes cannot be negative");
+      throw new IllegalArgumentException(Messages.get("error.common.bytes_cannot_be_negative"));
     }
     currentSize += bytes;
   }

--- a/java/common/src/main/java/org/apache/tsfile/block/column/ColumnBuilderStatus.java
+++ b/java/common/src/main/java/org/apache/tsfile/block/column/ColumnBuilderStatus.java
@@ -20,12 +20,12 @@
 package org.apache.tsfile.block.column;
 
 import org.apache.tsfile.block.TsBlockBuilderStatus;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.RamUsageEstimator;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class ColumnBuilderStatus {
@@ -61,20 +61,22 @@ public class ColumnBuilderStatus {
   private static long deepInstanceSize(Class<?> clazz) {
     if (clazz.isArray()) {
       throw new IllegalArgumentException(
-          format(
-              "Cannot determine size of %s because it contains an array", clazz.getSimpleName()));
+          Messages.format("error.common.cannot_determine_size_array", clazz.getSimpleName()));
     }
     if (clazz.isInterface()) {
-      throw new IllegalArgumentException(format("%s is an interface", clazz.getSimpleName()));
+      throw new IllegalArgumentException(
+          Messages.format("error.common.class_is_interface", clazz.getSimpleName()));
     }
     if (Modifier.isAbstract(clazz.getModifiers())) {
-      throw new IllegalArgumentException(format("%s is abstract", clazz.getSimpleName()));
+      throw new IllegalArgumentException(
+          Messages.format("error.common.class_is_abstract", clazz.getSimpleName()));
     }
     if (!clazz.getSuperclass().equals(Object.class)) {
       throw new IllegalArgumentException(
-          format(
-              "Cannot determine size of a subclass. %s extends from %s",
-              clazz.getSimpleName(), clazz.getSuperclass().getSimpleName()));
+          Messages.format(
+              "error.common.cannot_determine_size_subclass",
+              clazz.getSimpleName(),
+              clazz.getSuperclass().getSimpleName()));
     }
 
     long size = RamUsageEstimator.shallowSizeOf(clazz);

--- a/java/common/src/main/java/org/apache/tsfile/block/column/ColumnEncoding.java
+++ b/java/common/src/main/java/org/apache/tsfile/block/column/ColumnEncoding.java
@@ -19,6 +19,8 @@
 
 package org.apache.tsfile.block.column;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -66,7 +68,8 @@ public enum ColumnEncoding {
       case 5:
         return DICTIONARY;
       default:
-        throw new IllegalArgumentException("Invalid value: " + value);
+        throw new IllegalArgumentException(
+            Messages.format("error.common.invalid_column_encoding_value", value));
     }
   }
 }

--- a/java/common/src/main/java/org/apache/tsfile/enums/TSDataType.java
+++ b/java/common/src/main/java/org/apache/tsfile/enums/TSDataType.java
@@ -19,6 +19,7 @@
 
 package org.apache.tsfile.enums;
 
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.write.UnSupportedDataTypeException;
 
@@ -193,7 +194,7 @@ public enum TSDataType {
       case 12:
         return TSDataType.OBJECT;
       default:
-        throw new IllegalArgumentException("Invalid input: " + type);
+        throw new IllegalArgumentException(Messages.format("error.common.invalid_input", type));
     }
   }
 
@@ -325,7 +326,7 @@ public enum TSDataType {
         break;
     }
     throw new ClassCastException(
-        String.format("Unsupported cast: from %s to %s", sourceType, this));
+        Messages.format("error.common.unsupported_cast", sourceType, this));
   }
 
   @SuppressWarnings({"java:S3012", "java:S3776", "java:S6541"})
@@ -472,7 +473,7 @@ public enum TSDataType {
         break;
     }
     throw new ClassCastException(
-        String.format("Unsupported cast: from %s to %s", sourceType, this));
+        Messages.format("error.common.unsupported_cast", sourceType, this));
   }
 
   public static TSDataType deserializeFrom(ByteBuffer buffer) {

--- a/java/common/src/main/java/org/apache/tsfile/i18n/Messages.java
+++ b/java/common/src/main/java/org/apache/tsfile/i18n/Messages.java
@@ -86,6 +86,18 @@ public final class Messages {
    * Chinese characters directly in {@code messages_zh.properties} without Unicode escapes.
    */
   private static final class Utf8Control extends ResourceBundle.Control {
+    /**
+     * Disable Java's default fallback to {@link Locale#getDefault()}. Without this override, when a
+     * user requests "en" (via {@code -Dtsfile.locale=en}) on a JVM whose default locale is "zh",
+     * ResourceBundle's default behavior is to ALSO load the zh bundle as a parent, which causes
+     * {@code BUNDLE.getString(key)} to return Chinese text. Returning {@code null} keeps the
+     * resolution strictly within the requested locale's candidate chain (e.g., {@code [en, ROOT]}).
+     */
+    @Override
+    public Locale getFallbackLocale(String baseName, Locale locale) {
+      return null;
+    }
+
     @Override
     public ResourceBundle newBundle(
         String baseName, Locale locale, String format, ClassLoader loader, boolean reload)

--- a/java/common/src/main/java/org/apache/tsfile/i18n/Messages.java
+++ b/java/common/src/main/java/org/apache/tsfile/i18n/Messages.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tsfile.i18n;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.PropertyResourceBundle;
+import java.util.ResourceBundle;
+
+/**
+ * Resolves log and exception message patterns from locale-specific resource bundles.
+ *
+ * <p>Locale resolution order (evaluated once at class load):
+ *
+ * <ol>
+ *   <li>System property {@code -Dtsfile.locale} (e.g. {@code zh}, {@code zh-CN}).
+ *   <li>{@link Locale#getDefault()}.
+ *   <li>English fallback via {@link ResourceBundle}'s root-bundle mechanism.
+ * </ol>
+ *
+ * <p>Use {@link #get(String)} for SLF4J patterns (which contain {@code &#123;&#125;} placeholders
+ * and are formatted lazily by SLF4J), and {@link #format(String, Object...)} for exception messages
+ * (which use {@link String#format} positional placeholders like {@code %1$s}).
+ */
+public final class Messages {
+
+  private static final String BUNDLE_BASE_NAME = "org.apache.tsfile.i18n.messages";
+  private static final ResourceBundle BUNDLE = loadBundle();
+
+  private Messages() {}
+
+  /**
+   * Returns the raw message pattern.
+   *
+   * @throws java.util.MissingResourceException if {@code key} is not defined in the bundle
+   */
+  public static String get(String key) {
+    return BUNDLE.getString(key);
+  }
+
+  /**
+   * Returns the message pattern formatted with the given arguments via {@link String#format}.
+   *
+   * @throws java.util.MissingResourceException if {@code key} is not defined in the bundle
+   * @throws java.util.IllegalFormatException if the pattern and {@code args} are incompatible
+   */
+  public static String format(String key, Object... args) {
+    return String.format(BUNDLE.getString(key), args);
+  }
+
+  private static ResourceBundle loadBundle() {
+    return ResourceBundle.getBundle(
+        BUNDLE_BASE_NAME, determineLocale(), Messages.class.getClassLoader(), new Utf8Control());
+  }
+
+  private static Locale determineLocale() {
+    String prop = System.getProperty("tsfile.locale");
+    if (prop != null && !prop.isEmpty()) {
+      return Locale.forLanguageTag(prop);
+    }
+    return Locale.getDefault();
+  }
+
+  /**
+   * Loads {@code .properties} files as UTF-8 instead of the JDK default ISO-8859-1. Lets us write
+   * Chinese characters directly in {@code messages_zh.properties} without Unicode escapes.
+   */
+  private static final class Utf8Control extends ResourceBundle.Control {
+    @Override
+    public ResourceBundle newBundle(
+        String baseName, Locale locale, String format, ClassLoader loader, boolean reload)
+        throws IOException, IllegalAccessException, InstantiationException {
+      if (!"java.properties".equals(format)) {
+        return super.newBundle(baseName, locale, format, loader, reload);
+      }
+      String bundleName = toBundleName(baseName, locale);
+      String resourceName = toResourceName(bundleName, "properties");
+      try (InputStream in = loader.getResourceAsStream(resourceName)) {
+        if (in == null) {
+          return null;
+        }
+        try (Reader reader = new InputStreamReader(in, StandardCharsets.UTF_8)) {
+          return new PropertyResourceBundle(reader);
+        }
+      }
+    }
+  }
+}

--- a/java/common/src/main/java/org/apache/tsfile/utils/BitMap.java
+++ b/java/common/src/main/java/org/apache/tsfile/utils/BitMap.java
@@ -19,6 +19,8 @@
 
 package org.apache.tsfile.utils;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -81,7 +83,8 @@ public class BitMap {
 
     if (startPosition < 0 || startPosition + length > size) {
       throw new IndexOutOfBoundsException(
-          "startPosition " + startPosition + " + length " + length + " is out of range " + size);
+          Messages.format(
+              "error.common.bitmap_start_length_out_of_range", startPosition, length, size));
     }
 
     int bitEnd = startPosition + length - 1;
@@ -118,7 +121,8 @@ public class BitMap {
 
     if (startPosition < 0 || startPosition + length > size) {
       throw new IndexOutOfBoundsException(
-          "startPosition " + startPosition + " + length " + length + " is out of range " + size);
+          Messages.format(
+              "error.common.bitmap_start_length_out_of_range", startPosition, length, size));
     }
 
     int bitEnd = startPosition + length - 1;
@@ -267,10 +271,10 @@ public class BitMap {
     BitMap other = (BitMap) obj;
     if (rangeSize > size || rangeSize > other.size) {
       throw new IllegalArgumentException(
-          "range size "
-              + rangeSize
-              + " should <= the minimal bitmap size "
-              + Math.min(this.size, other.size));
+          Messages.format(
+              "error.common.bitmap_range_size_exceeds",
+              rangeSize,
+              Math.min(this.size, other.size)));
     }
 
     int byteSize = rangeSize / Byte.SIZE;
@@ -314,10 +318,11 @@ public class BitMap {
   public static void copyOfRange(BitMap src, int srcPos, BitMap dest, int destPos, int length) {
     if (srcPos + length > src.size) {
       throw new IndexOutOfBoundsException(
-          (srcPos + length - 1) + " is out of src range " + src.size);
+          Messages.format("error.common.bitmap_out_of_src_range", (srcPos + length - 1), src.size));
     } else if (destPos + length > dest.size) {
       throw new IndexOutOfBoundsException(
-          (destPos + length - 1) + " is out of dest range " + dest.size);
+          Messages.format(
+              "error.common.bitmap_out_of_dest_range", (destPos + length - 1), dest.size));
     }
     for (int i = 0; i < length; ++i) {
       if (src.isMarked(srcPos + i)) {

--- a/java/common/src/main/java/org/apache/tsfile/utils/RamUsageEstimator.java
+++ b/java/common/src/main/java/org/apache/tsfile/utils/RamUsageEstimator.java
@@ -19,6 +19,8 @@
 
 package org.apache.tsfile.utils;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -565,7 +567,7 @@ public final class RamUsageEstimator {
    */
   public static long shallowSizeOfInstance(Class<?> clazz) {
     if (clazz.isArray())
-      throw new IllegalArgumentException("This method does not work with array classes.");
+      throw new IllegalArgumentException(Messages.get("error.common.no_array_classes"));
     if (clazz.isPrimitive()) return primitiveSizes.get(clazz);
 
     long size = NUM_BYTES_OBJECT_HEADER;

--- a/java/common/src/main/java/org/apache/tsfile/utils/TsPrimitiveType.java
+++ b/java/common/src/main/java/org/apache/tsfile/utils/TsPrimitiveType.java
@@ -19,6 +19,7 @@
 package org.apache.tsfile.utils;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.write.UnSupportedDataTypeException;
 
 import java.io.Serializable;
@@ -55,7 +56,8 @@ public abstract class TsPrimitiveType implements Serializable {
       case VECTOR:
         return new TsPrimitiveType.TsVector();
       default:
-        throw new UnSupportedDataTypeException("Unsupported data type:" + dataType);
+        throw new UnSupportedDataTypeException(
+            Messages.format("error.common.unsupported_data_type", dataType));
     }
   }
 
@@ -88,64 +90,79 @@ public abstract class TsPrimitiveType implements Serializable {
       case VECTOR:
         return new TsPrimitiveType.TsVector((TsPrimitiveType[]) v);
       default:
-        throw new UnSupportedDataTypeException("Unsupported data type:" + dataType);
+        throw new UnSupportedDataTypeException(
+            Messages.format("error.common.unsupported_data_type", dataType));
     }
   }
 
   public boolean getBoolean() {
-    throw new UnsupportedOperationException("getBoolean() is not supported for current sub-class");
+    throw new UnsupportedOperationException(
+        Messages.format("error.common.subclass_op_not_supported", "getBoolean()"));
   }
 
   public int getInt() {
-    throw new UnsupportedOperationException("getInt() is not supported for current sub-class");
+    throw new UnsupportedOperationException(
+        Messages.format("error.common.subclass_op_not_supported", "getInt()"));
   }
 
   public long getLong() {
-    throw new UnsupportedOperationException("getLong() is not supported for current sub-class");
+    throw new UnsupportedOperationException(
+        Messages.format("error.common.subclass_op_not_supported", "getLong()"));
   }
 
   public float getFloat() {
-    throw new UnsupportedOperationException("getFloat() is not supported for current sub-class");
+    throw new UnsupportedOperationException(
+        Messages.format("error.common.subclass_op_not_supported", "getFloat()"));
   }
 
   public double getDouble() {
-    throw new UnsupportedOperationException("getDouble() is not supported for current sub-class");
+    throw new UnsupportedOperationException(
+        Messages.format("error.common.subclass_op_not_supported", "getDouble()"));
   }
 
   public Binary getBinary() {
-    throw new UnsupportedOperationException("getBinary() is not supported for current sub-class");
+    throw new UnsupportedOperationException(
+        Messages.format("error.common.subclass_op_not_supported", "getBinary()"));
   }
 
   public TsPrimitiveType[] getVector() {
-    throw new UnsupportedOperationException("getVector() is not supported for current sub-class");
+    throw new UnsupportedOperationException(
+        Messages.format("error.common.subclass_op_not_supported", "getVector()"));
   }
 
   public void setBoolean(boolean val) {
-    throw new UnsupportedOperationException("setBoolean() is not supported for current sub-class");
+    throw new UnsupportedOperationException(
+        Messages.format("error.common.subclass_op_not_supported", "setBoolean()"));
   }
 
   public void setInt(int val) {
-    throw new UnsupportedOperationException("setInt() is not supported for current sub-class");
+    throw new UnsupportedOperationException(
+        Messages.format("error.common.subclass_op_not_supported", "setInt()"));
   }
 
   public void setLong(long val) {
-    throw new UnsupportedOperationException("setLong() is not supported for current sub-class");
+    throw new UnsupportedOperationException(
+        Messages.format("error.common.subclass_op_not_supported", "setLong()"));
   }
 
   public void setFloat(float val) {
-    throw new UnsupportedOperationException("setFloat() is not supported for current sub-class");
+    throw new UnsupportedOperationException(
+        Messages.format("error.common.subclass_op_not_supported", "setFloat()"));
   }
 
   public void setDouble(double val) {
-    throw new UnsupportedOperationException("setDouble() is not supported for current sub-class");
+    throw new UnsupportedOperationException(
+        Messages.format("error.common.subclass_op_not_supported", "setDouble()"));
   }
 
   public void setBinary(Binary val) {
-    throw new UnsupportedOperationException("setBinary() is not supported for current sub-class");
+    throw new UnsupportedOperationException(
+        Messages.format("error.common.subclass_op_not_supported", "setBinary()"));
   }
 
   public void setVector(TsPrimitiveType[] val) {
-    throw new UnsupportedOperationException("setVector() is not supported for current sub-class");
+    throw new UnsupportedOperationException(
+        Messages.format("error.common.subclass_op_not_supported", "setVector()"));
   }
 
   public abstract void setObject(Object val);
@@ -212,7 +229,8 @@ public abstract class TsPrimitiveType implements Serializable {
         setBoolean((Boolean) val);
         return;
       }
-      throw new UnSupportedDataTypeException("TsBoolean can only be set Boolean value");
+      throw new UnSupportedDataTypeException(
+          Messages.format("error.common.tsprimitive_wrong_value_type", "TsBoolean", "Boolean"));
     }
 
     @Override
@@ -315,7 +333,8 @@ public abstract class TsPrimitiveType implements Serializable {
         setInt((Integer) val);
         return;
       }
-      throw new UnSupportedDataTypeException("TsInt can only be set Integer value");
+      throw new UnSupportedDataTypeException(
+          Messages.format("error.common.tsprimitive_wrong_value_type", "TsInt", "Integer"));
     }
 
     @Override
@@ -397,7 +416,8 @@ public abstract class TsPrimitiveType implements Serializable {
         setLong((Long) val);
         return;
       }
-      throw new UnSupportedDataTypeException("TsLong can only be set Long value");
+      throw new UnSupportedDataTypeException(
+          Messages.format("error.common.tsprimitive_wrong_value_type", "TsLong", "Long"));
     }
 
     @Override
@@ -479,7 +499,8 @@ public abstract class TsPrimitiveType implements Serializable {
         setFloat((Float) val);
         return;
       }
-      throw new UnSupportedDataTypeException("TsFloat can only be set float value");
+      throw new UnSupportedDataTypeException(
+          Messages.format("error.common.tsprimitive_wrong_value_type", "TsFloat", "float"));
     }
 
     @Override
@@ -556,7 +577,8 @@ public abstract class TsPrimitiveType implements Serializable {
         setDouble((Double) val);
         return;
       }
-      throw new UnSupportedDataTypeException("TsDouble can only be set Double value");
+      throw new UnSupportedDataTypeException(
+          Messages.format("error.common.tsprimitive_wrong_value_type", "TsDouble", "Double"));
     }
 
     @Override
@@ -628,7 +650,8 @@ public abstract class TsPrimitiveType implements Serializable {
         setBinary((Binary) val);
         return;
       }
-      throw new UnSupportedDataTypeException("TsBinary can only be set Binary value");
+      throw new UnSupportedDataTypeException(
+          Messages.format("error.common.tsprimitive_wrong_value_type", "TsBinary", "Binary"));
     }
 
     @Override
@@ -700,7 +723,9 @@ public abstract class TsPrimitiveType implements Serializable {
         setVector((TsPrimitiveType[]) val);
         return;
       }
-      throw new UnSupportedDataTypeException("TsVector can only be set TsPrimitiveType[] value");
+      throw new UnSupportedDataTypeException(
+          Messages.format(
+              "error.common.tsprimitive_wrong_value_type", "TsVector", "TsPrimitiveType[]"));
     }
 
     @Override

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
@@ -389,3 +389,259 @@ error.read.time_col_builder_position_invalid = position is not valid
 
 # PathParseError — syntax error with line and position
 error.read.path_parse_error = line %1$s:%2$s %3$s
+
+# === read ===
+
+# TsFileSequenceReader / selfCheck — unexpected marker
+error.read.unexpected_marker = Unexpected marker %1$s
+
+# TsFileSequenceReader.selfCheck / checkChunkAndPagesStatistics — unexpected data type in switch
+error.read.unexpected_type = Unexpected type %1$s
+
+# TsFileSequenceReader — device not in tsFileMetaData (with file name, 3 sites)
+error.read.device_not_in_metadata_file = Device {%1$s} is not in tsFileMetaData of %2$s
+
+# TsFileSequenceReader — device not in tsFileMetaData (no file name, 1 site)
+error.read.device_not_in_metadata = Device {%1$s} is not in tsFileMetaData
+
+# TsFileSequenceReader / readPlanIndex / readMarker — reach end of file (3 sites)
+error.read.reach_end_of_file = reach the end of the file.
+
+# TsFileSequenceReader.readData — reach end of data (short form)
+error.read.reach_end_of_data = reach the end of the data
+
+# TsFileSequenceReader.readData — reach end of data with position detail
+error.read.reach_end_of_data_detail = reach the end of the data. Size of data that want to read: %1$s,actual read size: %2$s, position: %3$s
+
+# TsFileSequenceReader.uncompress — uncompress error with counts (no page header)
+error.read.uncompress_error = Uncompress error! uncompress size: %1$scompressed size: %2$s%3$s
+
+# ChunkReader.uncompressPageData / decryptAndUncompressPageData / LazyLoadPageData — uncompress error with page header
+error.read.uncompress_error_with_header = Uncompress error! uncompress size: %1$scompressed size: %2$spage header: %3$s%4$s
+
+# AbstractChunkReader — no more page
+error.read.no_more_page = No more page
+
+# ChunkReader.readCompressedPageData — incomplete page body
+error.read.chunk_incomplete_page_body = do not has a complete page body. Expected:%1$s. Actual:%2$s
+
+# TsFileSequenceReaderTimeseriesMetadataIterator — deserializeTimeseriesMetadataUsingTsFileInput failed
+error.read.tsm_iterator_tsfinput_failed = TsFileSequenceReaderTimeseriesMetadataIterator: deserializeTimeseriesMetadataUsingTsFileInput failed, currentEndOffset: %1$d, %2$s
+
+# TsFileSequenceReaderTimeseriesMetadataIterator — deserializeMetadataIndexEntry failed
+error.read.tsm_iterator_index_entry_failed = TsFileSequenceReaderTimeseriesMetadataIterator: deserializeMetadataIndexEntry failed, MetadataIndexEntryInfo: %1$s, %2$s
+
+# TsFileSequenceReaderTimeseriesMetadataIterator — currentBuffer still has remaining data
+error.read.tsm_iterator_buffer_not_empty = currentBuffer still has some data left before deserializeLeafMeasurement
+
+# TsFileSequenceReader — timeseries of device are not aligned
+error.read.timeseries_not_aligned = Timeseries of device {%1$s} are not aligned
+
+# TsFileSequenceReader — aligned chunk metadata should only have one timeseriesMetadataList per device
+error.read.aligned_chunk_metadata_one_device = Error when reading timeseriesMetadata of device %1$s in file %2$s: should only one timeseriesMetadataList in one device, actual: %3$d
+
+# TsFileSequenceReader.selfCheckWithInfo — statistics mistakes in Chunk
+error.read.stats_mistakes_chunk = Chunk exists statistics mistakes at position %1$s
+
+# TsFileSequenceReader.selfCheckWithInfo — statistics mistakes in TimeseriesMetadata
+error.read.stats_mistakes_tsm = TimeseriesMetadata exists statistics mistakes at position %1$s
+
+# TsFileSequenceReader / TsFileDeviceIterator — error reading a time series metadata block (2 sites)
+error.read.metadata_block_read_error = Error occurred while reading a time series metadata block.
+
+# LazyTsFileDeviceIterator.getDevicesOfLeafNode — first param should be device leaf node
+error.read.device_leaf_node_required = the first param should be device leaf node.
+
+# LazyTsFileDeviceIterator — next() must be called before accessing current device (3 sites)
+error.read.device_iterator_no_current = next() must be called before accessing current device
+
+# DeviceMetaIterator — non-device node detected
+error.read.non_device_node_detected = A non-device node detected: %1$s
+
+# MetadataQuerierByFileImpl — spacePartitionStartPos > spacePartitionEndPos
+error.read.metadata_querier_illegal_arg = 'spacePartitionStartPos' should not be larger than 'spacePartitionEndPos'.
+
+# ExpressionOptimizer — unsupported IExpression type in binary expression
+error.read.expression_unsupported_binary_type = unsupported IExpression type: %1$s
+
+# ExpressionOptimizer — StackOverflowError
+error.read.expression_stack_overflow = StackOverflowError is encountered.
+
+# ExpressionOptimizer — unknown IExpression type
+error.read.expression_unknown_type = unknown IExpression type: %1$s
+
+# ExpressionOptimizer — unknown relation in IExpression
+error.read.expression_unknown_relation = unknown relation in IExpression:%1$s
+
+# ExpressionOptimizer — size of selectSeries could not be 0
+error.read.expression_empty_select_series = size of selectSeries could not be 0
+
+# ExpressionOptimizer — IExpression should contain only SingleSeriesExpression
+error.read.expression_unexpected_type = IExpression should contains only SingleSeriesExpression but other type is found:%1$s
+
+# ExpressionOptimizer — unrecognized QueryFilterOperatorType
+error.read.expression_unrecognized_operator = unrecognized QueryFilterOperatorType :%1$s
+
+# ValueFilter — unsupported data type (7 satisfy methods, 1 key; arg = class name)
+error.read.value_filter_unsupported_type = Unsupported data type for value filter: %1$s
+
+# ValueFilter — getTimeRanges not supported
+error.read.value_filter_no_time_ranges = Value filter does not support getTimeRanges()
+
+# Not filter — contains NOT (4 sites, 1 key; appended with filter.toString())
+error.read.filter_contains_not = This predicate contains a not! Did you forget to run this predicate through PredicateRemoveNotRewriter? %1$s
+
+# Filter.deserialize — unsupported operator type
+error.read.filter_unsupported_operator = Unsupported operator type:%1$s
+
+# TimeFilterOperators.In — set must not be null
+error.read.filter_timein_set_null = set must not be null!
+
+# ExtractTimeFilterOperators — unexpected extract field (2 sites)
+error.read.extract_unexpected_field = Unexpected extract field: %1$s
+
+# ValueFilterApi — unsupported data type (14 sites, 1 key)
+error.read.filter_api_unsupported_type = Unsupported data type: %1$s
+
+# TagFilterBuilder — column is not a tag column
+error.read.tag_not_a_tag_column = Column '%1$s' is not a tag column
+
+# TimeGenerator.getValues — OR node present
+error.read.time_generator_or_get_values = getValues() method should not be invoked when there is OR operator in where clause
+
+# TimeGenerator.getValues — path not in where clause
+error.read.time_generator_path_not_found_values = getValues() method should not be invoked by non-existent path in where clause
+
+# TimeGenerator.getValue — OR node present
+error.read.time_generator_or_get_value = getValue() method should not be invoked when there is OR operator in where clause
+
+# TimeGenerator.getValue — path not in where clause
+error.read.time_generator_path_not_found_value = getValue() method should not be invoked by non-existent path in where clause
+
+# TimeGenerator.construct — unsupported ExpressionType
+error.read.time_generator_unsupported_expression = Unsupported ExpressionType when construct OperatorNode: %1$s
+
+# AndNode / OrNode / LeafNode — no more data (3 sites)
+error.read.node_no_more_data = no more data
+
+# AbstractResultSet — column name not found
+error.read.result_set_column_not_found = Can't find columnName %1$s from result set
+
+# AbstractResultSet — field is null
+error.read.result_set_null_field = Field in columnIndex %1$s is null
+
+# AbstractResultSet — column index out of bound
+error.read.result_set_index_out_of_bound = column index %1$s out of bound
+
+# DataSetWithoutTimeGenerator — unsupported data type
+error.read.dataset_unsupported_type = UnSupported%1$s
+
+# SingleDeviceTsBlockReader — unsupported data type (3 sites, same key)
+error.read.block_reader_unsupported_type = Unsupported data type: %1$s
+
+# TableQueryExecutor — unsupported ordering
+error.read.table_query_unsupported_ordering = Unsupported ordering: %1$s
+
+# TableQueryExecutor — no column exception
+error.read.table_query_no_column = No column: %1$s
+
+# TsFileTreeReaderBuilder — file must be set
+error.read.tree_reader_file_required = file must be set before build()
+
+# TsFileReaderBuilder — file must be non-null and non-directory
+error.read.reader_builder_file_non_null = The file must be a non-null and non-directory File.
+
+# --- read LOG messages ---
+
+# TsFileRestorableReader — file has no correct tail magic
+log.read.file_repair = File {} has no correct tail magic, try to repair...
+
+# LocalTsFileInput — error getting file size
+log.read.local_input_size_error = Error happened while getting {} size
+
+# LocalTsFileInput — error getting current position
+log.read.local_input_position_error = Error happened while getting {} current position
+
+# LocalTsFileInput — error changing position
+log.read.local_input_position_change_error = Error happened while changing {} position to {}
+
+# LocalTsFileInput — ClosedByInterruptException on read (2 sites, 1 key)
+log.read.local_input_interrupted = Current thread is interrupted by another thread when it is blocked in an I/O operation upon a channel.
+
+# LocalTsFileInput — error reading from current position
+log.read.local_input_read_current_error = Error happened while reading {} from current position
+
+# LocalTsFileInput — error reading from position
+log.read.local_input_read_position_error = Error happened while reading {} from position {}
+
+# LocalTsFileInput — error closing
+log.read.local_input_close_error = Error happened while closing {}
+
+# TsFileSequenceReader — reading file metadata error
+log.read.sequence_reader_file_metadata_error = Something error happened while reading file metadata of file {}
+
+# TsFileSequenceReader — deserializing TimeseriesMetadata error (multiple sites, same key)
+log.read.sequence_reader_tsm_deserialize_error = Something error happened while deserializing TimeseriesMetadata of file {}
+
+# TsFileSequenceReader — deserializing MetadataIndexNode error (constant METADATA_INDEX_NODE_DESERIALIZE_ERROR, 8 sites)
+log.read.sequence_reader_metadata_index_node_error = Something error happened while deserializing MetadataIndexNode of file {}
+
+# TsFileSequenceReader — reading chunk header error (2 sites, 1 key)
+log.read.sequence_reader_chunk_header_error = Exception {} happened while reading chunk header of {}
+
+# TsFileSequenceReader — reading chunk error (3 sites, 1 key)
+log.read.sequence_reader_chunk_error = Exception {} happened while reading chunk of {}
+
+# TsFileSequenceReader — reading page header error
+log.read.sequence_reader_page_header_error = Exception {} happened while reading page header of {}
+
+# TsFileSequenceReader — reading data error
+log.read.sequence_reader_data_error = Exception {} happened while reading data of {}
+
+# TsFileSequenceReader — getting all paths error
+log.read.sequence_reader_paths_error = Something error happened while getting all paths of file {}
+
+# TsFileSequenceReader — generating MetadataIndex error (2 sites, 1 key)
+log.read.sequence_reader_metadata_index_error = Something error happened while generating MetadataIndex of file {}
+
+# TsFileSequenceReader — deserializing MetadataIndex error (2 sites, 1 key; different from MetadataIndexNode constant)
+log.read.sequence_reader_deserialize_metadata_error = Something error happened while deserializing MetadataIndex of file {}
+
+# TsFileSequenceReader.selfCheck — cannot proceed warning
+log.read.sequence_reader_self_check_warn = TsFile {} self-check cannot proceed at position {} recovered, because : {}
+
+# TsFileSequenceReader.selfCheckWithInfo — file length info
+log.read.sequence_reader_file_length = file length: {}
+
+# TsFileSequenceReader.selfCheckWithInfo — fast check error
+log.read.sequence_reader_fast_check_error = Error occurred while fast checking TsFile.
+
+# TsFileSequenceReader.selfCheckWithInfo — statistics check error
+log.read.sequence_reader_stats_check_error = Error occurred while checking the statistics of chunk and its pages
+
+# TsFileSequenceReader — collecting offset ranges error
+log.read.sequence_reader_collect_offset_error = Error occurred while collecting offset ranges of measurement nodes of file {}
+
+# TsFileSequenceReader.TimeseriesMetadataIterator — cannot read timeseries metadata
+log.read.sequence_reader_tsm_warn = Cannot read timeseries metadata from {},
+
+# TsFileLastReader — cannot read timeseries metadata from file (2 sites, 1 key)
+log.read.last_reader_tsm_error = Cannot read timeseries metadata from {}
+
+# TsFileLastReader — error while reading timeseries metadata (async)
+log.read.last_reader_tsm_meta_error = Error while reading timeseries metadata
+
+# DeviceOrderedTsBlockReader — failed to construct reader
+log.read.block_reader_construct_error = Failed to construct reader for {}
+
+# SingleDeviceTsBlockReader — cannot fill measurements
+log.read.block_reader_fill_measurements_error = Cannot fill measurements
+
+# TableResultSet — failed to close tsBlockReader
+log.read.table_result_set_close_error = Failed to close tsBlockReader
+
+# DeviceMetaIterator — failed to load device meta data
+log.read.device_meta_iterator_error = Failed to load device meta data
+
+# DeviceTableModelReader — close file reader exception
+log.read.v4_close_reader_error = Meet exception when close file reader:

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
@@ -1069,3 +1069,295 @@ error.external.lrumap_npe = NPE, entry=%1$s entryIsHeader=%2$s key=%3$s value=%4
 
 # ComparatorChain.checkChainIntegrity — must contain at least one comparator
 error.external.comparator_chain_empty = ComparatorChains must contain at least one Comparator
+
+# === encrypt ===
+
+# IEncryptor.getEncryptor — class not found (class name arg)
+error.encrypt.encryptor_class_not_found = Get encryptor class failed, class not found: %1$s
+
+# IEncryptor.getEncryptor — no constructor (class name arg)
+error.encrypt.encryptor_no_constructor = Get constructor for encryptor failed: %1$s
+
+# IEncryptor.getEncryptor — instantiation failed (class name arg)
+error.encrypt.encryptor_instantiation_failed = New encryptor instance failed: %1$s
+
+# IDecryptor.getDecryptor — class not found (class name arg)
+error.encrypt.decryptor_class_not_found = Get decryptor class failed, class not found: %1$s
+
+# IDecryptor.getDecryptor — no constructor (class name arg)
+error.encrypt.decryptor_no_constructor = Get constructor for decryptor failed: %1$s
+
+# IDecryptor.getDecryptor — instantiation failed (class name arg)
+error.encrypt.decryptor_instantiation_failed = New decryptor instance failed: %1$s
+
+# EncryptUtils.getEncryptKeyFromToken — key derivation failed
+error.encrypt.key_derivation_failed = Error deriving key from token
+
+# EncryptUtils.deriveKeyInternal — dkLen not positive (value arg)
+error.encrypt.dklen_not_positive = main key's dkLen must be positive integer: %1$s
+
+# EncryptUtils.deriveKeyInternal — dkLen too long (value arg)
+error.encrypt.dklen_too_long = main key's dkLen is too long: %1$s
+
+# EncryptUtils.getNormalKeyStr / generateEncryptParameter — SHA-256 not found
+error.encrypt.sha256_not_found = SHA-256 algorithm not found while using SHA-256 to generate data key
+
+# EncryptUtils.getEncrypt — class not found (encryptType arg)
+error.encrypt.encrypt_class_not_found = Get encryptor class failed: %1$s
+
+# EncryptUtils.getEncrypt — no constructor (encryptType arg)
+error.encrypt.encrypt_no_constructor = Get constructor for encryptor failed: %1$s
+
+# EncryptUtils.getEncrypt — instantiation failed (encryptType arg)
+error.encrypt.encrypt_instantiation_failed = New encryptor instance failed: %1$s
+
+# === compress ===
+
+# ICompressor.getCompressor / IUnCompressor.getUnCompressor — null type
+error.compress.type_not_supported_null = NULL
+
+# ICompressor.getCompressor / IUnCompressor.getUnCompressor — unsupported type (name arg)
+error.compress.type_not_supported = %1$s
+
+# NoCompressor — compress not supported (3 method variants, 1 key)
+error.compress.no_compressor_not_supported = No Compressor does not support compression function
+
+# NoUnCompressor — uncompress ByteBuffer not supported
+error.compress.no_uncompressor_not_supported = NoUnCompressor does not support this method.
+
+# LZ4UnCompressor / GZIPUnCompressor / LZMA2UnCompressor — getUncompressedLength not supported (6 sites, 1 key)
+error.compress.get_uncompress_length_unsupported = unsupported get uncompress length
+
+# --- compress LOG messages ---
+
+# SnappyUnCompressor — uncompress input byte error (2 sites, 1 key)
+log.compress.snappy_uncompress_error = tsfile-compression SnappyUnCompressor: errors occurs when uncompress input byte
+
+# LZ4UnCompressor — uncompress input byte error (3 sites, 1 key)
+log.compress.lz4_uncompress_error = tsfile-compression LZ4UnCompressor: errors occurs when uncompress input byte
+
+# === fileSystem ===
+
+# HDFSOutputFactory / OSFileOutputFactory — init error: get input class
+log.fs.hdfs_output_factory_init_error = Failed to get HDFSInput in Hadoop file system. Please check your dependency of Hadoop module.
+log.fs.os_output_factory_init_error = Failed to get OSInput in object storage. Please check your dependency of object storage module.
+
+# HDFSOutputFactory / OSFileOutputFactory — getTsFileOutput error (path arg)
+log.fs.hdfs_output_factory_get_error = Failed to get TsFile output of file: {}. Please check your dependency of Hadoop module.
+log.fs.os_output_factory_get_error = Failed to get TsFile output of file: {}. Please check your dependency of object storage module.
+
+# LocalFSOutputFactory — getTsFileOutput error (path arg)
+log.fs.local_output_factory_get_error = Failed to get TsFile output of file: {},
+
+# HDFSFactory — init error
+log.fs.hdfs_factory_init_error = Failed to get Hadoop file system. Please check your dependency of Hadoop module.
+
+# OSFSFactory — init error
+log.fs.os_factory_init_error = Failed to get object storage. Please check your dependency of object storage module.
+
+# HDFSFactory.getFileWithParent — get file error (path arg)
+log.fs.hdfs_factory_get_file_with_parent_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.getFile(String) — get file error (path arg)
+log.fs.hdfs_factory_get_file_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.getFile(String, String) — get file error (path arg)
+log.fs.hdfs_factory_get_file2_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.getFile(File, String) — get file error (path arg)
+log.fs.hdfs_factory_get_file3_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.getFile(URI) — get file error (uri arg)
+log.fs.hdfs_factory_get_file_uri_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.getBufferedReader — error (path arg)
+log.fs.hdfs_factory_get_reader_error = Failed to get buffered reader for {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.getBufferedWriter — error (path arg)
+log.fs.hdfs_factory_get_writer_error = Failed to get buffered writer for {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.getBufferedInputStream — error (path arg)
+log.fs.hdfs_factory_get_input_stream_error = Failed to get buffered input stream for {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.getBufferedOutputStream — error (path arg)
+log.fs.hdfs_factory_get_output_stream_error = Failed to get buffered output stream for {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.listFilesBySuffix — error (folder, suffix args)
+log.fs.hdfs_factory_list_suffix_error = Failed to list files in {} with SUFFIX {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.listFilesByPrefix — error (folder, prefix args)
+log.fs.hdfs_factory_list_prefix_error = Failed to list files in {} with PREFIX {}. Please check your dependency of Hadoop module.
+
+# OSFSFactory.getFileWithParent — error (path arg)
+log.fs.os_factory_get_file_with_parent_error = Failed to get file: {}. Please check your dependency of object storage module.
+
+# OSFSFactory.getFile(String) — error (path arg)  [note: message says Hadoop module — matching original]
+log.fs.os_factory_get_file_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+
+# OSFSFactory.getFile(String, String) — error (path arg) [matches original]
+log.fs.os_factory_get_file2_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+
+# OSFSFactory.getFile(File, String) — error (path arg) [matches original]
+log.fs.os_factory_get_file3_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+
+# OSFSFactory.getFile(URI) — error (uri arg)
+log.fs.os_factory_get_file_uri_error = Failed to get file: {}. Please check your dependency of object storage module.
+
+# OSFSFactory.getBufferedReader — error (path arg)
+log.fs.os_factory_get_reader_error = Failed to get buffered reader for {}. Please check your dependency of object storage module.
+
+# OSFSFactory.getBufferedWriter — error (path arg)
+log.fs.os_factory_get_writer_error = Failed to get buffered writer for {}. Please check your dependency of object storage module.
+
+# OSFSFactory.getBufferedInputStream — error (path arg)
+log.fs.os_factory_get_input_stream_error = Failed to get buffered input stream for {}. Please check your dependency of object storage module.
+
+# OSFSFactory.getBufferedOutputStream — error (path arg)
+log.fs.os_factory_get_output_stream_error = Failed to get buffered output stream for {}. Please check your dependency of object storage module.
+
+# OSFSFactory.listFilesBySuffix — error (folder, suffix args)
+log.fs.os_factory_list_suffix_error = Failed to list files in {} with SUFFIX {}. Please check your dependency of object storage module.
+
+# OSFSFactory.listFilesByPrefix — error (folder, prefix args)
+log.fs.os_factory_list_prefix_error = Failed to list files in {} with PREFIX {}. Please check your dependency of object storage module.
+
+# OSFSFactory.copyFile — unsupported copy direction (srcType, destType args)
+error.fs.os_factory_copy_unsupported = Doesn't support copy file from %1$s to %2$s.
+
+# LocalFSFactory — buffered reader/writer/stream errors (4 sites, 4 keys)
+log.fs.local_factory_get_reader_error = Failed to get buffered reader for {}.
+log.fs.local_factory_get_writer_error = Failed to get buffered writer for {}.
+log.fs.local_factory_get_input_stream_error = Failed to get buffered input stream for {}.
+log.fs.local_factory_get_output_stream_error = Failed to get buffered output stream for {}.
+
+# HybridFSFactory.moveFile — unsupported cross-type move (srcType, destType args)
+error.fs.hybrid_factory_move_unsupported = Doesn't support move file from %1$s to %2$s.
+
+# HybridFSFactory.copyFile — unsupported cross-type copy (srcType, destType args)
+error.fs.hybrid_factory_copy_unsupported = Doesn't support move file from %1$s to %2$s.
+
+# OSFileInputFactory / HDFSInputFactory — init error
+log.fs.os_input_factory_init_error = Failed to get OSInput in object storage. Please check your dependency of object storage module.
+log.fs.hdfs_input_factory_init_error = Failed to get HDFSInput in Hadoop file system. Please check your dependency of Hadoop module.
+
+# OSFileInputFactory.getTsFileInput — error (path arg)
+error.fs.os_input_factory_get_error = Failed to get TsFile input of file: %1$s. Please check your dependency of object storage module.
+
+# HDFSInputFactory.getTsFileInput — error (path arg)
+error.fs.hdfs_input_factory_get_error = Failed to get TsFile input of file: %1$s. Please check your dependency of Hadoop module.
+
+# FSUtils — load file system class error (fsType name arg)
+log.fs.fsutils_load_class_error = Failed to get {} file system. Please check your dependency of {} module.
+
+# === utils ===
+
+# NoSyncBufferedOutputStream — buffer size <= 0
+error.utils.buffer_size_not_positive = Buffer size <= 0
+
+# NoSyncBufferedInputStream — stream closed (2 sites, 1 key)
+error.utils.stream_closed = Stream closed
+
+# NoSyncBufferedInputStream — buffer size <= 0
+error.utils.buffer_size_not_positive_input = Buffer size <= 0
+
+# NoSyncBufferedInputStream — index out of bounds
+error.utils.index_out_of_bounds_read = Index out of bounds
+
+# NoSyncBufferedInputStream — resetting to invalid mark
+error.utils.reset_invalid_mark = Resetting to invalid mark
+
+# PublicBAOS — index out of bounds
+error.utils.public_baos_index_out_of_bounds = Index out of bounds
+
+# Loader — null input object
+error.utils.loader_null_input = Input object cannot be null
+
+# FilterDeserialize — unsupported operator type (type arg)
+error.utils.filter_unsupported_operator_type = Unsupported operator type:%1$s
+
+# FilterDeserialize — unsupported class serialize id (used for 15 methods via constant; id arg)
+error.utils.filter_unsupported_class_id = Unsupported class serialize id:%1$s
+
+# ReadWriteForEncodingUtils — too many bytes for bit width (paddedByteNum arg; 4 sites, 1 key)
+error.utils.too_long_byte_format = Too long byte number %1$s
+
+# BytesUtils — invalid input: desc.length - offset < 4 (intToBytes float variant)
+error.utils.bytes_desc_offset_too_short = Invalid input: desc.length - offset < 4
+
+# BytesUtils — invalid input: i > 0xFFFF
+error.utils.bytes_int_too_large = Invalid input: %1$s > 0xFFFF
+
+# BytesUtils — invalid input: ret.length != 2
+error.utils.bytes_ret_length_not_two = Invalid input: ret.length != 2
+
+# BytesUtils — row count too large
+error.utils.bytes_row_count_too_large = Row count is larger than Integer.MAX_VALUE
+
+# BytesUtils — invalid input: bytes.length - offset < 4
+error.utils.bytes_offset_too_short_4 = Invalid input: bytes.length - offset < 4
+
+# BytesUtils — invalid input: b.length != 4
+error.utils.bytes_b_length_not_four = Invalid input: b.length != 4
+
+# BytesUtils — invalid input: b.length - offset < 4
+error.utils.bytes_b_offset_too_short_4 = Invalid input: b.length - offset < 4
+
+# BytesUtils — invalid input: bytes.length - offset < 8
+error.utils.bytes_offset_too_short_8 = Invalid input: bytes.length - offset < 8
+
+# BytesUtils — invalid input: b.length != 1
+error.utils.bytes_b_length_not_one = Invalid input: b.length != 1
+
+# BytesUtils — invalid input: b.length - offset < 1
+error.utils.bytes_b_offset_too_short_1 = Invalid input: b.length - offset < 1
+
+# BytesUtils — invalid input: byteNum.length - offset < len
+error.utils.bytes_bytenum_offset_too_short = Invalid input: byteNum.length - offset < len
+
+# BytesUtils.intToBytes — cannot convert int to byte array (3 args: srcNum, pos, width)
+log.utils.bytes_int_to_bytes_error = tsfile-common BytesUtils: cannot convert an integer {} to a byte array, pos {}, width {}
+
+# BytesUtils.longToBytes — cannot convert long to byte array (3 args: srcNum, pos, width)
+log.utils.bytes_long_to_bytes_error = tsfile-common BytesUtils: cannot convert a long {} to a byte array, pos {}, width {}
+
+# TsFileSketchTool — cannot load file (filename arg)
+error.utils.sketch_tool_cannot_load = Cannot load file %1$s because the file has crashed.
+
+# ReadWriteIOUtils — short read (expectedLen, readLen args; 7 sites use String.format directly)
+error.utils.rwio_short_read = Intend to read %1$d bytes but %2$d are actually returned
+
+# ReadWriteIOUtils — string list must not be null (2 sites, 1 key)
+error.utils.rwio_stringlist_null = stringList must not be null!
+
+# ReadWriteIOUtils — set must not be null (2 sites via SET_NOT_NULL_MSG constant)
+error.utils.rwio_set_null = set must not be null!
+
+# StringContainer — index out of bounds (getSubString; 1 site)
+error.utils.string_container_index_out_of_bounds = Index: %1$d, Real Index: %2$d, Size: %3$d
+
+# StringContainer — start index out of bounds (getSubStringContainer)
+error.utils.string_container_start_index_out_of_bounds = start Index: %1$d, Real start Index: %2$d, Size: %3$d
+
+# StringContainer — end index out of bounds (getSubStringContainer)
+error.utils.string_container_end_index_out_of_bounds = end Index: %1$d, Real end Index: %2$d, Size: %3$d
+
+# TimeDuration — unsupported operation
+error.utils.time_duration_unsupported = unsupported operation
+
+# DateUtils — date expression null or empty (2 sites, 1 key)
+error.utils.date_expression_null_or_empty = Date expression is null or empty.
+
+# DateUtils — invalid date format (parse exception)
+error.utils.date_invalid_format = Invalid date format. Please use YYYY-MM-DD format.
+
+# DateUtils — year out of range (dateExpression arg)
+error.utils.date_year_out_of_range = Year must be between 1000 and 9999.
+
+# DateUtils — invalid date format (parseIntToLocalDate)
+error.utils.date_invalid_format_local = Invalid date format.
+
+# TsFileGeneratorUtils — invalid input (value arg)
+error.utils.generator_invalid_input = Invalid input: %1$s
+
+# FSUtils — failed to get file system (fsType name arg — used with string concat in original)
+log.fs.fsutils_class_not_found = Failed to get {} file system. Please check your dependency of {} module.

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
@@ -872,3 +872,200 @@ log.file.device_id_serialize_failed = Failed to serialize device ID: {}
 
 # Statistics — statistics classes mismatched, no merge
 log.file.stats_classes_mismatched = Statistics classes mismatched,no merge: {} v.s. {}
+
+# === external ===
+
+# ArrayUtils.remove — index out of bounds
+error.external.array_index_out_of_bounds = Index: %1$s, Length: %2$s
+
+# ArrayUtils.addAll — incompatible array types
+error.external.array_incompatible_types = Cannot store %1$s in an array of %2$s
+
+# Validate.isTrue() — default false expression
+error.external.validate_expression_false = The validated expression is false
+
+# Validate.isTrue(boolean, String, long) — formatted message with long value
+# (caller passes String.format'd message; key used as wrapper for the pattern arg itself)
+error.external.validate_size_too_large = Request %1$,d exceeds maximum %2$,d
+
+# IOUtils.toByteArray — cannot read more than max bytes
+error.external.io_cannot_read_max_bytes = Cannot read more than %1$,d into a byte array
+
+# IOUtils.toByteArray — size must be non-negative
+error.external.io_size_non_negative = Size must be equal or greater than zero: %1$s
+
+# IOUtils.toByteArray — unexpected read size
+error.external.io_unexpected_read_size = Unexpected read size, current: %1$s, expected: %2$s
+
+# IOUtils.toString — null input stream supplier
+error.external.io_null_input = input
+
+# FileUtils.requireDirectoryExists — not a directory
+error.external.file_not_a_directory = Parameter '%1$s' is not a directory: '%2$s'
+
+# FileUtils.requireDirectoryExists — directory does not exist
+error.external.file_directory_not_exist = Directory '%1$s' does not exist.
+
+# FileUtils.listFiles — I/O error listing directory
+error.external.file_list_io_error = Unknown I/O error listing contents of directory: %1$s
+
+# FileUtils.forceDelete — cannot delete file
+error.external.file_cannot_delete = Cannot delete file: %1$s
+
+# FileUtils.forceDelete — file does not exist
+error.external.file_not_exist = File does not exist: %1$s
+
+# FileUtils.moveFile — failed to delete original after copy
+error.external.file_move_delete_original = Failed to delete original file '%1$s' after copy to '%2$s'
+
+# FileUtils.checkFileExists — not a file
+error.external.file_param_not_a_file = Parameter '%1$s' is not a file: %2$s
+
+# FileUtils.checkFileExists — source does not exist
+error.external.file_source_not_exist = Source '%1$s' does not exist
+
+# FileUtils.requireAbsent — file already exists
+error.external.file_already_exists = File element in parameter '%1$s' already exists: '%2$s'
+
+# FileUtils.copyFile — cannot set file time
+error.external.file_cannot_set_time = Cannot set the file time.
+
+# FileUtils.requireCanonicalPathsNotEquals — canonical paths equal
+error.external.file_canonical_paths_equal = File canonical paths are equal: '%1$s' (file1='%2$s', file2='%3$s')
+
+# FileUtils.mkdirs — cannot create directory
+error.external.file_cannot_create_directory = Cannot create directory '%1$s'.
+
+# FileUtils.validateMoveParameters — source does not exist (same key as checkFileExists for source)
+# (reuses error.external.file_source_not_exist)
+
+# FileUtils.requireExistsChecked — file system element does not exist
+error.external.file_element_not_exist = File system element for parameter '%1$s' does not exist: '%2$s'
+
+# FileUtils.requireDirectory — not a directory (same pattern as requireDirectoryExists)
+# (reuses error.external.file_not_a_directory)
+
+# FileUtils.moveDirectory — cannot move to subdirectory of itself
+error.external.file_move_to_subdirectory = Cannot move directory: %1$s to a subdirectory of itself: %2$s
+
+# FileUtils.moveDirectory — failed to delete original directory after copy
+error.external.file_move_delete_directory = Failed to delete original directory '%1$s' after copy to '%2$s'
+
+# FileUtils.requireCanWrite — file is not writable
+error.external.file_not_writable = File parameter '%1$s is not writable: '%2$s'
+
+# FilenameUtils.requireNonNullChars — null character in path
+error.external.filename_null_char = Null character present in file/path name. There are no known legitimate use cases for such data, but several injection attacks may use it
+
+# FilenameUtils.indexOfExtension — NTFS ADS separator in file name
+error.external.filename_ntfs_ads_forbidden = NTFS ADS separator (':') in file name is forbidden.
+
+# FilenameUtils.flipSeparator — invalid separator character
+error.external.filename_invalid_separator = %1$s
+
+# PathUtils.setReadOnly — DOS or POSIX not available
+error.external.path_file_ops_not_available = DOS or POSIX file operations not available for '%1$s', linkOptions %2$s
+
+# PathUtils.deleteFile — is a directory, not a file
+error.external.path_is_directory = %1$s
+
+# PathUtils.deleteFile — I/O error
+error.external.path_set_readonly_io_error = DOS or POSIX file operations not available for '%1$s', linkOptions %2$s
+
+# ReaderInputStream.checkMinBufferSize — buffer too small
+error.external.reader_input_stream_buffer_too_small = Buffer size %1$,d must be at least %2$s for a CharsetEncoder %3$s.
+
+# ReaderInputStream.read — index out of bounds
+error.external.reader_input_stream_index_out_of_bounds = Array size=%1$s, offset=%2$s, length=%3$s
+
+# UnsynchronizedByteArrayInputStream — length cannot be negative
+error.external.ubais_length_negative = length cannot be negative
+
+# UnsynchronizedByteArrayInputStream — offset cannot be negative
+error.external.ubais_offset_negative = offset cannot be negative
+
+# UnsynchronizedByteArrayInputStream.skip — skipping backward not supported
+error.external.ubais_skip_backward = Skipping backward is not supported
+
+# UnsynchronizedByteArrayOutputStream — negative initial size
+error.external.ubaos_negative_initial_size = Negative initial size: %1$s
+
+# UnsynchronizedByteArrayOutputStream.write — offset/length out of bounds
+error.external.ubaos_offset_length_out_of_bounds = offset=%1$,d, length=%2$,d
+
+# ByteArrayOutputStream — negative initial size (same as UBAOS)
+# (reuses error.external.ubaos_negative_initial_size)
+
+# WriterOutputStream — UTF-16 IBM JDK broken support
+error.external.writer_output_stream_utf16_ibm = UTF-16 requested when running on an IBM JDK with broken UTF-16 support. Please find a JDK that supports UTF-16 if you intend to use UF-16 with WriterOutputStream
+
+# WriterOutputStream.processInput — unexpected coder result
+error.external.writer_output_stream_unexpected_coder = Unexpected coder result
+
+# AbstractOrigin.getFile — not supported
+error.external.abstract_origin_get_file = %1$s#getFile() for %2$s origin %3$s
+
+# AbstractOrigin.getPath — not supported
+error.external.abstract_origin_get_path = %1$s#getPath() for %2$s origin %3$s
+
+# AbstractStreamBuilder.throwIae — request exceeds maximum
+error.external.stream_builder_request_exceeds_max = Request %1$,d exceeds maximum %2$,d
+
+# AbstractOriginSupplier.checkOrigin — origin is null
+error.external.origin_null = origin == null
+
+# AbstractEmptyMapIterator — iterator contains no elements (3 operations: setValue, getKey, getValue)
+error.external.empty_map_iterator_no_elements = Iterator contains no elements
+
+# AbstractEmptyIterator — iterator contains no elements (3 operations: remove, next, previous)
+error.external.empty_iterator_no_elements = Iterator contains no elements
+
+# AbstractLinkedMap — map is empty (first/last)
+error.external.linked_map_empty = Map is empty
+
+# AbstractLinkedMap — index less than zero
+error.external.linked_map_index_negative = Index %1$s is less than zero
+
+# AbstractLinkedMap — index invalid for size
+error.external.linked_map_index_invalid = Index %1$s is invalid for size %2$s
+
+# AbstractHashedMap — initial capacity negative
+error.external.hashed_map_capacity_negative = Initial capacity must be a non negative number
+
+# AbstractHashedMap — load factor not positive
+error.external.hashed_map_load_factor_invalid = Load factor must be greater than 0
+
+# AbstractHashedMap constants — iterator state errors (6 constants → 6 keys)
+error.external.map_no_next_entry = No next() entry in the iteration
+error.external.map_no_previous_entry = No previous() entry in the iteration
+error.external.map_remove_invalid = remove() can only be called once after next()
+error.external.map_getkey_invalid = getKey() can only be called after next() and before remove()
+error.external.map_getvalue_invalid = getValue() can only be called after next() and before remove()
+error.external.map_setvalue_invalid = setValue() can only be called after next() and before remove()
+
+# LRUMap — max size constraint
+error.external.lrumap_max_size_positive = LRUMap max size must be greater than 0
+
+# LRUMap — initial size vs max size constraint (note: typo "greather" preserved for behaviour parity)
+error.external.lrumap_initial_exceeds_max = LRUMap initial size must not be greather than max size
+
+# LRUMap.moveToMRU — entry.before is null
+error.external.lrumap_entry_before_null = Entry.before is null. This should not occur if your keys are immutable, and you have used synchronization properly.
+
+# LRUMap.moveToMRU — cannot move header to MRU
+error.external.lrumap_cannot_move_header = Can't move header to MRU This should not occur if your keys are immutable, and you have used synchronization properly.
+
+# LRUMap.addMapping — entry.after is null (scanUntilRemovable path)
+error.external.lrumap_entry_after_null = Entry.after=null, header.after=%1$s header.before=%2$s key=%3$s value=%4$s size=%5$s maxSize=%6$s This should not occur if your keys are immutable, and you have used synchronization properly.
+
+# LRUMap.addMapping — reuse is null
+error.external.lrumap_reuse_null = reuse=null, header.after=%1$s header.before=%2$s key=%3$s value=%4$s size=%5$s maxSize=%6$s This should not occur if your keys are immutable, and you have used synchronization properly.
+
+# LRUMap.reuseMapping — loop is null (entry not found)
+error.external.lrumap_loop_null = Entry.next=null, data[removeIndex]=%1$s previous=%2$s key=%3$s value=%4$s size=%5$s maxSize=%6$s This should not occur if your keys are immutable, and you have used synchronization properly.
+
+# LRUMap.reuseMapping — NullPointerException
+error.external.lrumap_npe = NPE, entry=%1$s entryIsHeader=%2$s key=%3$s value=%4$s size=%5$s maxSize=%6$s This should not occur if your keys are immutable, and you have used synchronization properly.
+
+# ComparatorChain.checkChainIntegrity — must contain at least one comparator
+error.external.comparator_chain_empty = ComparatorChains must contain at least one Comparator

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
@@ -817,3 +817,58 @@ log.encoding.float_decoder_init_int_delta = tsfile-encoding FloatDecoder: init d
 log.encoding.float_decoder_init_long_delta = tsfile-encoding FloatDecoder: init decoder using long-delta and double
 log.encoding.float_decoder_init_int_rlbe = tsfile-encoding FloatDecoder: init decoder using int-rlbe and float
 log.encoding.float_decoder_init_long_rlbe = tsfile-encoding FloatDecoder: init decoder using long-rlbe and double
+
+# === file ===
+
+# MetaMarker — unexpected marker byte
+error.file.unexpected_marker = Unexpected marker %1$s
+
+# AbstractAlignedChunkMetadata — unsupported getNewType/setNewType (2 sites, 1 key)
+error.file.aligned_chunk_metadata_new_type_unsupported = AlignedChunkMetadata doesn't support setNewType method
+
+# AbstractAlignedChunkMetadata — serializeTo not supported
+error.file.aligned_chunk_metadata_serialize_unsupported = VectorChunkMetadata doesn't support serial method
+
+# MetadataIndexConstructor — utility class guard
+error.file.utility_class = Utility class
+
+# TsFileMetadata — encryptType missing for encryptLevel 1 or 2 (2 sites, 1 key with level arg)
+error.file.tsfile_metadata_no_encrypt_type = TsfileMetadata lack of encryptType while encryptLevel is %1$s
+
+# TsFileMetadata — encryptKey missing for encryptLevel 1 or 2 (2 sites, 1 key with level arg)
+error.file.tsfile_metadata_no_encrypt_key = TsfileMetadata lack of encryptKey while encryptLevel is %1$s
+
+# TsFileMetadata — encryptKey null/empty for encryptLevel 1 or 2 (2 sites, 1 key with level arg)
+error.file.tsfile_metadata_null_encrypt_key = TsfileMetadata null encryptKey while encryptLevel is %1$s
+
+# TsFileMetadata — unsupported encryptLevel
+error.file.tsfile_metadata_unsupported_encrypt_level = Unsupported encryptLevel: %1$s
+
+# TableSchema — duplicate column name (4 sites, 1 key)
+error.file.table_schema_duplicate_column = Each column name in the table should be unique(case insensitive).
+
+# ColumnSchemaBuilder — name must be non-empty
+error.file.column_schema_builder_name_empty = Column name must be a non empty string
+
+# ColumnSchemaBuilder — name must be set before building
+error.file.column_schema_builder_name_not_set = Column name must be set before building
+
+# ColumnSchemaBuilder — data type must be set before building
+error.file.column_schema_builder_type_not_set = Column data type must be set before building
+
+# StringArrayDeviceID — all segments are null
+error.file.device_id_all_segments_null = All segments are null
+
+# Statistics — unsupported stat operation (many sites across subclasses; args: type name, op name)
+error.file.stats_unsupported = %1$s statistics does not support: %2$s
+
+# --- file LOG messages ---
+
+# IDeviceID — using default inefficient serialized size implementation
+log.file.device_id_default_serialized_size = Using default inefficient implementation of serialized size by {}
+
+# IDeviceID — failed to serialize device ID
+log.file.device_id_serialize_failed = Failed to serialize device ID: {}
+
+# Statistics — statistics classes mismatched, no merge
+log.file.stats_classes_mismatched = Statistics classes mismatched,no merge: {} v.s. {}

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
@@ -1361,3 +1361,190 @@ error.utils.generator_invalid_input = Invalid input: %1$s
 
 # FSUtils — failed to get file system (fsType name arg — used with string concat in original)
 log.fs.fsutils_class_not_found = Failed to get {} file system. Please check your dependency of {} module.
+
+# === tools ===
+
+# ArrowSourceReader / ParquetSourceReader / CsvSourceReader — inferSchema called in schema mode
+error.tools.infer_schema_not_in_auto_mode = inferSchema() is only available in auto mode
+
+# CsvSourceReader.inferSchema — inferSchema called in schema mode (more descriptive variant)
+error.tools.infer_schema_not_in_auto_mode_csv = inferSchema() is only available in auto mode (no schema provided)
+
+# ArrowSourceReader / ParquetSourceReader / CsvSourceReader — failed to infer schema
+error.tools.infer_schema_failed = Failed to infer schema from: %1$s
+
+# CsvSourceReader.inferSchema — CSV file is empty
+error.tools.csv_file_empty = CSV file is empty: %1$s
+
+# CsvSourceReader.validateColumnCount — column count mismatch
+error.tools.csv_column_count_mismatch = Column count mismatch: schema defines %1$s columns but CSV header has %2$s columns in %3$s
+
+# TimeConverter — time value cannot be null (2 sites, 1 key)
+error.tools.time_value_null = Time value cannot be null
+
+# TimeConverter.toNanos / fromNanos — unknown precision (2 sites, 1 key)
+error.tools.unknown_precision = Unknown precision: %1$s
+
+# TsFileTool.parseBlockSize — unsupported block_size unit
+error.tools.block_size_unsupported_unit = block_size only supports units of K, M, G, or numbers
+
+# SchemaParser.parseIdColumns — invalid id_columns format
+error.tools.schema_id_columns_invalid = The data format of id_columns is incorrect
+
+# SchemaParser.parseCsvColumns — invalid csv_columns format
+error.tools.schema_csv_columns_invalid = The data format of csv_columns is incorrect
+
+# SchemaParser — has_header not true/false
+error.tools.schema_has_header_invalid = The data format of has_header is incorrect
+
+# SchemaParser.validateParams — time_precision not supported
+error.tools.schema_time_precision_unsupported = The time_precision parameter only supports ms,us,ns
+
+# SchemaParser.validateParams — separator invalid
+error.tools.schema_separator_invalid = separator must be ",", tab, or ";"
+
+# SchemaParser.validateParams — table_name required
+error.tools.schema_table_name_required = table_name is required
+
+# SchemaParser.validateParams — id_columns required
+error.tools.schema_id_columns_required = id_columns is required
+
+# SchemaParser.validateParams — csv_columns required
+error.tools.schema_csv_columns_required = csv_columns is required
+
+# SchemaParser.validateParams — time_column required
+error.tools.schema_time_column_required = time_column is required
+
+# SchemaParser.validateParams — time_column value not in csv_columns
+error.tools.schema_time_column_not_in_csv = The value %1$s of time_column is not in csv_columns
+
+# SchemaParser.validateParams — id_columns value not in csv_columns
+error.tools.schema_id_column_not_in_csv = The value %1$s of id_columns is not in csv_columns
+
+# ImportSchemaParser — has_header not true/false
+error.tools.import_has_header_invalid = has_header must be true or false
+
+# ImportSchemaParser.parseTagColumn — invalid tag_columns format
+error.tools.import_tag_columns_invalid = Invalid tag_columns format: %1$s
+
+# ImportSchemaParser.parseSourceColumn — invalid source_columns format
+error.tools.import_source_columns_invalid = Invalid source_columns format: %1$s
+
+# ImportSchemaParser.resolveDataType — unknown data type
+error.tools.import_unknown_data_type = Unknown data type: %1$s
+
+# ImportSchemaParser.validate — time_precision not supported
+error.tools.import_time_precision_unsupported = time_precision must be ms, us, ns, or s
+
+# ImportSchemaParser.validate — separator invalid
+error.tools.import_separator_invalid = separator must be ",", tab, or ";"
+
+# ImportSchemaParser.validate — table_name required
+error.tools.import_table_name_required = table_name is required
+
+# ImportSchemaParser.validate — time_column required
+error.tools.import_time_column_required = time_column is required
+
+# ImportSchemaParser.validate — source_columns required
+error.tools.import_source_columns_required = source_columns is required
+
+# ImportSchemaParser.validate — time_column not found in source_columns
+error.tools.import_time_column_not_found = time_column '%1$s' not found in source_columns
+
+# ImportSchemaParser.validate — tag_columns entry not found in source_columns
+error.tools.import_tag_column_not_found = tag_columns '%1$s' not found in source_columns
+
+# AutoSchemaInferer.detectTimeColumn — no time column found
+error.tools.auto_no_time_column = No time column found. Auto mode requires exactly one column named 'time' or 'TIME'.
+
+# AutoSchemaInferer.detectTimeColumn — ambiguous time column
+error.tools.auto_ambiguous_time_column = Ambiguous time column: found multiple columns matching 'time'/'TIME': %1$s
+
+# TabletBuilder.resolveTimeColumnIndex — time column not found in source columns
+error.tools.tablet_time_column_not_found = Time column '%1$s' not found in source columns
+
+# DateTimeUtils.convertDatetimeStrToLong — failed to convert timestamp (depth >= 2)
+error.tools.datetime_convert_failed = Failed to convert %1$s to millisecond, zone offset is %2$s, please input like 2011-12-03T10:15:30 or 2011-12-03T10:15:30+01:00
+
+# DateTimeUtils.convertDatetimeStrToLong — time-region not supported
+error.tools.datetime_time_region_unsupported = %1$s with [time-region] at end is not supported now, please input like 2011-12-03T10:15:30 or 2011-12-03T10:15:30+01:00
+
+# --- tools LOG messages ---
+
+# ImportExecutor — failed to create output directory
+log.tools.executor_create_dir_failed = Failed to create output directory: %1$s
+
+# ImportExecutor — failed to write chunk
+log.tools.executor_write_chunk_failed = Failed to write chunk %1$s to %2$s
+
+# ImportExecutor — no data read from source
+log.tools.executor_no_data = No data read from source: %1$s
+
+# ImportExecutor — failed to rename indexed file to single name
+log.tools.executor_rename_failed = Failed to rename %1$s to %2$s
+
+# ImportExecutor.writeTsFile — failed to write file
+log.tools.executor_write_file_failed = Failed to write file: %1$s
+
+# ImportExecutor.writeTsFile — failed to close file
+log.tools.executor_close_file_failed = Failed to close file: %1$s
+
+# ImportExecutor.deleteFile — failed to delete file
+log.tools.executor_delete_failed = Failed to delete: %1$s
+
+# TsFileTool — failed to parse schema file
+log.tools.tool_parse_schema_failed = Failed to parse schema file: %1$s
+
+# TsFileTool — failed to await termination
+log.tools.tool_await_termination_failed = Failed to await termination
+
+# TsFileTool — directory or file has completed execution
+log.tools.tool_execution_completed = The %1$s directory or file has completed execution
+
+# TsFileTool — failed to process file
+log.tools.tool_process_file_failed = Failed to process file: %1$s
+
+# TsFileTool — file successfully generated
+log.tools.tool_file_generated = %1$s.tsfile successfully generated
+
+# TsFileTool — failed to copy file
+log.tools.tool_copy_file_failed = Failed to copy file: %1$s
+
+# TsFileTool — error parsing command line options
+log.tools.tool_parse_cli_error = Error parsing command line options
+
+# TsFileTool.validateParams — source is required
+log.tools.tool_source_required = Missing required parameters. --source/-s is required
+
+# TsFileTool.validateParams — target is required
+log.tools.tool_target_required = Missing required parameters. --target/-t is required
+
+# TsFileTool.validateParams — source does not exist
+log.tools.tool_source_not_exist = %1$s directory or file does not exist.
+
+# TsFileTool.validateParams — schema file does not exist
+log.tools.tool_schema_not_exist = %1$s schema file does not exist.
+
+# TsFileTool.validateParams — invalid thread number
+log.tools.tool_invalid_thread_num = Invalid thread number. Thread number must be greater than 0.
+
+# ArrowSourceReader — error reading Arrow file
+log.tools.arrow_read_error = Error reading Arrow file: %1$s
+
+# ArrowSourceReader — error closing Arrow reader
+log.tools.arrow_close_reader_error = Error closing Arrow reader
+
+# ArrowSourceReader — error closing FileInputStream
+log.tools.arrow_close_stream_error = Error closing FileInputStream
+
+# ParquetSourceReader — error reading Parquet file
+log.tools.parquet_read_error = Error reading Parquet file: %1$s
+
+# ParquetSourceReader — error closing Parquet reader
+log.tools.parquet_close_reader_error = Error closing Parquet reader
+
+# CsvSourceReader — error reading CSV file
+log.tools.csv_read_error = Error reading CSV file: %1$s
+
+# CsvSourceReader — error closing CSV reader
+log.tools.csv_close_reader_error = Error closing CSV reader

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
@@ -645,3 +645,175 @@ log.read.device_meta_iterator_error = Failed to load device meta data
 
 # DeviceTableModelReader — close file reader exception
 log.read.v4_close_reader_error = Meet exception when close file reader:
+
+# === encoding ===
+
+# --- encoder error messages ---
+
+# Encoder — method not supported (8 sites, 1 key per type; parameterized on method name and class)
+error.encoding.encoder_method_not_supported = Method encode %1$s is not supported by Encoder
+
+# FloatEncoder / FloatDecoder — data type not supported (3+3 sites; same English text)
+error.encoding.float_encoder_unsupported_type = data type %1$s is not supported by FloatEncoder
+
+# FloatDecoder — encoding not supported
+error.encoding.float_decoder_unsupported_encoding = %1$s encoding is not supported by FloatDecoder
+
+# FloatEncoder — encoding not supported
+error.encoding.float_encoder_unsupported_encoding = %1$s encoding is not supported by FloatEncoder
+
+# PlainEncoder — BigDecimal not supported
+error.encoding.plain_encoder_bigdecimal_unsupported = tsfile-encoding PlainEncoder: current version does not support BigDecimal value encoding
+
+# RleEncoder/RleDecoder — getClass().getName() sites (8 RleEncoder throws; skip — data-only)
+
+# RleDecoder — method not supported (8 sites, 1 key; note typo "supproted" preserved for backward compat)
+error.encoding.rle_decoder_method_not_supported = Method %1$s is not supproted by RleDecoder
+
+# RleDecoder — unknown encoding mode
+error.encoding.rle_decoder_unknown_mode = tsfile-encoding IntRleDecoder: unknown encoding mode %1$s
+
+# RleDecoder — bitPackedGroupCount < 1
+error.encoding.rle_decoder_bit_packed_group_count = tsfile-encoding IntRleDecoder: bitPackedGroupCount %1$d, smaller than 1
+
+# IntRleDecoder / LongRleDecoder — not a valid mode
+error.encoding.rle_decoder_invalid_mode_int = tsfile-encoding IntRleDecoder: not a valid mode %1$s
+error.encoding.rle_decoder_invalid_mode_long = tsfile-encoding LongRleDecoder: not a valid mode %1$s
+
+# BitmapDecoder — method not supported (7 sites, 1 key)
+error.encoding.bitmap_decoder_method_not_supported = Method %1$s is not supported by BitmapDecoder
+
+# FloatDecoder — method not supported (5 sites, 1 key)
+error.encoding.float_decoder_method_not_supported = Method %1$s is not supported by FloatDecoder
+
+# PlainDecoder — BigDecimal not supported
+error.encoding.plain_decoder_bigdecimal_unsupported = Method readBigDecimal is not supported by PlainDecoder
+
+# Decoder — method not supported (8 sites, 1 key)
+error.encoding.decoder_method_not_supported = Method %1$s is not supported by Decoder
+
+# Decoder.getDecoderByType — encoding+type combination not found (many sites, 1 key using ERROR_MSG)
+error.encoding.decoder_not_found = Decoder not found: %1$s , DataType is : %2$s
+
+# GorillaDecoderV1 — reading from empty buffer
+error.encoding.gorilla_empty_buffer = Reading from empty buffer
+
+# CamelDecoder — no more data
+error.encoding.camel_no_more_data = No more data to decode
+
+# CamelDecoder — unexpected empty block
+error.encoding.camel_unexpected_empty_block = Unexpected empty block
+
+# FloatSprintzDecoder / IntSprintzDecoder / DoubleSprintzDecoder / LongSprintzDecoder — unsupported predictive method (4 sites, 1 key)
+error.encoding.sprintz_unsupported_predict_method = Sprintz predictive method {} is not supported.
+
+# FloatSprintzEncoder / IntSprintzEncoder / DoubleSprintzEncoder / LongSprintzEncoder — unsupported predictive method (4 sites, 1 key)
+error.encoding.sprintz_encoder_unsupported_predict_method = Config: Predict Method {} of SprintzEncoder is not supported.
+
+# TSEncodingBuilder — unsupported encoding type
+error.encoding.ts_encoding_builder_unsupported = Unsupported encoding: %1$s
+
+# TSEncodingBuilder — data type not supported (many sites using ERROR_MSG pattern, 1 key)
+error.encoding.ts_encoding_builder_unsupported_type = %1$s doesn't support data type: %2$s
+
+# --- encoder LOG messages ---
+
+# DeltaBinaryEncoder / RegularDataEncoder — flush data to stream failed (2 sites, 1 key)
+log.encoding.flush_data_failed = flush data to stream failed!
+
+# DoubleSprintzEncoder — encoding error
+log.encoding.sprintz_double_encode_error = Error occured when encoding INT32 Type value with with Sprintz
+
+# FloatSprintzEncoder — encoding error
+log.encoding.sprintz_float_encode_error = Error occured when encoding Float Type value with with Sprintz
+
+# IntSprintzEncoder — encoding error
+log.encoding.sprintz_int_encode_error = Error occured when encoding INT32 Type value with with Sprintz
+
+# LongSprintzEncoder — encoding error
+log.encoding.sprintz_long_encode_error = Error occured when encoding INT64 Type value with with Sprintz
+
+# DictionaryEncoder — flush error
+log.encoding.dictionary_encoder_flush_error = tsfile-encoding DictionaryEncoder: error occurs when flushing
+
+# PlainEncoder — encode Binary error
+log.encoding.plain_encoder_binary_error = tsfile-encoding PlainEncoder: error occurs when encode Binary value {}
+
+# RleEncoder — flush rle run error (context-carrying message)
+log.encoding.rle_flush_rle_run_error = tsfile-encoding RleEncoder : error occurs when writing nums to OutputStram when flushing left nums. numBufferedValues {}, repeatCount {}, bitPackedGroupCount{}, isBitPackRun {}, isBitWidthSaved {}
+
+# RleEncoder — write full rle run debug
+log.encoding.rle_write_full_rle_run = tsfile-encoding RleEncoder : write full rle run to stream
+
+# RleEncoder — writing full rle run error
+log.encoding.rle_full_rle_run_error =  error occurs when writing full rle run to OutputStram when repeatCount = {}.numBufferedValues {}, repeatCount {}, bitPackedGroupCount{}, isBitPackRun {}, isBitWidthSaved {}
+
+# RleEncoder — writing num error when repeatCount > min
+log.encoding.rle_write_num_error = tsfile-encoding RleEncoder : error occurs when writing num to OutputStram when repeatCount > {}.numBufferedValues {}, repeatCount {}, bitPackedGroupCount{}, isBitPackRun {}, isBitWidthSaved {}
+
+# --- decoder LOG messages ---
+
+# SinglePrecisionDecoderV1 — cannot read first float
+log.encoding.single_precision_v1_first_float_error = SinglePrecisionDecoderV1 cannot read first float number
+
+# SinglePrecisionDecoderV1 — cannot read following float
+log.encoding.single_precision_v1_following_float_error = SinglePrecisionDecoderV1 cannot read following float number
+
+# DoublePrecisionDecoderV1 — cannot read first double
+log.encoding.double_precision_v1_first_double_error = DoublePrecisionDecoderV1 cannot read first double number
+
+# DoublePrecisionDecoderV1 — cannot read following double
+log.encoding.double_precision_v1_following_double_error = DoublePrecisionDecoderV1 cannot read following double number
+
+# GorillaDecoderV1 — fill buffer failed
+log.encoding.gorilla_fill_buffer_failed = Failed to fill a new buffer, because there is no byte to read
+
+# IntRleDecoder — reading error
+log.encoding.int_rle_decoder_read_error = tsfile-encoding IntRleDecoder: error occurs when reading all encoding number, length is {}, bit width is {}
+
+# LongRleDecoder — reading error (same text but different logger)
+log.encoding.long_rle_decoder_read_error = tsfile-encoding IntRleDecoder: error occurs when reading all encoding number, length is {}, bit width is {}
+
+# DictionaryDecoder — decoding error
+log.encoding.dictionary_decoder_error = tsfile-decoding DictionaryDecoder: error occurs when decoding
+
+# FloatSprintzDecoder / IntSprintzDecoder / DoubleSprintzDecoder / LongSprintzDecoder — readInt error (4 sites, 1 key)
+log.encoding.sprintz_decoder_read_error = Error occured when readInt with Sprintz Decoder.
+
+# TSEncodingBuilder — max string length negative value warning
+log.encoding.ts_encoding_max_string_length_negative = cannot set max string length to negative value, replaced with default value:{}
+
+# TSEncodingBuilder — max point number bad format warning
+log.encoding.ts_encoding_max_point_number_format = The format of max point number {} is not correct. Using default float precision.
+
+# TSEncodingBuilder — max point number negative value warning
+log.encoding.ts_encoding_max_point_number_negative = cannot set max point number to negative value, replaced with default value:{}
+
+# IntZigzagEncoder — constructor debug
+log.encoding.int_zigzag_encoder_init = tsfile-encoding IntZigzagEncoder: int zigzag encoder
+
+# LongZigzagEncoder — constructor debug
+log.encoding.long_zigzag_encoder_init = tsfile-encoding LongZigzagEncoder: long zigzag encoder
+
+# BitmapEncoder — constructor debug
+log.encoding.bitmap_encoder_init = tsfile-encoding BitmapEncoder: init bitmap encoder
+
+# IntZigzagDecoder — constructor debug
+log.encoding.int_zigzag_decoder_init = tsfile-decoding IntZigzagDecoder: int zigzag decoder
+
+# LongZigzagDecoder — constructor debug
+log.encoding.long_zigzag_decoder_init = tsfile-encoding LongZigzagDecoder: long zigzag decoder
+
+# BitmapDecoder — constructor debug
+log.encoding.bitmap_decoder_init = tsfile-encoding BitmapDecoder: init bitmap decoder
+
+# BitmapDecoder — page data debug (2 args: number, byteArrayLength)
+log.encoding.bitmap_decoder_page_data = tsfile-encoding BitmapDecoder: number {} in current page, byte length {}
+
+# FloatDecoder — init decoder debug (6 keys for 6 branches)
+log.encoding.float_decoder_init_int_rle = tsfile-encoding FloatDecoder: init decoder using int-rle and float
+log.encoding.float_decoder_init_long_rle = tsfile-encoding FloatDecoder: init decoder using long-rle and double
+log.encoding.float_decoder_init_int_delta = tsfile-encoding FloatDecoder: init decoder using int-delta and float
+log.encoding.float_decoder_init_long_delta = tsfile-encoding FloatDecoder: init decoder using long-delta and double
+log.encoding.float_decoder_init_int_rlbe = tsfile-encoding FloatDecoder: init decoder using int-rlbe and float
+log.encoding.float_decoder_init_long_rlbe = tsfile-encoding FloatDecoder: init decoder using long-rlbe and double

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Seed entry used by MessagesTest. Real entries are added by migration tasks.
+test.seed = hello %1$s

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
@@ -57,3 +57,198 @@ error.common.bitmap_out_of_dest_range = %1$s is out of dest range %2$s
 
 # TSDataType
 error.common.unsupported_cast = Unsupported cast: from %1$s to %2$s
+
+# === write ===
+
+# DataPoint — set<Type> not supported (7 sites collapsed to 1 key; arg = type name)
+error.write.datapoint_set_not_supported = set %1$s not support in DataPoint
+
+# DataPoint / Tablet / AlignedChunkGroupWriterImpl / NonAlignedChunkGroupWriterImpl / TableTsBlock2TsFileWriter
+# — "Data type X is not supported." (many sites collapsed to 1 key)
+error.write.type_not_supported = Data type %1$s is not supported.
+
+# DataPoint — type/value mismatch in getDataPoint
+error.write.datapoint_type_value_mismatch = Data type of %1$s is %2$s, but input value is %3$s
+
+# Tablet.addValue(rowIndex, indexOfSchema, Object) — wrong Java type for column type (7 sites collapsed to 1 key)
+error.write.tablet_expected_type = Expected value of type %1$s for data type %2$s, but got %3$s
+
+# Tablet.addValue(rowIndex, columnIndex, primitiveVal) — wrong array type (7 sites collapsed to 1 key)
+error.write.tablet_col_wrong_type = The data type of column index %1$s is not %2$s
+
+# Tablet — null measurement argument
+error.write.tablet_null_measurement = measurement should be non null value
+
+# Tablet — measurement not found
+error.write.tablet_no_measurement = No measurement for %1$s
+
+# Tablet.getValue — unsupported data type
+error.write.tablet_unsupported_type = Unsupported type: %1$s
+
+# Tablet.readvaluesFromBuffer — unsupported type at client
+error.write.tablet_client_type_not_supported = data type %1$s is not supported when convert data at client
+
+# VectorMeasurementSchema — getCompressor deprecated method
+error.write.schema_vector_aligned_no_compressor = Aligned series should not invoke this method
+
+# VectorMeasurementSchema — unsupported method (4 sites collapsed to 1 key)
+error.write.schema_vector_method_unsupported = unsupported method for VectorMeasurementSchema
+
+# VectorMeasurementSchema — unexpected end of stream
+error.write.schema_vector_unexpected_end_of_stream = Unexpected end of stream when reading compressors
+
+# MeasurementSchema — unsupported method (4 sites collapsed to 1 key)
+error.write.schema_measurement_method_unsupported = unsupported method for MeasurementSchema
+
+# MeasurementSchemaBuilder — validation errors
+error.write.schema_builder_null_name = Measurement name cannot be null or empty
+error.write.schema_builder_null_type = Data type cannot be null
+error.write.schema_builder_null_property = Property key and value cannot be null
+
+# ValueChunkWriter / ChunkWriterImpl / TimeChunkWriter — page header IO exception (3 files, 1 key)
+error.write.page_write_header_io_exception = IO Exception in writeDataPageHeader,ignore this page
+
+# ValueChunkWriter / ChunkWriterImpl / TimeChunkWriter — written bytes inconsistent (3 files, 1 key)
+error.write.chunk_bytes_inconsistent = Bytes written is inconsistent with the size of data: %1$s != %2$s
+
+# AlignedChunkWriterImpl — unknown data type
+error.write.chunk_unknown_type = Unknown data type %1$s
+
+# AlignedChunkGroupWriterImpl — out-of-order write (aligned)
+error.write.chunk_group_aligned_out_of_order = Not allowed to write out-of-order data in timeseries %1$s%2$s%3$s, time should later than %4$s
+
+# NonAlignedChunkGroupWriterImpl — out-of-order write
+error.write.chunk_group_non_aligned_out_of_order = Not allowed to write out-of-order data in timeseries %1$s%2$s%3$s, time should later than %4$s
+
+# TsFileWriter — file writer cannot write
+error.write.tsfile_writer_cannot_write = the given file Writer does not support writing any more. Maybe it is an complete TsFile
+
+# TsFileWriter — page size too large vs chunk group size
+error.write.tsfile_writer_page_size_too_large = Invalid memory threshold configuration: page size %1$d must be smaller than chunk group size %2$d. Please either increase the chunk group size or decrease the page size.
+
+# TsFileWriter — template not found
+error.write.tsfile_writer_template_not_found = given template is not existed! %1$s
+
+# TsFileWriter — device already registered (via template)
+error.write.tsfile_writer_device_registered = this device %1$s has been registered, you can only use registerDevice method to register empty device.
+
+# TsFileWriter — nonAligned timeseries trying to register on already-aligned device
+error.write.tsfile_writer_timeseries_registered_aligned = given device %1$s has been registered for aligned timeseries.
+
+# TsFileWriter — timeseries already registered (nonAligned)
+error.write.tsfile_writer_timeseries_registered = given nonAligned timeseries %1$s has been registered.
+
+# TsFileWriter — aligned device cannot be expanded
+error.write.tsfile_writer_device_aligned_no_expand = given device %1$s has been registered for aligned timeseries and should not be expanded.
+
+# TsFileWriter — trying to register nonAligned on already-nonAligned device
+error.write.tsfile_writer_device_registered_nonaligned = given device %1$s has been registered for nonAligned timeseries.
+
+# TsFileWriter — new measurement after flush
+error.write.tsfile_writer_new_measurement = TsFile has flushed chunk group and should not add new measurement %1$s in device %2$s
+
+# TsFileWriter / AbstractTableModelTsFileWriter — flush size inconsistent
+error.write.tsfile_writer_flush_inconsistent = Flushed data size is inconsistent with computation! Estimated: %1$d, Actual: %2$d
+
+# RestorableTsFileIOWriter — incompatible file format
+error.write.restorable_writer_not_compatible = %1$s is not in TsFile format.
+
+# ForceAppendTsFileWriter — not a complete TsFile
+error.write.force_append_not_complete = File %1$s is not a complete TsFile
+
+# DiskTSMIterator — read size mismatch
+error.write.disk_tsm_read_size_mismatch = Expected to read %1$s bytes, but actually read %2$s bytes
+
+# DeviceTableModelWriter / v4 — table name is null
+error.write.v4_table_name_null = Table name is null
+
+# TableTsBlock2TsFileWriter — null value in time column
+error.write.v4_all_time_null = All values in time column should not be null
+
+# TsFileTreeWriter — delegate error messages
+error.write.v4_tree_writer_register_failed = Failed to register timeseries for device %1$s
+error.write.v4_tree_writer_register_aligned_failed = Failed to register aligned timeseries for device %1$s
+error.write.v4_tree_writer_write_tablet_failed = Failed to write tablet data
+error.write.v4_tree_writer_write_record_failed = Failed to write TSRecord
+error.write.v4_tree_writer_close_failed = Failed to close TsFileTreeWriter
+
+# TsFileTreeWriterBuilder — output file not specified
+error.write.v4_output_file_required = Output file must be specified
+
+# TsFileWriterBuilder — parameter validation
+error.write.v4_file_non_null = The file must be a non-null and non-directory File.
+error.write.v4_table_schema_non_null = TableSchema must not be null.
+error.write.v4_memory_threshold_positive = Memory threshold must be > 0 bytes.
+error.write.v4_table_name_blank = TableName must not be blank.
+error.write.v4_column_name_blank = Column name must not be blank.
+
+# --- write LOG messages ---
+
+# DataPoint subclasses — null IChunkWriter (7 files, 1 key)
+log.write.datapoint_chunk_writer_null = given IChunkWriter is null, do nothing and return
+
+# ChunkWriterImpl / TimeChunkWriter / ValueChunkWriter — upper bound hit (3 files, 1 key)
+log.write.chunk_writer_write_page = current line count reaches the upper bound, write page {}
+
+# ChunkWriterImpl / TimeChunkWriter / ValueChunkWriter — page write error (3 files, 1 key)
+log.write.chunk_writer_page_error = meet error in pageWriter.writePageHeaderAndDataIntoBuff,ignore this page:
+
+# AlignedChunkGroupWriterImpl / NonAlignedChunkGroupWriterImpl — flush device (2 files, 1 key)
+log.write.flush_device = start flush device id:{}
+
+# TsFileWriter / AbstractTableModelTsFileWriter — flush chunk groups (2 files, 1 key)
+log.write.flush_chunk_groups = start to flush chunk groups, memory space occupy:{}
+
+# TsFileWriter / AbstractTableModelTsFileWriter — close file (2 files, 1 key)
+log.write.close_file = start close file
+
+# AbstractTableModelTsFileWriter — close file exception (1 site)
+log.write.close_file_exception = Meet exception when close file writer.
+
+# TsFileWriter / AbstractTableModelTsFileWriter — page size vs chunk group size warn (2 files, 1 key)
+log.write.page_size_warn = TsFile's page size {} is greater than chunk group size {}, please enlarge the chunk group size or decrease page size.
+
+# TsFileWriter — ignore nonAligned measurement (1 site)
+log.write.ignore_nonaligned_measurement = Ignore nonAligned measurement {} , because it is not registered or in the default template
+
+# ForceAppendTsFileWriter / RestorableTsFileIOWriter — writer opened debug (2 files, 1 key)
+log.write.writer_opened = {} writer is opened.
+
+# TsFileIOWriter — start chunk group debug (1 site)
+log.write.start_chunk_group = start chunk group:{}, file position {}
+
+# TsFileIOWriter — start flush footer debug (1 site)
+log.write.start_flush_footer = start to flush the footer,file pos:{}
+
+# TsFileIOWriter — device timeseries metadata error (1 site)
+log.write.tsm_device_metadata_error = Failed to get device timeseries metadata map
+
+# TsFileIOWriter — flush metadata to temp file error (1 site)
+log.write.flush_metadata_exception = Meets exception when flushing metadata to temp file for {}
+
+# TsFileIOWriter — flushing series debug (1 site)
+log.write.flushing_series = Flushing {}
+
+# DiskTSMIterator — IOException reading timeseries metadata from disk (1 site)
+log.write.tsm_disk_read_error = Meets IOException when reading timeseries metadata from disk
+
+# ChunkWriterImpl / TimeChunkWriter / ValueChunkWriter — page header start (3 files, 1 key)
+log.write.page_header_flush_start = start to flush a page header into buffer, buffer position {}
+
+# ChunkWriterImpl / TimeChunkWriter / ValueChunkWriter — page header done (3 files, 1 key)
+log.write.page_header_flush_done = finish to flush a page header {} of {} into buffer, buffer position {}
+
+# TimeChunkWriter / ValueChunkWriter — page header done (time page variant, 2 files)
+log.write.page_header_flush_done_time = finish to flush a page header {} of time page into buffer, buffer position {}
+
+# ChunkWriterImpl / TimeChunkWriter / ValueChunkWriter — enough size, write page (3 files, 1 key)
+log.write.page_enough_size = enough size, write page {}, pageSizeThreshold:{}, currentPateSize:{}, valueCountInOnePage:{}
+
+# ValueChunkWriter variant of above (uses currentPageSize instead of currentPateSize)
+log.write.page_enough_size_value = enough size, write page {}, pageSizeThreshold:{}, currentPageSize:{}, valueCountInOnePage:{}
+
+# TsFileIOWriter — end flushing a chunk (1 site)
+log.write.end_flush_chunk = end flushing a chunk:{}, totalvalue:{}
+
+# TsFileIOWriter — flushing chunk metadata summary (1 site)
+log.write.flush_chunk_metadata = Flushing chunk metadata, total size is {}, count is {}, avg size is {}

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
@@ -252,3 +252,140 @@ log.write.end_flush_chunk = end flushing a chunk:{}, totalvalue:{}
 
 # TsFileIOWriter — flushing chunk metadata summary (1 site)
 log.write.flush_chunk_metadata = Flushing chunk metadata, total size is {}, count is {}, avg size is {}
+
+# === read.common ===
+
+# TimeRange — null input in compareTo
+error.read.timerange_null_input = The input cannot be null!
+
+# TimeRange — setMin/setMax invalid input
+error.read.timerange_invalid_input = Invalid input!
+
+# TimeRange — set(min, max) range violation
+error.read.timerange_min_gt_max = min:%1$s should not be larger than max: %2$s
+
+# Chunk — unsupported data type in rewrite (2 sites, 1 key)
+error.read.chunk_unsupported_type = Unsupported data type: %1$s
+
+# Chunk — NonAlignedChunk null value at timestamp
+error.read.chunk_non_aligned_null = NonAlignedChunk contains null, timestamp: %1$s
+
+# BatchDataFactory — instantiation guard
+error.read.factory_class = Factory class
+
+# Field — OBJECT type does not support getBinaryV
+error.read.field_object_type_no_binary = OBJECT Type only support getStringValue
+
+# Path — getFullPathWithAlias not supported
+error.read.path_no_alias = doesn't alias in TSFile Path
+
+# SignalBatchData — hasCurrent not supported
+error.read.signal_batch_data_no_has_current = hasCurrent is not supported for SignalBatchData
+
+# BatchData — unknown data type (2 sites, 1 key)
+error.read.batch_data_unknown_type = Unknown data type for BatchData:%1$s
+
+# BatchData — invalid input in deserialize
+error.read.batch_data_invalid_input = Invalid input: %1$s
+
+# TypeFactory — invalid TSDataType
+error.read.typefactory_invalid_tsdata_type = Invalid TSDataType for TypeFactory: %1$s
+
+# TypeFactory — invalid TypeEnum
+error.read.typefactory_invalid_type_enum = Invalid TypeEnum for TypeFactory: %1$s
+
+# TsBlockBuilder — unknown data type (2 sites, 1 key)
+error.read.tsblock_builder_unknown_type = Unknown data type: %1$s
+
+# TsBlockBuilder.build — declared positions mismatch (time column)
+error.read.tsblock_builder_time_mismatch = Declared positions (%1$s) does not match time column's number of entries (%2$s)
+
+# TsBlockBuilder.build — declared positions mismatch (value column)
+error.read.tsblock_builder_col_mismatch = Declared positions (%1$s) does not match column %2$s's number of entries (%3$s)
+
+# TsBlock.getRegion — invalid position/length
+error.read.tsblock_invalid_region = Invalid position %1$s and length %2$s in page with %3$s positions
+
+# TsBlock.subTsBlock — fromIndex over positionCount
+error.read.tsblock_from_index_over = FromIndex of subTsBlock cannot over positionCount.
+
+# TsBlock.determinePositionCount — columns is empty
+error.read.tsblock_columns_empty = columns is empty
+
+# TsBlock — unknown datatype in updateWithoutTimeColumn
+error.read.tsblock_unknown_datatype = Unknown datatype: %1$s
+
+# ColumnBuilder — type-specific unsupported data type (1 key per builder, 6 builders)
+error.read.col_builder_double_type = DoubleColumn only support Double data type
+error.read.col_builder_int_type = IntegerColumn only support Integer data type
+error.read.col_builder_float_type = FloatColumn only support Float data type
+error.read.col_builder_long_type = LongColumn only support Long data type
+error.read.col_builder_boolean_type = BooleanColumn only support Boolean data type
+error.read.col_builder_binary_type = BinaryColumn only support Binary data type
+
+# ColumnFactory — unsupported data type
+error.read.column_factory_unsupported_type = Unsupported data type: %1$s
+
+# TsBlockSerde — block too large
+error.read.tsblock_too_large = TsBlock should not be that large: %1$s
+
+# Shared column constructor checks (reused across multiple column classes)
+error.read.col_array_offset_negative = arrayOffset is negative
+error.read.col_position_count_negative = positionCount is negative
+error.read.col_values_length_lt_position = values length is less than positionCount
+error.read.col_isnull_length_lt_position = isNull length is less than positionCount
+error.read.col_ids_length_lt_position = ids length is less than positionCount
+
+# Shared fromIndex validation (reused across multiple column classes)
+error.read.col_from_index_invalid = fromIndex is not valid
+
+# TimeColumn — isNull not supported
+error.read.time_column_isnull_unsupported = isNull is not supported for TimeColumn
+
+# ColumnEncoderFactory — unsupported column encoding
+error.read.col_encoder_unsupported = Unsupported column encoding: %1$s
+
+# Int32/Int64/Binary/ByteArray array column encoders — invalid data type
+error.read.col_encoder_invalid_type = Invalid data type: %1$s
+
+# RunLengthEncodedColumn — expected single position
+error.read.rle_col_expected_single = Expected value to contain a single position but has %1$s positions
+
+# RunLengthEncodedColumn — setNull not supported
+error.read.rle_col_set_null_unsupported = set null of %1$s is not supported !
+
+# RunLengthColumnEncoder — nested RLE not supported
+error.read.rle_encoder_nested = Unable to encode a nested RLE column.
+
+# DictionaryColumn — sequential ids flag constraint
+error.read.dict_col_sequential_ids = sequential ids flag is only valid for compacted dictionary
+
+# DictionaryColumn — non-existent key reference (2 sites, 1 key)
+error.read.dict_col_nonexistent_key = reference to a non-existent key
+
+# DictionaryColumn — dictionary source ids mismatch
+error.read.dict_col_source_ids_mismatch = dictionarySourceIds must be the same
+
+# NullColumn — unknown data type
+error.read.null_col_unknown_type = Unknown data type: %1$s
+
+# ColumnUtil — invalid offset/length in array
+error.read.col_util_invalid_offset_length = Invalid offset %1$s and length %2$s in array with %3$s elements
+
+# ColumnUtil — invalid position/length in block
+error.read.col_util_invalid_pos_length = Invalid position %1$s and length %2$s in block with %3$s positions
+
+# ColumnUtil — invalid positions array size
+error.read.col_util_invalid_positions_size = Invalid positions array size %1$d, actual position count is %2$d
+
+# ColumnUtil — invalid position in block
+error.read.col_util_invalid_position = Invalid position %1$s in block with %2$s positions
+
+# ColumnUtil — cannot grow array
+error.read.col_util_cannot_grow = Cannot grow array beyond '%1$s'
+
+# TimeColumnBuilder — position not valid
+error.read.time_col_builder_position_invalid = position is not valid
+
+# PathParseError — syntax error with line and position
+error.read.path_parse_error = line %1$s:%2$s %3$s

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
@@ -19,3 +19,41 @@
 
 # Seed entry used by MessagesTest. Real entries are added by migration tasks.
 test.seed = hello %1$s
+
+# === common ===
+
+# TSDataType
+error.common.invalid_input = Invalid input: %1$s
+
+# RamUsageEstimator
+error.common.no_array_classes = This method does not work with array classes.
+
+# TsPrimitiveType — unsupported data type (typo fixed: added space after colon)
+error.common.unsupported_data_type = Unsupported data type: %1$s
+
+# TsPrimitiveType — get/set operations not supported for sub-class (14 sites collapsed to 1 key)
+error.common.subclass_op_not_supported = %1$s is not supported for current sub-class
+
+# TsPrimitiveType — wrong value type passed to setObject (7 sites collapsed to 1 key)
+error.common.tsprimitive_wrong_value_type = %1$s can only be set %2$s value
+
+# TsBlockBuilderStatus
+error.common.bytes_cannot_be_negative = bytes cannot be negative
+
+# ColumnEncoding
+error.common.invalid_column_encoding_value = Invalid value: %1$s
+
+# ColumnBuilderStatus
+error.common.cannot_determine_size_array = Cannot determine size of %1$s because it contains an array
+error.common.class_is_interface = %1$s is an interface
+error.common.class_is_abstract = %1$s is abstract
+error.common.cannot_determine_size_subclass = Cannot determine size of a subclass. %1$s extends from %2$s
+
+# BitMap
+error.common.bitmap_range_size_exceeds = range size %1$s should <= the minimal bitmap size %2$s
+error.common.bitmap_start_length_out_of_range = startPosition %1$s + length %2$s is out of range %3$s
+error.common.bitmap_out_of_src_range = %1$s is out of src range %2$s
+error.common.bitmap_out_of_dest_range = %1$s is out of dest range %2$s
+
+# TSDataType
+error.common.unsupported_cast = Unsupported cast: from %1$s to %2$s

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
@@ -389,3 +389,259 @@ error.read.time_col_builder_position_invalid = position is not valid
 
 # PathParseError — syntax error with line and position
 error.read.path_parse_error = line %1$s:%2$s %3$s
+
+# === read ===
+
+# TsFileSequenceReader / selfCheck — unexpected marker
+error.read.unexpected_marker = Unexpected marker %1$s
+
+# TsFileSequenceReader.selfCheck / checkChunkAndPagesStatistics — unexpected data type in switch
+error.read.unexpected_type = Unexpected type %1$s
+
+# TsFileSequenceReader — device not in tsFileMetaData (with file name, 3 sites)
+error.read.device_not_in_metadata_file = Device {%1$s} is not in tsFileMetaData of %2$s
+
+# TsFileSequenceReader — device not in tsFileMetaData (no file name, 1 site)
+error.read.device_not_in_metadata = Device {%1$s} is not in tsFileMetaData
+
+# TsFileSequenceReader / readPlanIndex / readMarker — reach end of file (3 sites)
+error.read.reach_end_of_file = reach the end of the file.
+
+# TsFileSequenceReader.readData — reach end of data (short form)
+error.read.reach_end_of_data = reach the end of the data
+
+# TsFileSequenceReader.readData — reach end of data with position detail
+error.read.reach_end_of_data_detail = reach the end of the data. Size of data that want to read: %1$s,actual read size: %2$s, position: %3$s
+
+# TsFileSequenceReader.uncompress — uncompress error with counts (no page header)
+error.read.uncompress_error = Uncompress error! uncompress size: %1$scompressed size: %2$s%3$s
+
+# ChunkReader.uncompressPageData / decryptAndUncompressPageData / LazyLoadPageData — uncompress error with page header
+error.read.uncompress_error_with_header = Uncompress error! uncompress size: %1$scompressed size: %2$spage header: %3$s%4$s
+
+# AbstractChunkReader — no more page
+error.read.no_more_page = No more page
+
+# ChunkReader.readCompressedPageData — incomplete page body
+error.read.chunk_incomplete_page_body = do not has a complete page body. Expected:%1$s. Actual:%2$s
+
+# TsFileSequenceReaderTimeseriesMetadataIterator — deserializeTimeseriesMetadataUsingTsFileInput failed
+error.read.tsm_iterator_tsfinput_failed = TsFileSequenceReaderTimeseriesMetadataIterator: deserializeTimeseriesMetadataUsingTsFileInput failed, currentEndOffset: %1$d, %2$s
+
+# TsFileSequenceReaderTimeseriesMetadataIterator — deserializeMetadataIndexEntry failed
+error.read.tsm_iterator_index_entry_failed = TsFileSequenceReaderTimeseriesMetadataIterator: deserializeMetadataIndexEntry failed, MetadataIndexEntryInfo: %1$s, %2$s
+
+# TsFileSequenceReaderTimeseriesMetadataIterator — currentBuffer still has remaining data
+error.read.tsm_iterator_buffer_not_empty = currentBuffer still has some data left before deserializeLeafMeasurement
+
+# TsFileSequenceReader — timeseries of device are not aligned
+error.read.timeseries_not_aligned = Timeseries of device {%1$s} are not aligned
+
+# TsFileSequenceReader — aligned chunk metadata should only have one timeseriesMetadataList per device
+error.read.aligned_chunk_metadata_one_device = Error when reading timeseriesMetadata of device %1$s in file %2$s: should only one timeseriesMetadataList in one device, actual: %3$d
+
+# TsFileSequenceReader.selfCheckWithInfo — statistics mistakes in Chunk
+error.read.stats_mistakes_chunk = Chunk exists statistics mistakes at position %1$s
+
+# TsFileSequenceReader.selfCheckWithInfo — statistics mistakes in TimeseriesMetadata
+error.read.stats_mistakes_tsm = TimeseriesMetadata exists statistics mistakes at position %1$s
+
+# TsFileSequenceReader / TsFileDeviceIterator — error reading a time series metadata block (2 sites)
+error.read.metadata_block_read_error = Error occurred while reading a time series metadata block.
+
+# LazyTsFileDeviceIterator.getDevicesOfLeafNode — first param should be device leaf node
+error.read.device_leaf_node_required = the first param should be device leaf node.
+
+# LazyTsFileDeviceIterator — next() must be called before accessing current device (3 sites)
+error.read.device_iterator_no_current = next() must be called before accessing current device
+
+# DeviceMetaIterator — non-device node detected
+error.read.non_device_node_detected = A non-device node detected: %1$s
+
+# MetadataQuerierByFileImpl — spacePartitionStartPos > spacePartitionEndPos
+error.read.metadata_querier_illegal_arg = 'spacePartitionStartPos' should not be larger than 'spacePartitionEndPos'.
+
+# ExpressionOptimizer — unsupported IExpression type in binary expression
+error.read.expression_unsupported_binary_type = unsupported IExpression type: %1$s
+
+# ExpressionOptimizer — StackOverflowError
+error.read.expression_stack_overflow = StackOverflowError is encountered.
+
+# ExpressionOptimizer — unknown IExpression type
+error.read.expression_unknown_type = unknown IExpression type: %1$s
+
+# ExpressionOptimizer — unknown relation in IExpression
+error.read.expression_unknown_relation = unknown relation in IExpression:%1$s
+
+# ExpressionOptimizer — size of selectSeries could not be 0
+error.read.expression_empty_select_series = size of selectSeries could not be 0
+
+# ExpressionOptimizer — IExpression should contain only SingleSeriesExpression
+error.read.expression_unexpected_type = IExpression should contains only SingleSeriesExpression but other type is found:%1$s
+
+# ExpressionOptimizer — unrecognized QueryFilterOperatorType
+error.read.expression_unrecognized_operator = unrecognized QueryFilterOperatorType :%1$s
+
+# ValueFilter — unsupported data type (7 satisfy methods, 1 key; arg = class name)
+error.read.value_filter_unsupported_type = Unsupported data type for value filter: %1$s
+
+# ValueFilter — getTimeRanges not supported
+error.read.value_filter_no_time_ranges = Value filter does not support getTimeRanges()
+
+# Not filter — contains NOT (4 sites, 1 key; appended with filter.toString())
+error.read.filter_contains_not = This predicate contains a not! Did you forget to run this predicate through PredicateRemoveNotRewriter? %1$s
+
+# Filter.deserialize — unsupported operator type
+error.read.filter_unsupported_operator = Unsupported operator type:%1$s
+
+# TimeFilterOperators.In — set must not be null
+error.read.filter_timein_set_null = set must not be null!
+
+# ExtractTimeFilterOperators — unexpected extract field (2 sites)
+error.read.extract_unexpected_field = Unexpected extract field: %1$s
+
+# ValueFilterApi — unsupported data type (14 sites, 1 key)
+error.read.filter_api_unsupported_type = Unsupported data type: %1$s
+
+# TagFilterBuilder — column is not a tag column
+error.read.tag_not_a_tag_column = Column '%1$s' is not a tag column
+
+# TimeGenerator.getValues — OR node present
+error.read.time_generator_or_get_values = getValues() method should not be invoked when there is OR operator in where clause
+
+# TimeGenerator.getValues — path not in where clause
+error.read.time_generator_path_not_found_values = getValues() method should not be invoked by non-existent path in where clause
+
+# TimeGenerator.getValue — OR node present
+error.read.time_generator_or_get_value = getValue() method should not be invoked when there is OR operator in where clause
+
+# TimeGenerator.getValue — path not in where clause
+error.read.time_generator_path_not_found_value = getValue() method should not be invoked by non-existent path in where clause
+
+# TimeGenerator.construct — unsupported ExpressionType
+error.read.time_generator_unsupported_expression = Unsupported ExpressionType when construct OperatorNode: %1$s
+
+# AndNode / OrNode / LeafNode — no more data (3 sites)
+error.read.node_no_more_data = no more data
+
+# AbstractResultSet — column name not found
+error.read.result_set_column_not_found = Can't find columnName %1$s from result set
+
+# AbstractResultSet — field is null
+error.read.result_set_null_field = Field in columnIndex %1$s is null
+
+# AbstractResultSet — column index out of bound
+error.read.result_set_index_out_of_bound = column index %1$s out of bound
+
+# DataSetWithoutTimeGenerator — unsupported data type
+error.read.dataset_unsupported_type = UnSupported%1$s
+
+# SingleDeviceTsBlockReader — unsupported data type (3 sites, same key)
+error.read.block_reader_unsupported_type = Unsupported data type: %1$s
+
+# TableQueryExecutor — unsupported ordering
+error.read.table_query_unsupported_ordering = Unsupported ordering: %1$s
+
+# TableQueryExecutor — no column exception
+error.read.table_query_no_column = No column: %1$s
+
+# TsFileTreeReaderBuilder — file must be set
+error.read.tree_reader_file_required = file must be set before build()
+
+# TsFileReaderBuilder — file must be non-null and non-directory
+error.read.reader_builder_file_non_null = The file must be a non-null and non-directory File.
+
+# --- read LOG messages ---
+
+# TsFileRestorableReader — file has no correct tail magic
+log.read.file_repair = File {} has no correct tail magic, try to repair...
+
+# LocalTsFileInput — error getting file size
+log.read.local_input_size_error = Error happened while getting {} size
+
+# LocalTsFileInput — error getting current position
+log.read.local_input_position_error = Error happened while getting {} current position
+
+# LocalTsFileInput — error changing position
+log.read.local_input_position_change_error = Error happened while changing {} position to {}
+
+# LocalTsFileInput — ClosedByInterruptException on read (2 sites, 1 key)
+log.read.local_input_interrupted = Current thread is interrupted by another thread when it is blocked in an I/O operation upon a channel.
+
+# LocalTsFileInput — error reading from current position
+log.read.local_input_read_current_error = Error happened while reading {} from current position
+
+# LocalTsFileInput — error reading from position
+log.read.local_input_read_position_error = Error happened while reading {} from position {}
+
+# LocalTsFileInput — error closing
+log.read.local_input_close_error = Error happened while closing {}
+
+# TsFileSequenceReader — reading file metadata error
+log.read.sequence_reader_file_metadata_error = Something error happened while reading file metadata of file {}
+
+# TsFileSequenceReader — deserializing TimeseriesMetadata error (multiple sites, same key)
+log.read.sequence_reader_tsm_deserialize_error = Something error happened while deserializing TimeseriesMetadata of file {}
+
+# TsFileSequenceReader — deserializing MetadataIndexNode error (constant METADATA_INDEX_NODE_DESERIALIZE_ERROR, 8 sites)
+log.read.sequence_reader_metadata_index_node_error = Something error happened while deserializing MetadataIndexNode of file {}
+
+# TsFileSequenceReader — reading chunk header error (2 sites, 1 key)
+log.read.sequence_reader_chunk_header_error = Exception {} happened while reading chunk header of {}
+
+# TsFileSequenceReader — reading chunk error (3 sites, 1 key)
+log.read.sequence_reader_chunk_error = Exception {} happened while reading chunk of {}
+
+# TsFileSequenceReader — reading page header error
+log.read.sequence_reader_page_header_error = Exception {} happened while reading page header of {}
+
+# TsFileSequenceReader — reading data error
+log.read.sequence_reader_data_error = Exception {} happened while reading data of {}
+
+# TsFileSequenceReader — getting all paths error
+log.read.sequence_reader_paths_error = Something error happened while getting all paths of file {}
+
+# TsFileSequenceReader — generating MetadataIndex error (2 sites, 1 key)
+log.read.sequence_reader_metadata_index_error = Something error happened while generating MetadataIndex of file {}
+
+# TsFileSequenceReader — deserializing MetadataIndex error (2 sites, 1 key; different from MetadataIndexNode constant)
+log.read.sequence_reader_deserialize_metadata_error = Something error happened while deserializing MetadataIndex of file {}
+
+# TsFileSequenceReader.selfCheck — cannot proceed warning
+log.read.sequence_reader_self_check_warn = TsFile {} self-check cannot proceed at position {} recovered, because : {}
+
+# TsFileSequenceReader.selfCheckWithInfo — file length info
+log.read.sequence_reader_file_length = file length: {}
+
+# TsFileSequenceReader.selfCheckWithInfo — fast check error
+log.read.sequence_reader_fast_check_error = Error occurred while fast checking TsFile.
+
+# TsFileSequenceReader.selfCheckWithInfo — statistics check error
+log.read.sequence_reader_stats_check_error = Error occurred while checking the statistics of chunk and its pages
+
+# TsFileSequenceReader — collecting offset ranges error
+log.read.sequence_reader_collect_offset_error = Error occurred while collecting offset ranges of measurement nodes of file {}
+
+# TsFileSequenceReader.TimeseriesMetadataIterator — cannot read timeseries metadata
+log.read.sequence_reader_tsm_warn = Cannot read timeseries metadata from {},
+
+# TsFileLastReader — cannot read timeseries metadata from file (2 sites, 1 key)
+log.read.last_reader_tsm_error = Cannot read timeseries metadata from {}
+
+# TsFileLastReader — error while reading timeseries metadata (async)
+log.read.last_reader_tsm_meta_error = Error while reading timeseries metadata
+
+# DeviceOrderedTsBlockReader — failed to construct reader
+log.read.block_reader_construct_error = Failed to construct reader for {}
+
+# SingleDeviceTsBlockReader — cannot fill measurements
+log.read.block_reader_fill_measurements_error = Cannot fill measurements
+
+# TableResultSet — failed to close tsBlockReader
+log.read.table_result_set_close_error = Failed to close tsBlockReader
+
+# DeviceMetaIterator — failed to load device meta data
+log.read.device_meta_iterator_error = Failed to load device meta data
+
+# DeviceTableModelReader — close file reader exception
+log.read.v4_close_reader_error = Meet exception when close file reader:

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
@@ -645,3 +645,173 @@ log.read.device_meta_iterator_error = Failed to load device meta data
 
 # DeviceTableModelReader — close file reader exception
 log.read.v4_close_reader_error = Meet exception when close file reader:
+
+# === encoding ===
+
+# --- encoder error messages ---
+
+# Encoder — method not supported (8 sites, 1 key per type; parameterized on method name and class)
+error.encoding.encoder_method_not_supported = Method encode %1$s is not supported by Encoder
+
+# FloatEncoder / FloatDecoder — data type not supported (3+3 sites; same English text)
+error.encoding.float_encoder_unsupported_type = data type %1$s is not supported by FloatEncoder
+
+# FloatDecoder — encoding not supported
+error.encoding.float_decoder_unsupported_encoding = %1$s encoding is not supported by FloatDecoder
+
+# FloatEncoder — encoding not supported
+error.encoding.float_encoder_unsupported_encoding = %1$s encoding is not supported by FloatEncoder
+
+# PlainEncoder — BigDecimal not supported
+error.encoding.plain_encoder_bigdecimal_unsupported = tsfile-encoding PlainEncoder: current version does not support BigDecimal value encoding
+
+# RleDecoder — method not supported (8 sites, 1 key; note typo "supproted" preserved for backward compat)
+error.encoding.rle_decoder_method_not_supported = Method %1$s is not supproted by RleDecoder
+
+# RleDecoder — unknown encoding mode
+error.encoding.rle_decoder_unknown_mode = tsfile-encoding IntRleDecoder: unknown encoding mode %1$s
+
+# RleDecoder — bitPackedGroupCount < 1
+error.encoding.rle_decoder_bit_packed_group_count = tsfile-encoding IntRleDecoder: bitPackedGroupCount %1$d, smaller than 1
+
+# IntRleDecoder / LongRleDecoder — not a valid mode
+error.encoding.rle_decoder_invalid_mode_int = tsfile-encoding IntRleDecoder: not a valid mode %1$s
+error.encoding.rle_decoder_invalid_mode_long = tsfile-encoding LongRleDecoder: not a valid mode %1$s
+
+# BitmapDecoder — method not supported (7 sites, 1 key)
+error.encoding.bitmap_decoder_method_not_supported = Method %1$s is not supported by BitmapDecoder
+
+# FloatDecoder — method not supported (5 sites, 1 key)
+error.encoding.float_decoder_method_not_supported = Method %1$s is not supported by FloatDecoder
+
+# PlainDecoder — BigDecimal not supported
+error.encoding.plain_decoder_bigdecimal_unsupported = Method readBigDecimal is not supported by PlainDecoder
+
+# Decoder — method not supported (8 sites, 1 key)
+error.encoding.decoder_method_not_supported = Method %1$s is not supported by Decoder
+
+# Decoder.getDecoderByType — encoding+type combination not found (many sites, 1 key using ERROR_MSG)
+error.encoding.decoder_not_found = Decoder not found: %1$s , DataType is : %2$s
+
+# GorillaDecoderV1 — reading from empty buffer
+error.encoding.gorilla_empty_buffer = Reading from empty buffer
+
+# CamelDecoder — no more data
+error.encoding.camel_no_more_data = No more data to decode
+
+# CamelDecoder — unexpected empty block
+error.encoding.camel_unexpected_empty_block = Unexpected empty block
+
+# FloatSprintzDecoder / IntSprintzDecoder / DoubleSprintzDecoder / LongSprintzDecoder — unsupported predictive method (4 sites, 1 key)
+error.encoding.sprintz_unsupported_predict_method = Sprintz predictive method {} is not supported.
+
+# FloatSprintzEncoder / IntSprintzEncoder / DoubleSprintzEncoder / LongSprintzEncoder — unsupported predictive method (4 sites, 1 key)
+error.encoding.sprintz_encoder_unsupported_predict_method = Config: Predict Method {} of SprintzEncoder is not supported.
+
+# TSEncodingBuilder — unsupported encoding type
+error.encoding.ts_encoding_builder_unsupported = Unsupported encoding: %1$s
+
+# TSEncodingBuilder — data type not supported (many sites using ERROR_MSG pattern, 1 key)
+error.encoding.ts_encoding_builder_unsupported_type = %1$s doesn't support data type: %2$s
+
+# --- encoder LOG messages ---
+
+# DeltaBinaryEncoder / RegularDataEncoder — flush data to stream failed (2 sites, 1 key)
+log.encoding.flush_data_failed = flush data to stream failed!
+
+# DoubleSprintzEncoder — encoding error
+log.encoding.sprintz_double_encode_error = Error occured when encoding INT32 Type value with with Sprintz
+
+# FloatSprintzEncoder — encoding error
+log.encoding.sprintz_float_encode_error = Error occured when encoding Float Type value with with Sprintz
+
+# IntSprintzEncoder — encoding error
+log.encoding.sprintz_int_encode_error = Error occured when encoding INT32 Type value with with Sprintz
+
+# LongSprintzEncoder — encoding error
+log.encoding.sprintz_long_encode_error = Error occured when encoding INT64 Type value with with Sprintz
+
+# DictionaryEncoder — flush error
+log.encoding.dictionary_encoder_flush_error = tsfile-encoding DictionaryEncoder: error occurs when flushing
+
+# PlainEncoder — encode Binary error
+log.encoding.plain_encoder_binary_error = tsfile-encoding PlainEncoder: error occurs when encode Binary value {}
+
+# RleEncoder — flush rle run error (context-carrying message)
+log.encoding.rle_flush_rle_run_error = tsfile-encoding RleEncoder : error occurs when writing nums to OutputStram when flushing left nums. numBufferedValues {}, repeatCount {}, bitPackedGroupCount{}, isBitPackRun {}, isBitWidthSaved {}
+
+# RleEncoder — write full rle run debug
+log.encoding.rle_write_full_rle_run = tsfile-encoding RleEncoder : write full rle run to stream
+
+# RleEncoder — writing full rle run error
+log.encoding.rle_full_rle_run_error =  error occurs when writing full rle run to OutputStram when repeatCount = {}.numBufferedValues {}, repeatCount {}, bitPackedGroupCount{}, isBitPackRun {}, isBitWidthSaved {}
+
+# RleEncoder — writing num error when repeatCount > min
+log.encoding.rle_write_num_error = tsfile-encoding RleEncoder : error occurs when writing num to OutputStram when repeatCount > {}.numBufferedValues {}, repeatCount {}, bitPackedGroupCount{}, isBitPackRun {}, isBitWidthSaved {}
+
+# --- decoder LOG messages ---
+
+# SinglePrecisionDecoderV1 — cannot read first float
+log.encoding.single_precision_v1_first_float_error = SinglePrecisionDecoderV1 cannot read first float number
+
+# SinglePrecisionDecoderV1 — cannot read following float
+log.encoding.single_precision_v1_following_float_error = SinglePrecisionDecoderV1 cannot read following float number
+
+# DoublePrecisionDecoderV1 — cannot read first double
+log.encoding.double_precision_v1_first_double_error = DoublePrecisionDecoderV1 cannot read first double number
+
+# DoublePrecisionDecoderV1 — cannot read following double
+log.encoding.double_precision_v1_following_double_error = DoublePrecisionDecoderV1 cannot read following double number
+
+# GorillaDecoderV1 — fill buffer failed
+log.encoding.gorilla_fill_buffer_failed = Failed to fill a new buffer, because there is no byte to read
+
+# IntRleDecoder — reading error
+log.encoding.int_rle_decoder_read_error = tsfile-encoding IntRleDecoder: error occurs when reading all encoding number, length is {}, bit width is {}
+
+# LongRleDecoder — reading error (same text but different logger)
+log.encoding.long_rle_decoder_read_error = tsfile-encoding IntRleDecoder: error occurs when reading all encoding number, length is {}, bit width is {}
+
+# DictionaryDecoder — decoding error
+log.encoding.dictionary_decoder_error = tsfile-decoding DictionaryDecoder: error occurs when decoding
+
+# FloatSprintzDecoder / IntSprintzDecoder / DoubleSprintzDecoder / LongSprintzDecoder — readInt error (4 sites, 1 key)
+log.encoding.sprintz_decoder_read_error = Error occured when readInt with Sprintz Decoder.
+
+# TSEncodingBuilder — max string length negative value warning
+log.encoding.ts_encoding_max_string_length_negative = cannot set max string length to negative value, replaced with default value:{}
+
+# TSEncodingBuilder — max point number bad format warning
+log.encoding.ts_encoding_max_point_number_format = The format of max point number {} is not correct. Using default float precision.
+
+# TSEncodingBuilder — max point number negative value warning
+log.encoding.ts_encoding_max_point_number_negative = cannot set max point number to negative value, replaced with default value:{}
+
+# IntZigzagEncoder — constructor debug
+log.encoding.int_zigzag_encoder_init = tsfile-encoding IntZigzagEncoder: int zigzag encoder
+
+# LongZigzagEncoder — constructor debug
+log.encoding.long_zigzag_encoder_init = tsfile-encoding LongZigzagEncoder: long zigzag encoder
+
+# BitmapEncoder — constructor debug
+log.encoding.bitmap_encoder_init = tsfile-encoding BitmapEncoder: init bitmap encoder
+
+# IntZigzagDecoder — constructor debug
+log.encoding.int_zigzag_decoder_init = tsfile-decoding IntZigzagDecoder: int zigzag decoder
+
+# LongZigzagDecoder — constructor debug
+log.encoding.long_zigzag_decoder_init = tsfile-encoding LongZigzagDecoder: long zigzag decoder
+
+# BitmapDecoder — constructor debug
+log.encoding.bitmap_decoder_init = tsfile-encoding BitmapDecoder: init bitmap decoder
+
+# BitmapDecoder — page data debug (2 args: number, byteArrayLength)
+log.encoding.bitmap_decoder_page_data = tsfile-encoding BitmapDecoder: number {} in current page, byte length {}
+
+# FloatDecoder — init decoder debug (6 keys for 6 branches)
+log.encoding.float_decoder_init_int_rle = tsfile-encoding FloatDecoder: init decoder using int-rle and float
+log.encoding.float_decoder_init_long_rle = tsfile-encoding FloatDecoder: init decoder using long-rle and double
+log.encoding.float_decoder_init_int_delta = tsfile-encoding FloatDecoder: init decoder using int-delta and float
+log.encoding.float_decoder_init_long_delta = tsfile-encoding FloatDecoder: init decoder using long-delta and double
+log.encoding.float_decoder_init_int_rlbe = tsfile-encoding FloatDecoder: init decoder using int-rlbe and float
+log.encoding.float_decoder_init_long_rlbe = tsfile-encoding FloatDecoder: init decoder using long-rlbe and double

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
@@ -815,3 +815,58 @@ log.encoding.float_decoder_init_int_delta = tsfile-encoding FloatDecoder: init d
 log.encoding.float_decoder_init_long_delta = tsfile-encoding FloatDecoder: init decoder using long-delta and double
 log.encoding.float_decoder_init_int_rlbe = tsfile-encoding FloatDecoder: init decoder using int-rlbe and float
 log.encoding.float_decoder_init_long_rlbe = tsfile-encoding FloatDecoder: init decoder using long-rlbe and double
+
+# === file ===
+
+# MetaMarker — unexpected marker byte
+error.file.unexpected_marker = Unexpected marker %1$s
+
+# AbstractAlignedChunkMetadata — unsupported getNewType/setNewType (2 sites, 1 key)
+error.file.aligned_chunk_metadata_new_type_unsupported = AlignedChunkMetadata doesn't support setNewType method
+
+# AbstractAlignedChunkMetadata — serializeTo not supported
+error.file.aligned_chunk_metadata_serialize_unsupported = VectorChunkMetadata doesn't support serial method
+
+# MetadataIndexConstructor — utility class guard
+error.file.utility_class = Utility class
+
+# TsFileMetadata — encryptType missing for encryptLevel 1 or 2 (2 sites, 1 key with level arg)
+error.file.tsfile_metadata_no_encrypt_type = TsfileMetadata lack of encryptType while encryptLevel is %1$s
+
+# TsFileMetadata — encryptKey missing for encryptLevel 1 or 2 (2 sites, 1 key with level arg)
+error.file.tsfile_metadata_no_encrypt_key = TsfileMetadata lack of encryptKey while encryptLevel is %1$s
+
+# TsFileMetadata — encryptKey null/empty for encryptLevel 1 or 2 (2 sites, 1 key with level arg)
+error.file.tsfile_metadata_null_encrypt_key = TsfileMetadata null encryptKey while encryptLevel is %1$s
+
+# TsFileMetadata — unsupported encryptLevel
+error.file.tsfile_metadata_unsupported_encrypt_level = Unsupported encryptLevel: %1$s
+
+# TableSchema — duplicate column name (4 sites, 1 key)
+error.file.table_schema_duplicate_column = Each column name in the table should be unique(case insensitive).
+
+# ColumnSchemaBuilder — name must be non-empty
+error.file.column_schema_builder_name_empty = Column name must be a non empty string
+
+# ColumnSchemaBuilder — name must be set before building
+error.file.column_schema_builder_name_not_set = Column name must be set before building
+
+# ColumnSchemaBuilder — data type must be set before building
+error.file.column_schema_builder_type_not_set = Column data type must be set before building
+
+# StringArrayDeviceID — all segments are null
+error.file.device_id_all_segments_null = All segments are null
+
+# Statistics — unsupported stat operation (many sites across subclasses; args: type name, op name)
+error.file.stats_unsupported = %1$s statistics does not support: %2$s
+
+# --- file LOG messages ---
+
+# IDeviceID — using default inefficient serialized size implementation
+log.file.device_id_default_serialized_size = Using default inefficient implementation of serialized size by {}
+
+# IDeviceID — failed to serialize device ID
+log.file.device_id_serialize_failed = Failed to serialize device ID: {}
+
+# Statistics — statistics classes mismatched, no merge
+log.file.stats_classes_mismatched = Statistics classes mismatched,no merge: {} v.s. {}

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
@@ -1057,3 +1057,295 @@ error.external.lrumap_npe = NPE, entry=%1$s entryIsHeader=%2$s key=%3$s value=%4
 
 # ComparatorChain.checkChainIntegrity — must contain at least one comparator
 error.external.comparator_chain_empty = ComparatorChains must contain at least one Comparator
+
+# === encrypt ===
+
+# IEncryptor.getEncryptor — class not found (class name arg)
+error.encrypt.encryptor_class_not_found = Get encryptor class failed, class not found: %1$s
+
+# IEncryptor.getEncryptor — no constructor (class name arg)
+error.encrypt.encryptor_no_constructor = Get constructor for encryptor failed: %1$s
+
+# IEncryptor.getEncryptor — instantiation failed (class name arg)
+error.encrypt.encryptor_instantiation_failed = New encryptor instance failed: %1$s
+
+# IDecryptor.getDecryptor — class not found (class name arg)
+error.encrypt.decryptor_class_not_found = Get decryptor class failed, class not found: %1$s
+
+# IDecryptor.getDecryptor — no constructor (class name arg)
+error.encrypt.decryptor_no_constructor = Get constructor for decryptor failed: %1$s
+
+# IDecryptor.getDecryptor — instantiation failed (class name arg)
+error.encrypt.decryptor_instantiation_failed = New decryptor instance failed: %1$s
+
+# EncryptUtils.getEncryptKeyFromToken — key derivation failed
+error.encrypt.key_derivation_failed = Error deriving key from token
+
+# EncryptUtils.deriveKeyInternal — dkLen not positive (value arg)
+error.encrypt.dklen_not_positive = main key's dkLen must be positive integer: %1$s
+
+# EncryptUtils.deriveKeyInternal — dkLen too long (value arg)
+error.encrypt.dklen_too_long = main key's dkLen is too long: %1$s
+
+# EncryptUtils.getNormalKeyStr / generateEncryptParameter — SHA-256 not found
+error.encrypt.sha256_not_found = SHA-256 algorithm not found while using SHA-256 to generate data key
+
+# EncryptUtils.getEncrypt — class not found (encryptType arg)
+error.encrypt.encrypt_class_not_found = Get encryptor class failed: %1$s
+
+# EncryptUtils.getEncrypt — no constructor (encryptType arg)
+error.encrypt.encrypt_no_constructor = Get constructor for encryptor failed: %1$s
+
+# EncryptUtils.getEncrypt — instantiation failed (encryptType arg)
+error.encrypt.encrypt_instantiation_failed = New encryptor instance failed: %1$s
+
+# === compress ===
+
+# ICompressor.getCompressor / IUnCompressor.getUnCompressor — null type
+error.compress.type_not_supported_null = NULL
+
+# ICompressor.getCompressor / IUnCompressor.getUnCompressor — unsupported type (name arg)
+error.compress.type_not_supported = %1$s
+
+# NoCompressor — compress not supported (3 method variants, 1 key)
+error.compress.no_compressor_not_supported = No Compressor does not support compression function
+
+# NoUnCompressor — uncompress ByteBuffer not supported
+error.compress.no_uncompressor_not_supported = NoUnCompressor does not support this method.
+
+# LZ4UnCompressor / GZIPUnCompressor / LZMA2UnCompressor — getUncompressedLength not supported (6 sites, 1 key)
+error.compress.get_uncompress_length_unsupported = unsupported get uncompress length
+
+# --- compress LOG messages ---
+
+# SnappyUnCompressor — uncompress input byte error (2 sites, 1 key)
+log.compress.snappy_uncompress_error = tsfile-compression SnappyUnCompressor: errors occurs when uncompress input byte
+
+# LZ4UnCompressor — uncompress input byte error (3 sites, 1 key)
+log.compress.lz4_uncompress_error = tsfile-compression LZ4UnCompressor: errors occurs when uncompress input byte
+
+# === fileSystem ===
+
+# HDFSOutputFactory / OSFileOutputFactory — init error: get input class
+log.fs.hdfs_output_factory_init_error = Failed to get HDFSInput in Hadoop file system. Please check your dependency of Hadoop module.
+log.fs.os_output_factory_init_error = Failed to get OSInput in object storage. Please check your dependency of object storage module.
+
+# HDFSOutputFactory / OSFileOutputFactory — getTsFileOutput error (path arg)
+log.fs.hdfs_output_factory_get_error = Failed to get TsFile output of file: {}. Please check your dependency of Hadoop module.
+log.fs.os_output_factory_get_error = Failed to get TsFile output of file: {}. Please check your dependency of object storage module.
+
+# LocalFSOutputFactory — getTsFileOutput error (path arg)
+log.fs.local_output_factory_get_error = Failed to get TsFile output of file: {},
+
+# HDFSFactory — init error
+log.fs.hdfs_factory_init_error = Failed to get Hadoop file system. Please check your dependency of Hadoop module.
+
+# OSFSFactory — init error
+log.fs.os_factory_init_error = Failed to get object storage. Please check your dependency of object storage module.
+
+# HDFSFactory.getFileWithParent — get file error (path arg)
+log.fs.hdfs_factory_get_file_with_parent_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.getFile(String) — get file error (path arg)
+log.fs.hdfs_factory_get_file_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.getFile(String, String) — get file error (path arg)
+log.fs.hdfs_factory_get_file2_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.getFile(File, String) — get file error (path arg)
+log.fs.hdfs_factory_get_file3_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.getFile(URI) — get file error (uri arg)
+log.fs.hdfs_factory_get_file_uri_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.getBufferedReader — error (path arg)
+log.fs.hdfs_factory_get_reader_error = Failed to get buffered reader for {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.getBufferedWriter — error (path arg)
+log.fs.hdfs_factory_get_writer_error = Failed to get buffered writer for {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.getBufferedInputStream — error (path arg)
+log.fs.hdfs_factory_get_input_stream_error = Failed to get buffered input stream for {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.getBufferedOutputStream — error (path arg)
+log.fs.hdfs_factory_get_output_stream_error = Failed to get buffered output stream for {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.listFilesBySuffix — error (folder, suffix args)
+log.fs.hdfs_factory_list_suffix_error = Failed to list files in {} with SUFFIX {}. Please check your dependency of Hadoop module.
+
+# HDFSFactory.listFilesByPrefix — error (folder, prefix args)
+log.fs.hdfs_factory_list_prefix_error = Failed to list files in {} with PREFIX {}. Please check your dependency of Hadoop module.
+
+# OSFSFactory.getFileWithParent — error (path arg)
+log.fs.os_factory_get_file_with_parent_error = Failed to get file: {}. Please check your dependency of object storage module.
+
+# OSFSFactory.getFile(String) — error (path arg)  [note: message says Hadoop module — matching original]
+log.fs.os_factory_get_file_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+
+# OSFSFactory.getFile(String, String) — error (path arg) [matches original]
+log.fs.os_factory_get_file2_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+
+# OSFSFactory.getFile(File, String) — error (path arg) [matches original]
+log.fs.os_factory_get_file3_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+
+# OSFSFactory.getFile(URI) — error (uri arg)
+log.fs.os_factory_get_file_uri_error = Failed to get file: {}. Please check your dependency of object storage module.
+
+# OSFSFactory.getBufferedReader — error (path arg)
+log.fs.os_factory_get_reader_error = Failed to get buffered reader for {}. Please check your dependency of object storage module.
+
+# OSFSFactory.getBufferedWriter — error (path arg)
+log.fs.os_factory_get_writer_error = Failed to get buffered writer for {}. Please check your dependency of object storage module.
+
+# OSFSFactory.getBufferedInputStream — error (path arg)
+log.fs.os_factory_get_input_stream_error = Failed to get buffered input stream for {}. Please check your dependency of object storage module.
+
+# OSFSFactory.getBufferedOutputStream — error (path arg)
+log.fs.os_factory_get_output_stream_error = Failed to get buffered output stream for {}. Please check your dependency of object storage module.
+
+# OSFSFactory.listFilesBySuffix — error (folder, suffix args)
+log.fs.os_factory_list_suffix_error = Failed to list files in {} with SUFFIX {}. Please check your dependency of object storage module.
+
+# OSFSFactory.listFilesByPrefix — error (folder, prefix args)
+log.fs.os_factory_list_prefix_error = Failed to list files in {} with PREFIX {}. Please check your dependency of object storage module.
+
+# OSFSFactory.copyFile — unsupported copy direction (srcType, destType args)
+error.fs.os_factory_copy_unsupported = Doesn't support copy file from %1$s to %2$s.
+
+# LocalFSFactory — buffered reader/writer/stream errors (4 sites, 4 keys)
+log.fs.local_factory_get_reader_error = Failed to get buffered reader for {}.
+log.fs.local_factory_get_writer_error = Failed to get buffered writer for {}.
+log.fs.local_factory_get_input_stream_error = Failed to get buffered input stream for {}.
+log.fs.local_factory_get_output_stream_error = Failed to get buffered output stream for {}.
+
+# HybridFSFactory.moveFile — unsupported cross-type move (srcType, destType args)
+error.fs.hybrid_factory_move_unsupported = Doesn't support move file from %1$s to %2$s.
+
+# HybridFSFactory.copyFile — unsupported cross-type copy (srcType, destType args)
+error.fs.hybrid_factory_copy_unsupported = Doesn't support move file from %1$s to %2$s.
+
+# OSFileInputFactory / HDFSInputFactory — init error
+log.fs.os_input_factory_init_error = Failed to get OSInput in object storage. Please check your dependency of object storage module.
+log.fs.hdfs_input_factory_init_error = Failed to get HDFSInput in Hadoop file system. Please check your dependency of Hadoop module.
+
+# OSFileInputFactory.getTsFileInput — error (path arg)
+error.fs.os_input_factory_get_error = Failed to get TsFile input of file: %1$s. Please check your dependency of object storage module.
+
+# HDFSInputFactory.getTsFileInput — error (path arg)
+error.fs.hdfs_input_factory_get_error = Failed to get TsFile input of file: %1$s. Please check your dependency of Hadoop module.
+
+# FSUtils — load file system class error (fsType name arg)
+log.fs.fsutils_load_class_error = Failed to get {} file system. Please check your dependency of {} module.
+
+# === utils ===
+
+# NoSyncBufferedOutputStream — buffer size <= 0
+error.utils.buffer_size_not_positive = Buffer size <= 0
+
+# NoSyncBufferedInputStream — stream closed (2 sites, 1 key)
+error.utils.stream_closed = Stream closed
+
+# NoSyncBufferedInputStream — buffer size <= 0
+error.utils.buffer_size_not_positive_input = Buffer size <= 0
+
+# NoSyncBufferedInputStream — index out of bounds
+error.utils.index_out_of_bounds_read = Index out of bounds
+
+# NoSyncBufferedInputStream — resetting to invalid mark
+error.utils.reset_invalid_mark = Resetting to invalid mark
+
+# PublicBAOS — index out of bounds
+error.utils.public_baos_index_out_of_bounds = Index out of bounds
+
+# Loader — null input object
+error.utils.loader_null_input = Input object cannot be null
+
+# FilterDeserialize — unsupported operator type (type arg)
+error.utils.filter_unsupported_operator_type = Unsupported operator type:%1$s
+
+# FilterDeserialize — unsupported class serialize id (used for 15 methods via constant; id arg)
+error.utils.filter_unsupported_class_id = Unsupported class serialize id:%1$s
+
+# ReadWriteForEncodingUtils — too many bytes for bit width (paddedByteNum arg; 4 sites, 1 key)
+error.utils.too_long_byte_format = Too long byte number %1$s
+
+# BytesUtils — invalid input: desc.length - offset < 4 (intToBytes float variant)
+error.utils.bytes_desc_offset_too_short = Invalid input: desc.length - offset < 4
+
+# BytesUtils — invalid input: i > 0xFFFF
+error.utils.bytes_int_too_large = Invalid input: %1$s > 0xFFFF
+
+# BytesUtils — invalid input: ret.length != 2
+error.utils.bytes_ret_length_not_two = Invalid input: ret.length != 2
+
+# BytesUtils — row count too large
+error.utils.bytes_row_count_too_large = Row count is larger than Integer.MAX_VALUE
+
+# BytesUtils — invalid input: bytes.length - offset < 4
+error.utils.bytes_offset_too_short_4 = Invalid input: bytes.length - offset < 4
+
+# BytesUtils — invalid input: b.length != 4
+error.utils.bytes_b_length_not_four = Invalid input: b.length != 4
+
+# BytesUtils — invalid input: b.length - offset < 4
+error.utils.bytes_b_offset_too_short_4 = Invalid input: b.length - offset < 4
+
+# BytesUtils — invalid input: bytes.length - offset < 8
+error.utils.bytes_offset_too_short_8 = Invalid input: bytes.length - offset < 8
+
+# BytesUtils — invalid input: b.length != 1
+error.utils.bytes_b_length_not_one = Invalid input: b.length != 1
+
+# BytesUtils — invalid input: b.length - offset < 1
+error.utils.bytes_b_offset_too_short_1 = Invalid input: b.length - offset < 1
+
+# BytesUtils — invalid input: byteNum.length - offset < len
+error.utils.bytes_bytenum_offset_too_short = Invalid input: byteNum.length - offset < len
+
+# BytesUtils.intToBytes — cannot convert int to byte array (3 args: srcNum, pos, width)
+log.utils.bytes_int_to_bytes_error = tsfile-common BytesUtils: cannot convert an integer {} to a byte array, pos {}, width {}
+
+# BytesUtils.longToBytes — cannot convert long to byte array (3 args: srcNum, pos, width)
+log.utils.bytes_long_to_bytes_error = tsfile-common BytesUtils: cannot convert a long {} to a byte array, pos {}, width {}
+
+# TsFileSketchTool — cannot load file (filename arg)
+error.utils.sketch_tool_cannot_load = Cannot load file %1$s because the file has crashed.
+
+# ReadWriteIOUtils — short read (expectedLen, readLen args; 7 sites use String.format directly)
+error.utils.rwio_short_read = Intend to read %1$d bytes but %2$d are actually returned
+
+# ReadWriteIOUtils — string list must not be null (2 sites, 1 key)
+error.utils.rwio_stringlist_null = stringList must not be null!
+
+# ReadWriteIOUtils — set must not be null (2 sites via SET_NOT_NULL_MSG constant)
+error.utils.rwio_set_null = set must not be null!
+
+# StringContainer — index out of bounds (getSubString; 1 site)
+error.utils.string_container_index_out_of_bounds = Index: %1$d, Real Index: %2$d, Size: %3$d
+
+# StringContainer — start index out of bounds (getSubStringContainer)
+error.utils.string_container_start_index_out_of_bounds = start Index: %1$d, Real start Index: %2$d, Size: %3$d
+
+# StringContainer — end index out of bounds (getSubStringContainer)
+error.utils.string_container_end_index_out_of_bounds = end Index: %1$d, Real end Index: %2$d, Size: %3$d
+
+# TimeDuration — unsupported operation
+error.utils.time_duration_unsupported = unsupported operation
+
+# DateUtils — date expression null or empty (2 sites, 1 key)
+error.utils.date_expression_null_or_empty = Date expression is null or empty.
+
+# DateUtils — invalid date format (parse exception)
+error.utils.date_invalid_format = Invalid date format. Please use YYYY-MM-DD format.
+
+# DateUtils — year out of range (dateExpression arg)
+error.utils.date_year_out_of_range = Year must be between 1000 and 9999.
+
+# DateUtils — invalid date format (parseIntToLocalDate)
+error.utils.date_invalid_format_local = Invalid date format.
+
+# TsFileGeneratorUtils — invalid input (value arg)
+error.utils.generator_invalid_input = Invalid input: %1$s
+
+# FSUtils — failed to get file system (fsType name arg — used with string concat in original)
+log.fs.fsutils_class_not_found = Failed to get {} file system. Please check your dependency of {} module.

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
@@ -19,3 +19,41 @@
 
 # Seed entry used by MessagesTest. Real entries are added by migration tasks.
 test.seed = 你好 %1$s
+
+# === common ===
+
+# TSDataType
+error.common.invalid_input = Invalid input: %1$s
+
+# RamUsageEstimator
+error.common.no_array_classes = This method does not work with array classes.
+
+# TsPrimitiveType — unsupported data type (typo fixed: added space after colon)
+error.common.unsupported_data_type = Unsupported data type: %1$s
+
+# TsPrimitiveType — get/set operations not supported for sub-class (14 sites collapsed to 1 key)
+error.common.subclass_op_not_supported = %1$s is not supported for current sub-class
+
+# TsPrimitiveType — wrong value type passed to setObject (7 sites collapsed to 1 key)
+error.common.tsprimitive_wrong_value_type = %1$s can only be set %2$s value
+
+# TsBlockBuilderStatus
+error.common.bytes_cannot_be_negative = bytes cannot be negative
+
+# ColumnEncoding
+error.common.invalid_column_encoding_value = Invalid value: %1$s
+
+# ColumnBuilderStatus
+error.common.cannot_determine_size_array = Cannot determine size of %1$s because it contains an array
+error.common.class_is_interface = %1$s is an interface
+error.common.class_is_abstract = %1$s is abstract
+error.common.cannot_determine_size_subclass = Cannot determine size of a subclass. %1$s extends from %2$s
+
+# BitMap
+error.common.bitmap_range_size_exceeds = range size %1$s should <= the minimal bitmap size %2$s
+error.common.bitmap_start_length_out_of_range = startPosition %1$s + length %2$s is out of range %3$s
+error.common.bitmap_out_of_src_range = %1$s is out of src range %2$s
+error.common.bitmap_out_of_dest_range = %1$s is out of dest range %2$s
+
+# TSDataType
+error.common.unsupported_cast = Unsupported cast: from %1$s to %2$s

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
@@ -1349,3 +1349,190 @@ error.utils.generator_invalid_input = Invalid input: %1$s
 
 # FSUtils — failed to get file system (fsType name arg — used with string concat in original)
 log.fs.fsutils_class_not_found = Failed to get {} file system. Please check your dependency of {} module.
+
+# === tools ===
+
+# ArrowSourceReader / ParquetSourceReader / CsvSourceReader — inferSchema called in schema mode
+error.tools.infer_schema_not_in_auto_mode = inferSchema() is only available in auto mode
+
+# CsvSourceReader.inferSchema — inferSchema called in schema mode (more descriptive variant)
+error.tools.infer_schema_not_in_auto_mode_csv = inferSchema() is only available in auto mode (no schema provided)
+
+# ArrowSourceReader / ParquetSourceReader / CsvSourceReader — failed to infer schema
+error.tools.infer_schema_failed = Failed to infer schema from: %1$s
+
+# CsvSourceReader.inferSchema — CSV file is empty
+error.tools.csv_file_empty = CSV file is empty: %1$s
+
+# CsvSourceReader.validateColumnCount — column count mismatch
+error.tools.csv_column_count_mismatch = Column count mismatch: schema defines %1$s columns but CSV header has %2$s columns in %3$s
+
+# TimeConverter — time value cannot be null (2 sites, 1 key)
+error.tools.time_value_null = Time value cannot be null
+
+# TimeConverter.toNanos / fromNanos — unknown precision (2 sites, 1 key)
+error.tools.unknown_precision = Unknown precision: %1$s
+
+# TsFileTool.parseBlockSize — unsupported block_size unit
+error.tools.block_size_unsupported_unit = block_size only supports units of K, M, G, or numbers
+
+# SchemaParser.parseIdColumns — invalid id_columns format
+error.tools.schema_id_columns_invalid = The data format of id_columns is incorrect
+
+# SchemaParser.parseCsvColumns — invalid csv_columns format
+error.tools.schema_csv_columns_invalid = The data format of csv_columns is incorrect
+
+# SchemaParser — has_header not true/false
+error.tools.schema_has_header_invalid = The data format of has_header is incorrect
+
+# SchemaParser.validateParams — time_precision not supported
+error.tools.schema_time_precision_unsupported = The time_precision parameter only supports ms,us,ns
+
+# SchemaParser.validateParams — separator invalid
+error.tools.schema_separator_invalid = separator must be ",", tab, or ";"
+
+# SchemaParser.validateParams — table_name required
+error.tools.schema_table_name_required = table_name is required
+
+# SchemaParser.validateParams — id_columns required
+error.tools.schema_id_columns_required = id_columns is required
+
+# SchemaParser.validateParams — csv_columns required
+error.tools.schema_csv_columns_required = csv_columns is required
+
+# SchemaParser.validateParams — time_column required
+error.tools.schema_time_column_required = time_column is required
+
+# SchemaParser.validateParams — time_column value not in csv_columns
+error.tools.schema_time_column_not_in_csv = The value %1$s of time_column is not in csv_columns
+
+# SchemaParser.validateParams — id_columns value not in csv_columns
+error.tools.schema_id_column_not_in_csv = The value %1$s of id_columns is not in csv_columns
+
+# ImportSchemaParser — has_header not true/false
+error.tools.import_has_header_invalid = has_header must be true or false
+
+# ImportSchemaParser.parseTagColumn — invalid tag_columns format
+error.tools.import_tag_columns_invalid = Invalid tag_columns format: %1$s
+
+# ImportSchemaParser.parseSourceColumn — invalid source_columns format
+error.tools.import_source_columns_invalid = Invalid source_columns format: %1$s
+
+# ImportSchemaParser.resolveDataType — unknown data type
+error.tools.import_unknown_data_type = Unknown data type: %1$s
+
+# ImportSchemaParser.validate — time_precision not supported
+error.tools.import_time_precision_unsupported = time_precision must be ms, us, ns, or s
+
+# ImportSchemaParser.validate — separator invalid
+error.tools.import_separator_invalid = separator must be ",", tab, or ";"
+
+# ImportSchemaParser.validate — table_name required
+error.tools.import_table_name_required = table_name is required
+
+# ImportSchemaParser.validate — time_column required
+error.tools.import_time_column_required = time_column is required
+
+# ImportSchemaParser.validate — source_columns required
+error.tools.import_source_columns_required = source_columns is required
+
+# ImportSchemaParser.validate — time_column not found in source_columns
+error.tools.import_time_column_not_found = time_column '%1$s' not found in source_columns
+
+# ImportSchemaParser.validate — tag_columns entry not found in source_columns
+error.tools.import_tag_column_not_found = tag_columns '%1$s' not found in source_columns
+
+# AutoSchemaInferer.detectTimeColumn — no time column found
+error.tools.auto_no_time_column = No time column found. Auto mode requires exactly one column named 'time' or 'TIME'.
+
+# AutoSchemaInferer.detectTimeColumn — ambiguous time column
+error.tools.auto_ambiguous_time_column = Ambiguous time column: found multiple columns matching 'time'/'TIME': %1$s
+
+# TabletBuilder.resolveTimeColumnIndex — time column not found in source columns
+error.tools.tablet_time_column_not_found = Time column '%1$s' not found in source columns
+
+# DateTimeUtils.convertDatetimeStrToLong — failed to convert timestamp (depth >= 2)
+error.tools.datetime_convert_failed = Failed to convert %1$s to millisecond, zone offset is %2$s, please input like 2011-12-03T10:15:30 or 2011-12-03T10:15:30+01:00
+
+# DateTimeUtils.convertDatetimeStrToLong — time-region not supported
+error.tools.datetime_time_region_unsupported = %1$s with [time-region] at end is not supported now, please input like 2011-12-03T10:15:30 or 2011-12-03T10:15:30+01:00
+
+# --- tools LOG messages ---
+
+# ImportExecutor — failed to create output directory
+log.tools.executor_create_dir_failed = Failed to create output directory: %1$s
+
+# ImportExecutor — failed to write chunk
+log.tools.executor_write_chunk_failed = Failed to write chunk %1$s to %2$s
+
+# ImportExecutor — no data read from source
+log.tools.executor_no_data = No data read from source: %1$s
+
+# ImportExecutor — failed to rename indexed file to single name
+log.tools.executor_rename_failed = Failed to rename %1$s to %2$s
+
+# ImportExecutor.writeTsFile — failed to write file
+log.tools.executor_write_file_failed = Failed to write file: %1$s
+
+# ImportExecutor.writeTsFile — failed to close file
+log.tools.executor_close_file_failed = Failed to close file: %1$s
+
+# ImportExecutor.deleteFile — failed to delete file
+log.tools.executor_delete_failed = Failed to delete: %1$s
+
+# TsFileTool — failed to parse schema file
+log.tools.tool_parse_schema_failed = Failed to parse schema file: %1$s
+
+# TsFileTool — failed to await termination
+log.tools.tool_await_termination_failed = Failed to await termination
+
+# TsFileTool — directory or file has completed execution
+log.tools.tool_execution_completed = The %1$s directory or file has completed execution
+
+# TsFileTool — failed to process file
+log.tools.tool_process_file_failed = Failed to process file: %1$s
+
+# TsFileTool — file successfully generated
+log.tools.tool_file_generated = %1$s.tsfile successfully generated
+
+# TsFileTool — failed to copy file
+log.tools.tool_copy_file_failed = Failed to copy file: %1$s
+
+# TsFileTool — error parsing command line options
+log.tools.tool_parse_cli_error = Error parsing command line options
+
+# TsFileTool.validateParams — source is required
+log.tools.tool_source_required = Missing required parameters. --source/-s is required
+
+# TsFileTool.validateParams — target is required
+log.tools.tool_target_required = Missing required parameters. --target/-t is required
+
+# TsFileTool.validateParams — source does not exist
+log.tools.tool_source_not_exist = %1$s directory or file does not exist.
+
+# TsFileTool.validateParams — schema file does not exist
+log.tools.tool_schema_not_exist = %1$s schema file does not exist.
+
+# TsFileTool.validateParams — invalid thread number
+log.tools.tool_invalid_thread_num = Invalid thread number. Thread number must be greater than 0.
+
+# ArrowSourceReader — error reading Arrow file
+log.tools.arrow_read_error = Error reading Arrow file: %1$s
+
+# ArrowSourceReader — error closing Arrow reader
+log.tools.arrow_close_reader_error = Error closing Arrow reader
+
+# ArrowSourceReader — error closing FileInputStream
+log.tools.arrow_close_stream_error = Error closing FileInputStream
+
+# ParquetSourceReader — error reading Parquet file
+log.tools.parquet_read_error = Error reading Parquet file: %1$s
+
+# ParquetSourceReader — error closing Parquet reader
+log.tools.parquet_close_reader_error = Error closing Parquet reader
+
+# CsvSourceReader — error reading CSV file
+log.tools.csv_read_error = Error reading CSV file: %1$s
+
+# CsvSourceReader — error closing CSV reader
+log.tools.csv_close_reader_error = Error closing CSV reader

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
@@ -870,3 +870,190 @@ log.file.device_id_serialize_failed = Failed to serialize device ID: {}
 
 # Statistics — statistics classes mismatched, no merge
 log.file.stats_classes_mismatched = Statistics classes mismatched,no merge: {} v.s. {}
+
+# === external ===
+
+# ArrayUtils.remove — index out of bounds
+error.external.array_index_out_of_bounds = Index: %1$s, Length: %2$s
+
+# ArrayUtils.addAll — incompatible array types
+error.external.array_incompatible_types = Cannot store %1$s in an array of %2$s
+
+# Validate.isTrue() — default false expression
+error.external.validate_expression_false = The validated expression is false
+
+# Validate.isTrue(boolean, String, long) — formatted message with long value
+error.external.validate_size_too_large = Request %1$,d exceeds maximum %2$,d
+
+# IOUtils.toByteArray — cannot read more than max bytes
+error.external.io_cannot_read_max_bytes = Cannot read more than %1$,d into a byte array
+
+# IOUtils.toByteArray — size must be non-negative
+error.external.io_size_non_negative = Size must be equal or greater than zero: %1$s
+
+# IOUtils.toByteArray — unexpected read size
+error.external.io_unexpected_read_size = Unexpected read size, current: %1$s, expected: %2$s
+
+# IOUtils.toString — null input stream supplier
+error.external.io_null_input = input
+
+# FileUtils.requireDirectoryExists — not a directory
+error.external.file_not_a_directory = Parameter '%1$s' is not a directory: '%2$s'
+
+# FileUtils.requireDirectoryExists — directory does not exist
+error.external.file_directory_not_exist = Directory '%1$s' does not exist.
+
+# FileUtils.listFiles — I/O error listing directory
+error.external.file_list_io_error = Unknown I/O error listing contents of directory: %1$s
+
+# FileUtils.forceDelete — cannot delete file
+error.external.file_cannot_delete = Cannot delete file: %1$s
+
+# FileUtils.forceDelete — file does not exist
+error.external.file_not_exist = File does not exist: %1$s
+
+# FileUtils.moveFile — failed to delete original after copy
+error.external.file_move_delete_original = Failed to delete original file '%1$s' after copy to '%2$s'
+
+# FileUtils.checkFileExists — not a file
+error.external.file_param_not_a_file = Parameter '%1$s' is not a file: %2$s
+
+# FileUtils.checkFileExists — source does not exist
+error.external.file_source_not_exist = Source '%1$s' does not exist
+
+# FileUtils.requireAbsent — file already exists
+error.external.file_already_exists = File element in parameter '%1$s' already exists: '%2$s'
+
+# FileUtils.copyFile — cannot set file time
+error.external.file_cannot_set_time = Cannot set the file time.
+
+# FileUtils.requireCanonicalPathsNotEquals — canonical paths equal
+error.external.file_canonical_paths_equal = File canonical paths are equal: '%1$s' (file1='%2$s', file2='%3$s')
+
+# FileUtils.mkdirs — cannot create directory
+error.external.file_cannot_create_directory = Cannot create directory '%1$s'.
+
+# FileUtils.requireExistsChecked — file system element does not exist
+error.external.file_element_not_exist = File system element for parameter '%1$s' does not exist: '%2$s'
+
+# FileUtils.moveDirectory — cannot move to subdirectory of itself
+error.external.file_move_to_subdirectory = Cannot move directory: %1$s to a subdirectory of itself: %2$s
+
+# FileUtils.moveDirectory — failed to delete original directory after copy
+error.external.file_move_delete_directory = Failed to delete original directory '%1$s' after copy to '%2$s'
+
+# FileUtils.requireCanWrite — file is not writable
+error.external.file_not_writable = File parameter '%1$s is not writable: '%2$s'
+
+# FilenameUtils.requireNonNullChars — null character in path
+error.external.filename_null_char = Null character present in file/path name. There are no known legitimate use cases for such data, but several injection attacks may use it
+
+# FilenameUtils.indexOfExtension — NTFS ADS separator in file name
+error.external.filename_ntfs_ads_forbidden = NTFS ADS separator (':') in file name is forbidden.
+
+# FilenameUtils.flipSeparator — invalid separator character
+error.external.filename_invalid_separator = %1$s
+
+# PathUtils.setReadOnly — DOS or POSIX not available
+error.external.path_file_ops_not_available = DOS or POSIX file operations not available for '%1$s', linkOptions %2$s
+
+# PathUtils.deleteFile — is a directory, not a file
+error.external.path_is_directory = %1$s
+
+# PathUtils.deleteFile — I/O error
+error.external.path_set_readonly_io_error = DOS or POSIX file operations not available for '%1$s', linkOptions %2$s
+
+# ReaderInputStream.checkMinBufferSize — buffer too small
+error.external.reader_input_stream_buffer_too_small = Buffer size %1$,d must be at least %2$s for a CharsetEncoder %3$s.
+
+# ReaderInputStream.read — index out of bounds
+error.external.reader_input_stream_index_out_of_bounds = Array size=%1$s, offset=%2$s, length=%3$s
+
+# UnsynchronizedByteArrayInputStream — length cannot be negative
+error.external.ubais_length_negative = length cannot be negative
+
+# UnsynchronizedByteArrayInputStream — offset cannot be negative
+error.external.ubais_offset_negative = offset cannot be negative
+
+# UnsynchronizedByteArrayInputStream.skip — skipping backward not supported
+error.external.ubais_skip_backward = Skipping backward is not supported
+
+# UnsynchronizedByteArrayOutputStream — negative initial size
+error.external.ubaos_negative_initial_size = Negative initial size: %1$s
+
+# UnsynchronizedByteArrayOutputStream.write — offset/length out of bounds
+error.external.ubaos_offset_length_out_of_bounds = offset=%1$,d, length=%2$,d
+
+# WriterOutputStream — UTF-16 IBM JDK broken support
+error.external.writer_output_stream_utf16_ibm = UTF-16 requested when running on an IBM JDK with broken UTF-16 support. Please find a JDK that supports UTF-16 if you intend to use UF-16 with WriterOutputStream
+
+# WriterOutputStream.processInput — unexpected coder result
+error.external.writer_output_stream_unexpected_coder = Unexpected coder result
+
+# AbstractOrigin.getFile — not supported
+error.external.abstract_origin_get_file = %1$s#getFile() for %2$s origin %3$s
+
+# AbstractOrigin.getPath — not supported
+error.external.abstract_origin_get_path = %1$s#getPath() for %2$s origin %3$s
+
+# AbstractStreamBuilder.throwIae — request exceeds maximum
+error.external.stream_builder_request_exceeds_max = Request %1$,d exceeds maximum %2$,d
+
+# AbstractOriginSupplier.checkOrigin — origin is null
+error.external.origin_null = origin == null
+
+# AbstractEmptyMapIterator — iterator contains no elements
+error.external.empty_map_iterator_no_elements = Iterator contains no elements
+
+# AbstractEmptyIterator — iterator contains no elements
+error.external.empty_iterator_no_elements = Iterator contains no elements
+
+# AbstractLinkedMap — map is empty (first/last)
+error.external.linked_map_empty = Map is empty
+
+# AbstractLinkedMap — index less than zero
+error.external.linked_map_index_negative = Index %1$s is less than zero
+
+# AbstractLinkedMap — index invalid for size
+error.external.linked_map_index_invalid = Index %1$s is invalid for size %2$s
+
+# AbstractHashedMap — initial capacity negative
+error.external.hashed_map_capacity_negative = Initial capacity must be a non negative number
+
+# AbstractHashedMap — load factor not positive
+error.external.hashed_map_load_factor_invalid = Load factor must be greater than 0
+
+# AbstractHashedMap constants — iterator state errors
+error.external.map_no_next_entry = No next() entry in the iteration
+error.external.map_no_previous_entry = No previous() entry in the iteration
+error.external.map_remove_invalid = remove() can only be called once after next()
+error.external.map_getkey_invalid = getKey() can only be called after next() and before remove()
+error.external.map_getvalue_invalid = getValue() can only be called after next() and before remove()
+error.external.map_setvalue_invalid = setValue() can only be called after next() and before remove()
+
+# LRUMap — max size constraint
+error.external.lrumap_max_size_positive = LRUMap max size must be greater than 0
+
+# LRUMap — initial size vs max size constraint (note: typo "greather" preserved)
+error.external.lrumap_initial_exceeds_max = LRUMap initial size must not be greather than max size
+
+# LRUMap.moveToMRU — entry.before is null
+error.external.lrumap_entry_before_null = Entry.before is null. This should not occur if your keys are immutable, and you have used synchronization properly.
+
+# LRUMap.moveToMRU — cannot move header to MRU
+error.external.lrumap_cannot_move_header = Can't move header to MRU This should not occur if your keys are immutable, and you have used synchronization properly.
+
+# LRUMap.addMapping — entry.after is null (scanUntilRemovable path)
+error.external.lrumap_entry_after_null = Entry.after=null, header.after=%1$s header.before=%2$s key=%3$s value=%4$s size=%5$s maxSize=%6$s This should not occur if your keys are immutable, and you have used synchronization properly.
+
+# LRUMap.addMapping — reuse is null
+error.external.lrumap_reuse_null = reuse=null, header.after=%1$s header.before=%2$s key=%3$s value=%4$s size=%5$s maxSize=%6$s This should not occur if your keys are immutable, and you have used synchronization properly.
+
+# LRUMap.reuseMapping — loop is null (entry not found)
+error.external.lrumap_loop_null = Entry.next=null, data[removeIndex]=%1$s previous=%2$s key=%3$s value=%4$s size=%5$s maxSize=%6$s This should not occur if your keys are immutable, and you have used synchronization properly.
+
+# LRUMap.reuseMapping — NullPointerException
+error.external.lrumap_npe = NPE, entry=%1$s entryIsHeader=%2$s key=%3$s value=%4$s size=%5$s maxSize=%6$s This should not occur if your keys are immutable, and you have used synchronization properly.
+
+# ComparatorChain.checkChainIntegrity — must contain at least one comparator
+error.external.comparator_chain_empty = ComparatorChains must contain at least one Comparator

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
@@ -57,3 +57,198 @@ error.common.bitmap_out_of_dest_range = %1$s is out of dest range %2$s
 
 # TSDataType
 error.common.unsupported_cast = Unsupported cast: from %1$s to %2$s
+
+# === write ===
+
+# DataPoint — set<Type> not supported (7 sites collapsed to 1 key; arg = type name)
+error.write.datapoint_set_not_supported = set %1$s not support in DataPoint
+
+# DataPoint / Tablet / AlignedChunkGroupWriterImpl / NonAlignedChunkGroupWriterImpl / TableTsBlock2TsFileWriter
+# — "Data type X is not supported." (many sites collapsed to 1 key)
+error.write.type_not_supported = Data type %1$s is not supported.
+
+# DataPoint — type/value mismatch in getDataPoint
+error.write.datapoint_type_value_mismatch = Data type of %1$s is %2$s, but input value is %3$s
+
+# Tablet.addValue(rowIndex, indexOfSchema, Object) — wrong Java type for column type (7 sites collapsed to 1 key)
+error.write.tablet_expected_type = Expected value of type %1$s for data type %2$s, but got %3$s
+
+# Tablet.addValue(rowIndex, columnIndex, primitiveVal) — wrong array type (7 sites collapsed to 1 key)
+error.write.tablet_col_wrong_type = The data type of column index %1$s is not %2$s
+
+# Tablet — null measurement argument
+error.write.tablet_null_measurement = measurement should be non null value
+
+# Tablet — measurement not found
+error.write.tablet_no_measurement = No measurement for %1$s
+
+# Tablet.getValue — unsupported data type
+error.write.tablet_unsupported_type = Unsupported type: %1$s
+
+# Tablet.readvaluesFromBuffer — unsupported type at client
+error.write.tablet_client_type_not_supported = data type %1$s is not supported when convert data at client
+
+# VectorMeasurementSchema — getCompressor deprecated method
+error.write.schema_vector_aligned_no_compressor = Aligned series should not invoke this method
+
+# VectorMeasurementSchema — unsupported method (4 sites collapsed to 1 key)
+error.write.schema_vector_method_unsupported = unsupported method for VectorMeasurementSchema
+
+# VectorMeasurementSchema — unexpected end of stream
+error.write.schema_vector_unexpected_end_of_stream = Unexpected end of stream when reading compressors
+
+# MeasurementSchema — unsupported method (4 sites collapsed to 1 key)
+error.write.schema_measurement_method_unsupported = unsupported method for MeasurementSchema
+
+# MeasurementSchemaBuilder — validation errors
+error.write.schema_builder_null_name = Measurement name cannot be null or empty
+error.write.schema_builder_null_type = Data type cannot be null
+error.write.schema_builder_null_property = Property key and value cannot be null
+
+# ValueChunkWriter / ChunkWriterImpl / TimeChunkWriter — page header IO exception (3 files, 1 key)
+error.write.page_write_header_io_exception = IO Exception in writeDataPageHeader,ignore this page
+
+# ValueChunkWriter / ChunkWriterImpl / TimeChunkWriter — written bytes inconsistent (3 files, 1 key)
+error.write.chunk_bytes_inconsistent = Bytes written is inconsistent with the size of data: %1$s != %2$s
+
+# AlignedChunkWriterImpl — unknown data type
+error.write.chunk_unknown_type = Unknown data type %1$s
+
+# AlignedChunkGroupWriterImpl — out-of-order write (aligned)
+error.write.chunk_group_aligned_out_of_order = Not allowed to write out-of-order data in timeseries %1$s%2$s%3$s, time should later than %4$s
+
+# NonAlignedChunkGroupWriterImpl — out-of-order write
+error.write.chunk_group_non_aligned_out_of_order = Not allowed to write out-of-order data in timeseries %1$s%2$s%3$s, time should later than %4$s
+
+# TsFileWriter — file writer cannot write
+error.write.tsfile_writer_cannot_write = the given file Writer does not support writing any more. Maybe it is an complete TsFile
+
+# TsFileWriter — page size too large vs chunk group size
+error.write.tsfile_writer_page_size_too_large = Invalid memory threshold configuration: page size %1$d must be smaller than chunk group size %2$d. Please either increase the chunk group size or decrease the page size.
+
+# TsFileWriter — template not found
+error.write.tsfile_writer_template_not_found = given template is not existed! %1$s
+
+# TsFileWriter — device already registered (via template)
+error.write.tsfile_writer_device_registered = this device %1$s has been registered, you can only use registerDevice method to register empty device.
+
+# TsFileWriter — nonAligned timeseries trying to register on already-aligned device
+error.write.tsfile_writer_timeseries_registered_aligned = given device %1$s has been registered for aligned timeseries.
+
+# TsFileWriter — timeseries already registered (nonAligned)
+error.write.tsfile_writer_timeseries_registered = given nonAligned timeseries %1$s has been registered.
+
+# TsFileWriter — aligned device cannot be expanded
+error.write.tsfile_writer_device_aligned_no_expand = given device %1$s has been registered for aligned timeseries and should not be expanded.
+
+# TsFileWriter — trying to register nonAligned on already-nonAligned device
+error.write.tsfile_writer_device_registered_nonaligned = given device %1$s has been registered for nonAligned timeseries.
+
+# TsFileWriter — new measurement after flush
+error.write.tsfile_writer_new_measurement = TsFile has flushed chunk group and should not add new measurement %1$s in device %2$s
+
+# TsFileWriter / AbstractTableModelTsFileWriter — flush size inconsistent
+error.write.tsfile_writer_flush_inconsistent = Flushed data size is inconsistent with computation! Estimated: %1$d, Actual: %2$d
+
+# RestorableTsFileIOWriter — incompatible file format
+error.write.restorable_writer_not_compatible = %1$s is not in TsFile format.
+
+# ForceAppendTsFileWriter — not a complete TsFile
+error.write.force_append_not_complete = File %1$s is not a complete TsFile
+
+# DiskTSMIterator — read size mismatch
+error.write.disk_tsm_read_size_mismatch = Expected to read %1$s bytes, but actually read %2$s bytes
+
+# DeviceTableModelWriter / v4 — table name is null
+error.write.v4_table_name_null = Table name is null
+
+# TableTsBlock2TsFileWriter — null value in time column
+error.write.v4_all_time_null = All values in time column should not be null
+
+# TsFileTreeWriter — delegate error messages
+error.write.v4_tree_writer_register_failed = Failed to register timeseries for device %1$s
+error.write.v4_tree_writer_register_aligned_failed = Failed to register aligned timeseries for device %1$s
+error.write.v4_tree_writer_write_tablet_failed = Failed to write tablet data
+error.write.v4_tree_writer_write_record_failed = Failed to write TSRecord
+error.write.v4_tree_writer_close_failed = Failed to close TsFileTreeWriter
+
+# TsFileTreeWriterBuilder — output file not specified
+error.write.v4_output_file_required = Output file must be specified
+
+# TsFileWriterBuilder — parameter validation
+error.write.v4_file_non_null = The file must be a non-null and non-directory File.
+error.write.v4_table_schema_non_null = TableSchema must not be null.
+error.write.v4_memory_threshold_positive = Memory threshold must be > 0 bytes.
+error.write.v4_table_name_blank = TableName must not be blank.
+error.write.v4_column_name_blank = Column name must not be blank.
+
+# --- write LOG messages ---
+
+# DataPoint subclasses — null IChunkWriter (7 files, 1 key)
+log.write.datapoint_chunk_writer_null = given IChunkWriter is null, do nothing and return
+
+# ChunkWriterImpl / TimeChunkWriter / ValueChunkWriter — upper bound hit (3 files, 1 key)
+log.write.chunk_writer_write_page = current line count reaches the upper bound, write page {}
+
+# ChunkWriterImpl / TimeChunkWriter / ValueChunkWriter — page write error (3 files, 1 key)
+log.write.chunk_writer_page_error = meet error in pageWriter.writePageHeaderAndDataIntoBuff,ignore this page:
+
+# AlignedChunkGroupWriterImpl / NonAlignedChunkGroupWriterImpl — flush device (2 files, 1 key)
+log.write.flush_device = start flush device id:{}
+
+# TsFileWriter / AbstractTableModelTsFileWriter — flush chunk groups (2 files, 1 key)
+log.write.flush_chunk_groups = start to flush chunk groups, memory space occupy:{}
+
+# TsFileWriter / AbstractTableModelTsFileWriter — close file (2 files, 1 key)
+log.write.close_file = start close file
+
+# AbstractTableModelTsFileWriter — close file exception (1 site)
+log.write.close_file_exception = Meet exception when close file writer.
+
+# TsFileWriter / AbstractTableModelTsFileWriter — page size vs chunk group size warn (2 files, 1 key)
+log.write.page_size_warn = TsFile's page size {} is greater than chunk group size {}, please enlarge the chunk group size or decrease page size.
+
+# TsFileWriter — ignore nonAligned measurement (1 site)
+log.write.ignore_nonaligned_measurement = Ignore nonAligned measurement {} , because it is not registered or in the default template
+
+# ForceAppendTsFileWriter / RestorableTsFileIOWriter — writer opened debug (2 files, 1 key)
+log.write.writer_opened = {} writer is opened.
+
+# TsFileIOWriter — start chunk group debug (1 site)
+log.write.start_chunk_group = start chunk group:{}, file position {}
+
+# TsFileIOWriter — start flush footer debug (1 site)
+log.write.start_flush_footer = start to flush the footer,file pos:{}
+
+# TsFileIOWriter — device timeseries metadata error (1 site)
+log.write.tsm_device_metadata_error = Failed to get device timeseries metadata map
+
+# TsFileIOWriter — flush metadata to temp file error (1 site)
+log.write.flush_metadata_exception = Meets exception when flushing metadata to temp file for {}
+
+# TsFileIOWriter — flushing series debug (1 site)
+log.write.flushing_series = Flushing {}
+
+# DiskTSMIterator — IOException reading timeseries metadata from disk (1 site)
+log.write.tsm_disk_read_error = Meets IOException when reading timeseries metadata from disk
+
+# ChunkWriterImpl / TimeChunkWriter / ValueChunkWriter — page header start (3 files, 1 key)
+log.write.page_header_flush_start = start to flush a page header into buffer, buffer position {}
+
+# ChunkWriterImpl / TimeChunkWriter / ValueChunkWriter — page header done (3 files, 1 key)
+log.write.page_header_flush_done = finish to flush a page header {} of {} into buffer, buffer position {}
+
+# TimeChunkWriter / ValueChunkWriter — page header done (time page variant, 2 files)
+log.write.page_header_flush_done_time = finish to flush a page header {} of time page into buffer, buffer position {}
+
+# ChunkWriterImpl / TimeChunkWriter / ValueChunkWriter — enough size, write page (3 files, 1 key)
+log.write.page_enough_size = enough size, write page {}, pageSizeThreshold:{}, currentPateSize:{}, valueCountInOnePage:{}
+
+# ValueChunkWriter variant of above (uses currentPageSize instead of currentPateSize)
+log.write.page_enough_size_value = enough size, write page {}, pageSizeThreshold:{}, currentPageSize:{}, valueCountInOnePage:{}
+
+# TsFileIOWriter — end flushing a chunk (1 site)
+log.write.end_flush_chunk = end flushing a chunk:{}, totalvalue:{}
+
+# TsFileIOWriter — flushing chunk metadata summary (1 site)
+log.write.flush_chunk_metadata = Flushing chunk metadata, total size is {}, count is {}, avg size is {}

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Seed entry used by MessagesTest. Real entries are added by migration tasks.
+test.seed = 你好 %1$s

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
@@ -252,3 +252,140 @@ log.write.end_flush_chunk = end flushing a chunk:{}, totalvalue:{}
 
 # TsFileIOWriter — flushing chunk metadata summary (1 site)
 log.write.flush_chunk_metadata = Flushing chunk metadata, total size is {}, count is {}, avg size is {}
+
+# === read.common ===
+
+# TimeRange — null input in compareTo
+error.read.timerange_null_input = The input cannot be null!
+
+# TimeRange — setMin/setMax invalid input
+error.read.timerange_invalid_input = Invalid input!
+
+# TimeRange — set(min, max) range violation
+error.read.timerange_min_gt_max = min:%1$s should not be larger than max: %2$s
+
+# Chunk — unsupported data type in rewrite (2 sites, 1 key)
+error.read.chunk_unsupported_type = Unsupported data type: %1$s
+
+# Chunk — NonAlignedChunk null value at timestamp
+error.read.chunk_non_aligned_null = NonAlignedChunk contains null, timestamp: %1$s
+
+# BatchDataFactory — instantiation guard
+error.read.factory_class = Factory class
+
+# Field — OBJECT type does not support getBinaryV
+error.read.field_object_type_no_binary = OBJECT Type only support getStringValue
+
+# Path — getFullPathWithAlias not supported
+error.read.path_no_alias = doesn't alias in TSFile Path
+
+# SignalBatchData — hasCurrent not supported
+error.read.signal_batch_data_no_has_current = hasCurrent is not supported for SignalBatchData
+
+# BatchData — unknown data type (2 sites, 1 key)
+error.read.batch_data_unknown_type = Unknown data type for BatchData:%1$s
+
+# BatchData — invalid input in deserialize
+error.read.batch_data_invalid_input = Invalid input: %1$s
+
+# TypeFactory — invalid TSDataType
+error.read.typefactory_invalid_tsdata_type = Invalid TSDataType for TypeFactory: %1$s
+
+# TypeFactory — invalid TypeEnum
+error.read.typefactory_invalid_type_enum = Invalid TypeEnum for TypeFactory: %1$s
+
+# TsBlockBuilder — unknown data type (2 sites, 1 key)
+error.read.tsblock_builder_unknown_type = Unknown data type: %1$s
+
+# TsBlockBuilder.build — declared positions mismatch (time column)
+error.read.tsblock_builder_time_mismatch = Declared positions (%1$s) does not match time column's number of entries (%2$s)
+
+# TsBlockBuilder.build — declared positions mismatch (value column)
+error.read.tsblock_builder_col_mismatch = Declared positions (%1$s) does not match column %2$s's number of entries (%3$s)
+
+# TsBlock.getRegion — invalid position/length
+error.read.tsblock_invalid_region = Invalid position %1$s and length %2$s in page with %3$s positions
+
+# TsBlock.subTsBlock — fromIndex over positionCount
+error.read.tsblock_from_index_over = FromIndex of subTsBlock cannot over positionCount.
+
+# TsBlock.determinePositionCount — columns is empty
+error.read.tsblock_columns_empty = columns is empty
+
+# TsBlock — unknown datatype in updateWithoutTimeColumn
+error.read.tsblock_unknown_datatype = Unknown datatype: %1$s
+
+# ColumnBuilder — type-specific unsupported data type (1 key per builder, 6 builders)
+error.read.col_builder_double_type = DoubleColumn only support Double data type
+error.read.col_builder_int_type = IntegerColumn only support Integer data type
+error.read.col_builder_float_type = FloatColumn only support Float data type
+error.read.col_builder_long_type = LongColumn only support Long data type
+error.read.col_builder_boolean_type = BooleanColumn only support Boolean data type
+error.read.col_builder_binary_type = BinaryColumn only support Binary data type
+
+# ColumnFactory — unsupported data type
+error.read.column_factory_unsupported_type = Unsupported data type: %1$s
+
+# TsBlockSerde — block too large
+error.read.tsblock_too_large = TsBlock should not be that large: %1$s
+
+# Shared column constructor checks (reused across multiple column classes)
+error.read.col_array_offset_negative = arrayOffset is negative
+error.read.col_position_count_negative = positionCount is negative
+error.read.col_values_length_lt_position = values length is less than positionCount
+error.read.col_isnull_length_lt_position = isNull length is less than positionCount
+error.read.col_ids_length_lt_position = ids length is less than positionCount
+
+# Shared fromIndex validation (reused across multiple column classes)
+error.read.col_from_index_invalid = fromIndex is not valid
+
+# TimeColumn — isNull not supported
+error.read.time_column_isnull_unsupported = isNull is not supported for TimeColumn
+
+# ColumnEncoderFactory — unsupported column encoding
+error.read.col_encoder_unsupported = Unsupported column encoding: %1$s
+
+# Int32/Int64/Binary/ByteArray array column encoders — invalid data type
+error.read.col_encoder_invalid_type = Invalid data type: %1$s
+
+# RunLengthEncodedColumn — expected single position
+error.read.rle_col_expected_single = Expected value to contain a single position but has %1$s positions
+
+# RunLengthEncodedColumn — setNull not supported
+error.read.rle_col_set_null_unsupported = set null of %1$s is not supported !
+
+# RunLengthColumnEncoder — nested RLE not supported
+error.read.rle_encoder_nested = Unable to encode a nested RLE column.
+
+# DictionaryColumn — sequential ids flag constraint
+error.read.dict_col_sequential_ids = sequential ids flag is only valid for compacted dictionary
+
+# DictionaryColumn — non-existent key reference (2 sites, 1 key)
+error.read.dict_col_nonexistent_key = reference to a non-existent key
+
+# DictionaryColumn — dictionary source ids mismatch
+error.read.dict_col_source_ids_mismatch = dictionarySourceIds must be the same
+
+# NullColumn — unknown data type
+error.read.null_col_unknown_type = Unknown data type: %1$s
+
+# ColumnUtil — invalid offset/length in array
+error.read.col_util_invalid_offset_length = Invalid offset %1$s and length %2$s in array with %3$s elements
+
+# ColumnUtil — invalid position/length in block
+error.read.col_util_invalid_pos_length = Invalid position %1$s and length %2$s in block with %3$s positions
+
+# ColumnUtil — invalid positions array size
+error.read.col_util_invalid_positions_size = Invalid positions array size %1$d, actual position count is %2$d
+
+# ColumnUtil — invalid position in block
+error.read.col_util_invalid_position = Invalid position %1$s in block with %2$s positions
+
+# ColumnUtil — cannot grow array
+error.read.col_util_cannot_grow = Cannot grow array beyond '%1$s'
+
+# TimeColumnBuilder — position not valid
+error.read.time_col_builder_position_invalid = position is not valid
+
+# PathParseError — syntax error with line and position
+error.read.path_parse_error = line %1$s:%2$s %3$s

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
@@ -23,769 +23,771 @@ test.seed = 你好 %1$s
 # === common ===
 
 # TSDataType
-error.common.invalid_input = Invalid input: %1$s
+error.common.invalid_input = 无效输入: %1$s
 
 # RamUsageEstimator
-error.common.no_array_classes = This method does not work with array classes.
+error.common.no_array_classes = 此方法不支持数组类
 
 # TsPrimitiveType — unsupported data type (typo fixed: added space after colon)
-error.common.unsupported_data_type = Unsupported data type: %1$s
+error.common.unsupported_data_type = 不支持的数据类型: %1$s
 
 # TsPrimitiveType — get/set operations not supported for sub-class (14 sites collapsed to 1 key)
-error.common.subclass_op_not_supported = %1$s is not supported for current sub-class
+error.common.subclass_op_not_supported = 当前子类不支持 %1$s
 
 # TsPrimitiveType — wrong value type passed to setObject (7 sites collapsed to 1 key)
-error.common.tsprimitive_wrong_value_type = %1$s can only be set %2$s value
+error.common.tsprimitive_wrong_value_type = %1$s 只能设置 %2$s 类型的值
 
 # TsBlockBuilderStatus
-error.common.bytes_cannot_be_negative = bytes cannot be negative
+error.common.bytes_cannot_be_negative = 字节数不能为负
 
 # ColumnEncoding
-error.common.invalid_column_encoding_value = Invalid value: %1$s
+error.common.invalid_column_encoding_value = 无效值: %1$s
 
 # ColumnBuilderStatus
-error.common.cannot_determine_size_array = Cannot determine size of %1$s because it contains an array
-error.common.class_is_interface = %1$s is an interface
-error.common.class_is_abstract = %1$s is abstract
-error.common.cannot_determine_size_subclass = Cannot determine size of a subclass. %1$s extends from %2$s
+error.common.cannot_determine_size_array = 无法确定 %1$s 的大小，因为它包含数组
+error.common.class_is_interface = %1$s 是接口
+error.common.class_is_abstract = %1$s 是抽象类
+error.common.cannot_determine_size_subclass = 无法确定子类的大小。%1$s 继承自 %2$s
 
 # BitMap
-error.common.bitmap_range_size_exceeds = range size %1$s should <= the minimal bitmap size %2$s
-error.common.bitmap_start_length_out_of_range = startPosition %1$s + length %2$s is out of range %3$s
-error.common.bitmap_out_of_src_range = %1$s is out of src range %2$s
-error.common.bitmap_out_of_dest_range = %1$s is out of dest range %2$s
+error.common.bitmap_range_size_exceeds = range size %1$s 应该 <= 最小的 bitmap size %2$s
+error.common.bitmap_start_length_out_of_range = startPosition %1$s + length %2$s 越界 %3$s
+error.common.bitmap_out_of_src_range = %1$s 超出源范围 %2$s
+error.common.bitmap_out_of_dest_range = %1$s 超出目标范围 %2$s
 
 # TSDataType
-error.common.unsupported_cast = Unsupported cast: from %1$s to %2$s
+error.common.unsupported_cast = 不支持的类型转换: 从 %1$s 到 %2$s
 
 # === write ===
 
 # DataPoint — set<Type> not supported (7 sites collapsed to 1 key; arg = type name)
-error.write.datapoint_set_not_supported = set %1$s not support in DataPoint
+error.write.datapoint_set_not_supported = DataPoint 不支持 set %1$s
 
 # DataPoint / Tablet / AlignedChunkGroupWriterImpl / NonAlignedChunkGroupWriterImpl / TableTsBlock2TsFileWriter
 # — "Data type X is not supported." (many sites collapsed to 1 key)
-error.write.type_not_supported = Data type %1$s is not supported.
+error.write.type_not_supported = 不支持数据类型 %1$s。
 
 # DataPoint — type/value mismatch in getDataPoint
-error.write.datapoint_type_value_mismatch = Data type of %1$s is %2$s, but input value is %3$s
+error.write.datapoint_type_value_mismatch = %1$s 的数据类型为 %2$s，但输入值为 %3$s
 
 # Tablet.addValue(rowIndex, indexOfSchema, Object) — wrong Java type for column type (7 sites collapsed to 1 key)
-error.write.tablet_expected_type = Expected value of type %1$s for data type %2$s, but got %3$s
+error.write.tablet_expected_type = 数据类型 %2$s 期望值类型为 %1$s，但得到 %3$s
 
 # Tablet.addValue(rowIndex, columnIndex, primitiveVal) — wrong array type (7 sites collapsed to 1 key)
-error.write.tablet_col_wrong_type = The data type of column index %1$s is not %2$s
+error.write.tablet_col_wrong_type = 列索引 %1$s 的数据类型不是 %2$s
 
 # Tablet — null measurement argument
-error.write.tablet_null_measurement = measurement should be non null value
+error.write.tablet_null_measurement = measurement 不能为 null
 
 # Tablet — measurement not found
-error.write.tablet_no_measurement = No measurement for %1$s
+error.write.tablet_no_measurement = 找不到 measurement: %1$s
 
 # Tablet.getValue — unsupported data type
-error.write.tablet_unsupported_type = Unsupported type: %1$s
+error.write.tablet_unsupported_type = 不支持的类型: %1$s
 
 # Tablet.readvaluesFromBuffer — unsupported type at client
-error.write.tablet_client_type_not_supported = data type %1$s is not supported when convert data at client
+error.write.tablet_client_type_not_supported = 在客户端转换数据时不支持数据类型 %1$s
 
 # VectorMeasurementSchema — getCompressor deprecated method
-error.write.schema_vector_aligned_no_compressor = Aligned series should not invoke this method
+error.write.schema_vector_aligned_no_compressor = 对齐时间序列不应调用此方法
 
 # VectorMeasurementSchema — unsupported method (4 sites collapsed to 1 key)
-error.write.schema_vector_method_unsupported = unsupported method for VectorMeasurementSchema
+error.write.schema_vector_method_unsupported = VectorMeasurementSchema 不支持此方法
 
 # VectorMeasurementSchema — unexpected end of stream
-error.write.schema_vector_unexpected_end_of_stream = Unexpected end of stream when reading compressors
+error.write.schema_vector_unexpected_end_of_stream = 读取 compressor 时数据流意外结束
 
 # MeasurementSchema — unsupported method (4 sites collapsed to 1 key)
-error.write.schema_measurement_method_unsupported = unsupported method for MeasurementSchema
+error.write.schema_measurement_method_unsupported = MeasurementSchema 不支持此方法
 
 # MeasurementSchemaBuilder — validation errors
-error.write.schema_builder_null_name = Measurement name cannot be null or empty
-error.write.schema_builder_null_type = Data type cannot be null
-error.write.schema_builder_null_property = Property key and value cannot be null
+error.write.schema_builder_null_name = Measurement 名称不能为空
+error.write.schema_builder_null_type = 数据类型不能为 null
+error.write.schema_builder_null_property = 属性的 key 和 value 不能为 null
 
 # ValueChunkWriter / ChunkWriterImpl / TimeChunkWriter — page header IO exception (3 files, 1 key)
-error.write.page_write_header_io_exception = IO Exception in writeDataPageHeader,ignore this page
+error.write.page_write_header_io_exception = writeDataPageHeader 发生 IO 异常，忽略此 page
 
 # ValueChunkWriter / ChunkWriterImpl / TimeChunkWriter — written bytes inconsistent (3 files, 1 key)
-error.write.chunk_bytes_inconsistent = Bytes written is inconsistent with the size of data: %1$s != %2$s
+error.write.chunk_bytes_inconsistent = 写入字节数与数据大小不一致: %1$s != %2$s
 
 # AlignedChunkWriterImpl — unknown data type
-error.write.chunk_unknown_type = Unknown data type %1$s
+error.write.chunk_unknown_type = 未知数据类型 %1$s
 
 # AlignedChunkGroupWriterImpl — out-of-order write (aligned)
-error.write.chunk_group_aligned_out_of_order = Not allowed to write out-of-order data in timeseries %1$s%2$s%3$s, time should later than %4$s
+error.write.chunk_group_aligned_out_of_order = 时间序列 %1$s%2$s%3$s 不允许写入乱序数据，时间应当晚于 %4$s
 
 # NonAlignedChunkGroupWriterImpl — out-of-order write
-error.write.chunk_group_non_aligned_out_of_order = Not allowed to write out-of-order data in timeseries %1$s%2$s%3$s, time should later than %4$s
+error.write.chunk_group_non_aligned_out_of_order = 时间序列 %1$s%2$s%3$s 不允许写入乱序数据，时间应当晚于 %4$s
 
 # TsFileWriter — file writer cannot write
-error.write.tsfile_writer_cannot_write = the given file Writer does not support writing any more. Maybe it is an complete TsFile
+error.write.tsfile_writer_cannot_write = 给定的文件 Writer 已不能再写入。可能是已完成的 TsFile
 
 # TsFileWriter — page size too large vs chunk group size
-error.write.tsfile_writer_page_size_too_large = Invalid memory threshold configuration: page size %1$d must be smaller than chunk group size %2$d. Please either increase the chunk group size or decrease the page size.
+error.write.tsfile_writer_page_size_too_large = 无效的内存阈值配置: page size %1$d 必须小于 chunk group size %2$d。请增大 chunk group size 或减小 page size。
 
 # TsFileWriter — template not found
-error.write.tsfile_writer_template_not_found = given template is not existed! %1$s
+error.write.tsfile_writer_template_not_found = 给定的 template 不存在: %1$s
 
 # TsFileWriter — device already registered (via template)
-error.write.tsfile_writer_device_registered = this device %1$s has been registered, you can only use registerDevice method to register empty device.
+error.write.tsfile_writer_device_registered = 设备 %1$s 已被注册，只能使用 registerDevice 方法注册空设备。
 
 # TsFileWriter — nonAligned timeseries trying to register on already-aligned device
-error.write.tsfile_writer_timeseries_registered_aligned = given device %1$s has been registered for aligned timeseries.
+error.write.tsfile_writer_timeseries_registered_aligned = 给定设备 %1$s 已被注册为对齐时间序列。
 
 # TsFileWriter — timeseries already registered (nonAligned)
-error.write.tsfile_writer_timeseries_registered = given nonAligned timeseries %1$s has been registered.
+error.write.tsfile_writer_timeseries_registered = 给定的非对齐时间序列 %1$s 已被注册。
 
 # TsFileWriter — aligned device cannot be expanded
-error.write.tsfile_writer_device_aligned_no_expand = given device %1$s has been registered for aligned timeseries and should not be expanded.
+error.write.tsfile_writer_device_aligned_no_expand = 给定设备 %1$s 已被注册为对齐时间序列，不允许扩展。
 
 # TsFileWriter — trying to register nonAligned on already-nonAligned device
-error.write.tsfile_writer_device_registered_nonaligned = given device %1$s has been registered for nonAligned timeseries.
+error.write.tsfile_writer_device_registered_nonaligned = 给定设备 %1$s 已被注册为非对齐时间序列。
 
 # TsFileWriter — new measurement after flush
-error.write.tsfile_writer_new_measurement = TsFile has flushed chunk group and should not add new measurement %1$s in device %2$s
+error.write.tsfile_writer_new_measurement = TsFile 已刷新 chunk group，无法在设备 %2$s 中添加新 measurement %1$s
 
 # TsFileWriter / AbstractTableModelTsFileWriter — flush size inconsistent
-error.write.tsfile_writer_flush_inconsistent = Flushed data size is inconsistent with computation! Estimated: %1$d, Actual: %2$d
+error.write.tsfile_writer_flush_inconsistent = Flush 的数据大小与计算不一致！预估: %1$d，实际: %2$d
 
 # RestorableTsFileIOWriter — incompatible file format
-error.write.restorable_writer_not_compatible = %1$s is not in TsFile format.
+error.write.restorable_writer_not_compatible = %1$s 不是 TsFile 格式。
 
 # ForceAppendTsFileWriter — not a complete TsFile
-error.write.force_append_not_complete = File %1$s is not a complete TsFile
+error.write.force_append_not_complete = 文件 %1$s 不是完整的 TsFile
 
 # DiskTSMIterator — read size mismatch
-error.write.disk_tsm_read_size_mismatch = Expected to read %1$s bytes, but actually read %2$s bytes
+error.write.disk_tsm_read_size_mismatch = 期望读取 %1$s 字节，实际读取 %2$s 字节
 
 # DeviceTableModelWriter / v4 — table name is null
-error.write.v4_table_name_null = Table name is null
+error.write.v4_table_name_null = 表名为 null
 
 # TableTsBlock2TsFileWriter — null value in time column
-error.write.v4_all_time_null = All values in time column should not be null
+error.write.v4_all_time_null = 时间列中的所有值都不能为 null
 
 # TsFileTreeWriter — delegate error messages
-error.write.v4_tree_writer_register_failed = Failed to register timeseries for device %1$s
-error.write.v4_tree_writer_register_aligned_failed = Failed to register aligned timeseries for device %1$s
-error.write.v4_tree_writer_write_tablet_failed = Failed to write tablet data
-error.write.v4_tree_writer_write_record_failed = Failed to write TSRecord
-error.write.v4_tree_writer_close_failed = Failed to close TsFileTreeWriter
+error.write.v4_tree_writer_register_failed = 注册设备 %1$s 的时间序列失败
+error.write.v4_tree_writer_register_aligned_failed = 注册设备 %1$s 的对齐时间序列失败
+error.write.v4_tree_writer_write_tablet_failed = 写入 tablet 数据失败
+error.write.v4_tree_writer_write_record_failed = 写入 TSRecord 失败
+error.write.v4_tree_writer_close_failed = 关闭 TsFileTreeWriter 失败
 
 # TsFileTreeWriterBuilder — output file not specified
-error.write.v4_output_file_required = Output file must be specified
+error.write.v4_output_file_required = 必须指定输出文件
 
 # TsFileWriterBuilder — parameter validation
-error.write.v4_file_non_null = The file must be a non-null and non-directory File.
-error.write.v4_table_schema_non_null = TableSchema must not be null.
-error.write.v4_memory_threshold_positive = Memory threshold must be > 0 bytes.
-error.write.v4_table_name_blank = TableName must not be blank.
-error.write.v4_column_name_blank = Column name must not be blank.
+error.write.v4_file_non_null = 文件必须是非空且非目录的 File。
+error.write.v4_table_schema_non_null = TableSchema 不能为 null。
+error.write.v4_memory_threshold_positive = 内存阈值必须大于 0 字节。
+error.write.v4_table_name_blank = TableName 不能为空。
+error.write.v4_column_name_blank = 列名不能为空。
 
 # --- write LOG messages ---
 
 # DataPoint subclasses — null IChunkWriter (7 files, 1 key)
-log.write.datapoint_chunk_writer_null = given IChunkWriter is null, do nothing and return
+log.write.datapoint_chunk_writer_null = 给定的 IChunkWriter 为 null，不执行任何操作并返回
 
 # ChunkWriterImpl / TimeChunkWriter / ValueChunkWriter — upper bound hit (3 files, 1 key)
-log.write.chunk_writer_write_page = current line count reaches the upper bound, write page {}
+log.write.chunk_writer_write_page = 当前行数达到上限，写入 page {}
 
 # ChunkWriterImpl / TimeChunkWriter / ValueChunkWriter — page write error (3 files, 1 key)
-log.write.chunk_writer_page_error = meet error in pageWriter.writePageHeaderAndDataIntoBuff,ignore this page:
+log.write.chunk_writer_page_error = pageWriter.writePageHeaderAndDataIntoBuff 出错，忽略此 page:
 
 # AlignedChunkGroupWriterImpl / NonAlignedChunkGroupWriterImpl — flush device (2 files, 1 key)
-log.write.flush_device = start flush device id:{}
+log.write.flush_device = 开始刷新设备 id: {}
 
 # TsFileWriter / AbstractTableModelTsFileWriter — flush chunk groups (2 files, 1 key)
-log.write.flush_chunk_groups = start to flush chunk groups, memory space occupy:{}
+log.write.flush_chunk_groups = 开始刷新 chunk groups，占用内存空间: {}
 
 # TsFileWriter / AbstractTableModelTsFileWriter — close file (2 files, 1 key)
-log.write.close_file = start close file
+log.write.close_file = 开始关闭文件
 
 # AbstractTableModelTsFileWriter — close file exception (1 site)
-log.write.close_file_exception = Meet exception when close file writer.
+log.write.close_file_exception = 关闭文件 writer 时发生异常。
 
 # TsFileWriter / AbstractTableModelTsFileWriter — page size vs chunk group size warn (2 files, 1 key)
-log.write.page_size_warn = TsFile's page size {} is greater than chunk group size {}, please enlarge the chunk group size or decrease page size.
+log.write.page_size_warn = TsFile 的 page size {} 大于 chunk group size {}，请增大 chunk group size 或减小 page size。
 
 # TsFileWriter — ignore nonAligned measurement (1 site)
-log.write.ignore_nonaligned_measurement = Ignore nonAligned measurement {} , because it is not registered or in the default template
+log.write.ignore_nonaligned_measurement = 忽略非对齐 measurement {}，因为它未被注册或不在默认 template 中
 
 # ForceAppendTsFileWriter / RestorableTsFileIOWriter — writer opened debug (2 files, 1 key)
-log.write.writer_opened = {} writer is opened.
+log.write.writer_opened = {} writer 已打开。
 
 # TsFileIOWriter — start chunk group debug (1 site)
-log.write.start_chunk_group = start chunk group:{}, file position {}
+log.write.start_chunk_group = 开始 chunk group: {}，文件位置 {}
 
 # TsFileIOWriter — start flush footer debug (1 site)
-log.write.start_flush_footer = start to flush the footer,file pos:{}
+log.write.start_flush_footer = 开始刷新 footer，文件位置: {}
 
 # TsFileIOWriter — device timeseries metadata error (1 site)
-log.write.tsm_device_metadata_error = Failed to get device timeseries metadata map
+log.write.tsm_device_metadata_error = 获取设备时间序列 metadata map 失败
 
 # TsFileIOWriter — flush metadata to temp file error (1 site)
-log.write.flush_metadata_exception = Meets exception when flushing metadata to temp file for {}
+log.write.flush_metadata_exception = 刷新 metadata 到临时文件 {} 时发生异常
 
 # TsFileIOWriter — flushing series debug (1 site)
-log.write.flushing_series = Flushing {}
+log.write.flushing_series = 正在刷新 {}
 
 # DiskTSMIterator — IOException reading timeseries metadata from disk (1 site)
-log.write.tsm_disk_read_error = Meets IOException when reading timeseries metadata from disk
+log.write.tsm_disk_read_error = 从磁盘读取时间序列 metadata 时发生 IOException
 
 # ChunkWriterImpl / TimeChunkWriter / ValueChunkWriter — page header start (3 files, 1 key)
-log.write.page_header_flush_start = start to flush a page header into buffer, buffer position {}
+log.write.page_header_flush_start = 开始将 page header 刷入 buffer，buffer 位置 {}
 
 # ChunkWriterImpl / TimeChunkWriter / ValueChunkWriter — page header done (3 files, 1 key)
-log.write.page_header_flush_done = finish to flush a page header {} of {} into buffer, buffer position {}
+log.write.page_header_flush_done = 完成将 {} 的 page header {} 刷入 buffer，buffer 位置 {}
 
 # TimeChunkWriter / ValueChunkWriter — page header done (time page variant, 2 files)
-log.write.page_header_flush_done_time = finish to flush a page header {} of time page into buffer, buffer position {}
+log.write.page_header_flush_done_time = 完成将 time page 的 page header {} 刷入 buffer，buffer 位置 {}
 
 # ChunkWriterImpl / TimeChunkWriter / ValueChunkWriter — enough size, write page (3 files, 1 key)
-log.write.page_enough_size = enough size, write page {}, pageSizeThreshold:{}, currentPateSize:{}, valueCountInOnePage:{}
+log.write.page_enough_size = 大小足够，写入 page {}，pageSizeThreshold: {}，currentPateSize: {}，valueCountInOnePage: {}
 
 # ValueChunkWriter variant of above (uses currentPageSize instead of currentPateSize)
-log.write.page_enough_size_value = enough size, write page {}, pageSizeThreshold:{}, currentPageSize:{}, valueCountInOnePage:{}
+log.write.page_enough_size_value = 大小足够，写入 page {}，pageSizeThreshold: {}，currentPageSize: {}，valueCountInOnePage: {}
 
 # TsFileIOWriter — end flushing a chunk (1 site)
-log.write.end_flush_chunk = end flushing a chunk:{}, totalvalue:{}
+log.write.end_flush_chunk = 完成刷新 chunk: {}，总值数: {}
 
 # TsFileIOWriter — flushing chunk metadata summary (1 site)
-log.write.flush_chunk_metadata = Flushing chunk metadata, total size is {}, count is {}, avg size is {}
+log.write.flush_chunk_metadata = 正在刷新 chunk metadata，总大小: {}，数量: {}，平均大小: {}
 
 # === read.common ===
 
 # TimeRange — null input in compareTo
-error.read.timerange_null_input = The input cannot be null!
+error.read.timerange_null_input = 输入不能为 null！
 
 # TimeRange — setMin/setMax invalid input
-error.read.timerange_invalid_input = Invalid input!
+error.read.timerange_invalid_input = 无效输入！
 
 # TimeRange — set(min, max) range violation
-error.read.timerange_min_gt_max = min:%1$s should not be larger than max: %2$s
+error.read.timerange_min_gt_max = min: %1$s 不能大于 max: %2$s
 
 # Chunk — unsupported data type in rewrite (2 sites, 1 key)
-error.read.chunk_unsupported_type = Unsupported data type: %1$s
+error.read.chunk_unsupported_type = 不支持的数据类型: %1$s
 
 # Chunk — NonAlignedChunk null value at timestamp
-error.read.chunk_non_aligned_null = NonAlignedChunk contains null, timestamp: %1$s
+error.read.chunk_non_aligned_null = NonAlignedChunk 包含 null，时间戳: %1$s
 
 # BatchDataFactory — instantiation guard
-error.read.factory_class = Factory class
+error.read.factory_class = 工厂类
 
 # Field — OBJECT type does not support getBinaryV
-error.read.field_object_type_no_binary = OBJECT Type only support getStringValue
+error.read.field_object_type_no_binary = OBJECT 类型只支持 getStringValue
 
 # Path — getFullPathWithAlias not supported
-error.read.path_no_alias = doesn't alias in TSFile Path
+error.read.path_no_alias = TSFile Path 中没有别名
 
 # SignalBatchData — hasCurrent not supported
-error.read.signal_batch_data_no_has_current = hasCurrent is not supported for SignalBatchData
+error.read.signal_batch_data_no_has_current = SignalBatchData 不支持 hasCurrent
 
 # BatchData — unknown data type (2 sites, 1 key)
-error.read.batch_data_unknown_type = Unknown data type for BatchData:%1$s
+error.read.batch_data_unknown_type = BatchData 的数据类型未知: %1$s
 
 # BatchData — invalid input in deserialize
-error.read.batch_data_invalid_input = Invalid input: %1$s
+error.read.batch_data_invalid_input = 无效输入: %1$s
 
 # TypeFactory — invalid TSDataType
-error.read.typefactory_invalid_tsdata_type = Invalid TSDataType for TypeFactory: %1$s
+error.read.typefactory_invalid_tsdata_type = TypeFactory 接收到无效的 TSDataType: %1$s
 
 # TypeFactory — invalid TypeEnum
-error.read.typefactory_invalid_type_enum = Invalid TypeEnum for TypeFactory: %1$s
+error.read.typefactory_invalid_type_enum = TypeFactory 接收到无效的 TypeEnum: %1$s
 
 # TsBlockBuilder — unknown data type (2 sites, 1 key)
-error.read.tsblock_builder_unknown_type = Unknown data type: %1$s
+error.read.tsblock_builder_unknown_type = 未知数据类型: %1$s
 
 # TsBlockBuilder.build — declared positions mismatch (time column)
-error.read.tsblock_builder_time_mismatch = Declared positions (%1$s) does not match time column's number of entries (%2$s)
+error.read.tsblock_builder_time_mismatch = 声明的 positions (%1$s) 与 time column 的条目数 (%2$s) 不匹配
 
 # TsBlockBuilder.build — declared positions mismatch (value column)
-error.read.tsblock_builder_col_mismatch = Declared positions (%1$s) does not match column %2$s's number of entries (%3$s)
+error.read.tsblock_builder_col_mismatch = 声明的 positions (%1$s) 与 column %2$s 的条目数 (%3$s) 不匹配
 
 # TsBlock.getRegion — invalid position/length
-error.read.tsblock_invalid_region = Invalid position %1$s and length %2$s in page with %3$s positions
+error.read.tsblock_invalid_region = 无效的 position %1$s 和 length %2$s，该 page 仅有 %3$s 个 positions
 
 # TsBlock.subTsBlock — fromIndex over positionCount
-error.read.tsblock_from_index_over = FromIndex of subTsBlock cannot over positionCount.
+error.read.tsblock_from_index_over = subTsBlock 的 fromIndex 不能超过 positionCount。
 
 # TsBlock.determinePositionCount — columns is empty
-error.read.tsblock_columns_empty = columns is empty
+error.read.tsblock_columns_empty = columns 为空
 
 # TsBlock — unknown datatype in updateWithoutTimeColumn
-error.read.tsblock_unknown_datatype = Unknown datatype: %1$s
+error.read.tsblock_unknown_datatype = 未知数据类型: %1$s
 
 # ColumnBuilder — type-specific unsupported data type (1 key per builder, 6 builders)
-error.read.col_builder_double_type = DoubleColumn only support Double data type
-error.read.col_builder_int_type = IntegerColumn only support Integer data type
-error.read.col_builder_float_type = FloatColumn only support Float data type
-error.read.col_builder_long_type = LongColumn only support Long data type
-error.read.col_builder_boolean_type = BooleanColumn only support Boolean data type
-error.read.col_builder_binary_type = BinaryColumn only support Binary data type
+error.read.col_builder_double_type = DoubleColumn 只支持 Double 数据类型
+error.read.col_builder_int_type = IntegerColumn 只支持 Integer 数据类型
+error.read.col_builder_float_type = FloatColumn 只支持 Float 数据类型
+error.read.col_builder_long_type = LongColumn 只支持 Long 数据类型
+error.read.col_builder_boolean_type = BooleanColumn 只支持 Boolean 数据类型
+error.read.col_builder_binary_type = BinaryColumn 只支持 Binary 数据类型
 
 # ColumnFactory — unsupported data type
-error.read.column_factory_unsupported_type = Unsupported data type: %1$s
+error.read.column_factory_unsupported_type = 不支持的数据类型: %1$s
 
 # TsBlockSerde — block too large
-error.read.tsblock_too_large = TsBlock should not be that large: %1$s
+error.read.tsblock_too_large = TsBlock 不应该这么大: %1$s
 
 # Shared column constructor checks (reused across multiple column classes)
-error.read.col_array_offset_negative = arrayOffset is negative
-error.read.col_position_count_negative = positionCount is negative
-error.read.col_values_length_lt_position = values length is less than positionCount
-error.read.col_isnull_length_lt_position = isNull length is less than positionCount
-error.read.col_ids_length_lt_position = ids length is less than positionCount
+error.read.col_array_offset_negative = arrayOffset 为负
+error.read.col_position_count_negative = positionCount 为负
+error.read.col_values_length_lt_position = values 长度小于 positionCount
+error.read.col_isnull_length_lt_position = isNull 长度小于 positionCount
+error.read.col_ids_length_lt_position = ids 长度小于 positionCount
 
 # Shared fromIndex validation (reused across multiple column classes)
-error.read.col_from_index_invalid = fromIndex is not valid
+error.read.col_from_index_invalid = fromIndex 无效
 
 # TimeColumn — isNull not supported
-error.read.time_column_isnull_unsupported = isNull is not supported for TimeColumn
+error.read.time_column_isnull_unsupported = TimeColumn 不支持 isNull
 
 # ColumnEncoderFactory — unsupported column encoding
-error.read.col_encoder_unsupported = Unsupported column encoding: %1$s
+error.read.col_encoder_unsupported = 不支持的 column encoding: %1$s
 
 # Int32/Int64/Binary/ByteArray array column encoders — invalid data type
-error.read.col_encoder_invalid_type = Invalid data type: %1$s
+error.read.col_encoder_invalid_type = 无效的数据类型: %1$s
 
 # RunLengthEncodedColumn — expected single position
-error.read.rle_col_expected_single = Expected value to contain a single position but has %1$s positions
+error.read.rle_col_expected_single = 期望值仅含单个 position，但有 %1$s 个 positions
 
 # RunLengthEncodedColumn — setNull not supported
-error.read.rle_col_set_null_unsupported = set null of %1$s is not supported !
+error.read.rle_col_set_null_unsupported = 不支持 set null of %1$s！
 
 # RunLengthColumnEncoder — nested RLE not supported
-error.read.rle_encoder_nested = Unable to encode a nested RLE column.
+error.read.rle_encoder_nested = 无法编码嵌套的 RLE column。
 
 # DictionaryColumn — sequential ids flag constraint
-error.read.dict_col_sequential_ids = sequential ids flag is only valid for compacted dictionary
+error.read.dict_col_sequential_ids = sequential ids 标志仅对 compacted dictionary 有效
 
 # DictionaryColumn — non-existent key reference (2 sites, 1 key)
-error.read.dict_col_nonexistent_key = reference to a non-existent key
+error.read.dict_col_nonexistent_key = 引用了不存在的 key
 
 # DictionaryColumn — dictionary source ids mismatch
-error.read.dict_col_source_ids_mismatch = dictionarySourceIds must be the same
+error.read.dict_col_source_ids_mismatch = dictionarySourceIds 必须相同
 
 # NullColumn — unknown data type
-error.read.null_col_unknown_type = Unknown data type: %1$s
+error.read.null_col_unknown_type = 未知数据类型: %1$s
 
 # ColumnUtil — invalid offset/length in array
-error.read.col_util_invalid_offset_length = Invalid offset %1$s and length %2$s in array with %3$s elements
+error.read.col_util_invalid_offset_length = 无效的 offset %1$s 和 length %2$s，数组共有 %3$s 个元素
 
 # ColumnUtil — invalid position/length in block
-error.read.col_util_invalid_pos_length = Invalid position %1$s and length %2$s in block with %3$s positions
+error.read.col_util_invalid_pos_length = 无效的 position %1$s 和 length %2$s，block 共有 %3$s 个 positions
 
 # ColumnUtil — invalid positions array size
-error.read.col_util_invalid_positions_size = Invalid positions array size %1$d, actual position count is %2$d
+error.read.col_util_invalid_positions_size = 无效的 positions 数组大小 %1$d，实际 position 数为 %2$d
 
 # ColumnUtil — invalid position in block
-error.read.col_util_invalid_position = Invalid position %1$s in block with %2$s positions
+error.read.col_util_invalid_position = 无效的 position %1$s，block 共有 %2$s 个 positions
 
 # ColumnUtil — cannot grow array
-error.read.col_util_cannot_grow = Cannot grow array beyond '%1$s'
+error.read.col_util_cannot_grow = 数组无法扩展到 '%1$s' 之外
 
 # TimeColumnBuilder — position not valid
-error.read.time_col_builder_position_invalid = position is not valid
+error.read.time_col_builder_position_invalid = position 无效
 
 # PathParseError — syntax error with line and position
-error.read.path_parse_error = line %1$s:%2$s %3$s
+error.read.path_parse_error = 第 %1$s 行第 %2$s 列: %3$s
 
 # === read ===
 
 # TsFileSequenceReader / selfCheck — unexpected marker
-error.read.unexpected_marker = Unexpected marker %1$s
+error.read.unexpected_marker = 意外的 marker %1$s
 
 # TsFileSequenceReader.selfCheck / checkChunkAndPagesStatistics — unexpected data type in switch
-error.read.unexpected_type = Unexpected type %1$s
+error.read.unexpected_type = 意外的类型 %1$s
 
 # TsFileSequenceReader — device not in tsFileMetaData (with file name, 3 sites)
-error.read.device_not_in_metadata_file = Device {%1$s} is not in tsFileMetaData of %2$s
+error.read.device_not_in_metadata_file = 设备 {%1$s} 不在 %2$s 的 tsFileMetaData 中
 
 # TsFileSequenceReader — device not in tsFileMetaData (no file name, 1 site)
-error.read.device_not_in_metadata = Device {%1$s} is not in tsFileMetaData
+error.read.device_not_in_metadata = 设备 {%1$s} 不在 tsFileMetaData 中
 
 # TsFileSequenceReader / readPlanIndex / readMarker — reach end of file (3 sites)
-error.read.reach_end_of_file = reach the end of the file.
+error.read.reach_end_of_file = 已到达文件末尾。
 
 # TsFileSequenceReader.readData — reach end of data (short form)
-error.read.reach_end_of_data = reach the end of the data
+error.read.reach_end_of_data = 已到达数据末尾
 
 # TsFileSequenceReader.readData — reach end of data with position detail
-error.read.reach_end_of_data_detail = reach the end of the data. Size of data that want to read: %1$s,actual read size: %2$s, position: %3$s
+error.read.reach_end_of_data_detail = 已到达数据末尾。期望读取大小: %1$s，实际读取大小: %2$s，位置: %3$s
 
 # TsFileSequenceReader.uncompress — uncompress error with counts (no page header)
-error.read.uncompress_error = Uncompress error! uncompress size: %1$scompressed size: %2$s%3$s
+error.read.uncompress_error = 解压错误！uncompress size: %1$scompressed size: %2$s%3$s
 
 # ChunkReader.uncompressPageData / decryptAndUncompressPageData / LazyLoadPageData — uncompress error with page header
-error.read.uncompress_error_with_header = Uncompress error! uncompress size: %1$scompressed size: %2$spage header: %3$s%4$s
+error.read.uncompress_error_with_header = 解压错误！uncompress size: %1$scompressed size: %2$spage header: %3$s%4$s
 
 # AbstractChunkReader — no more page
-error.read.no_more_page = No more page
+error.read.no_more_page = 没有更多 page
 
 # ChunkReader.readCompressedPageData — incomplete page body
-error.read.chunk_incomplete_page_body = do not has a complete page body. Expected:%1$s. Actual:%2$s
+error.read.chunk_incomplete_page_body = page body 不完整。期望: %1$s，实际: %2$s
 
 # TsFileSequenceReaderTimeseriesMetadataIterator — deserializeTimeseriesMetadataUsingTsFileInput failed
-error.read.tsm_iterator_tsfinput_failed = TsFileSequenceReaderTimeseriesMetadataIterator: deserializeTimeseriesMetadataUsingTsFileInput failed, currentEndOffset: %1$d, %2$s
+error.read.tsm_iterator_tsfinput_failed = TsFileSequenceReaderTimeseriesMetadataIterator: deserializeTimeseriesMetadataUsingTsFileInput 失败，currentEndOffset: %1$d，%2$s
 
 # TsFileSequenceReaderTimeseriesMetadataIterator — deserializeMetadataIndexEntry failed
-error.read.tsm_iterator_index_entry_failed = TsFileSequenceReaderTimeseriesMetadataIterator: deserializeMetadataIndexEntry failed, MetadataIndexEntryInfo: %1$s, %2$s
+error.read.tsm_iterator_index_entry_failed = TsFileSequenceReaderTimeseriesMetadataIterator: deserializeMetadataIndexEntry 失败，MetadataIndexEntryInfo: %1$s，%2$s
 
 # TsFileSequenceReaderTimeseriesMetadataIterator — currentBuffer still has remaining data
-error.read.tsm_iterator_buffer_not_empty = currentBuffer still has some data left before deserializeLeafMeasurement
+error.read.tsm_iterator_buffer_not_empty = deserializeLeafMeasurement 之前 currentBuffer 仍有剩余数据
 
 # TsFileSequenceReader — timeseries of device are not aligned
-error.read.timeseries_not_aligned = Timeseries of device {%1$s} are not aligned
+error.read.timeseries_not_aligned = 设备 {%1$s} 的时间序列不是对齐的
 
 # TsFileSequenceReader — aligned chunk metadata should only have one timeseriesMetadataList per device
-error.read.aligned_chunk_metadata_one_device = Error when reading timeseriesMetadata of device %1$s in file %2$s: should only one timeseriesMetadataList in one device, actual: %3$d
+error.read.aligned_chunk_metadata_one_device = 读取文件 %2$s 中设备 %1$s 的 timeseriesMetadata 时出错: 一个设备应只有一个 timeseriesMetadataList，实际: %3$d
 
 # TsFileSequenceReader.selfCheckWithInfo — statistics mistakes in Chunk
-error.read.stats_mistakes_chunk = Chunk exists statistics mistakes at position %1$s
+error.read.stats_mistakes_chunk = 位置 %1$s 处的 Chunk 存在 statistics 错误
 
 # TsFileSequenceReader.selfCheckWithInfo — statistics mistakes in TimeseriesMetadata
-error.read.stats_mistakes_tsm = TimeseriesMetadata exists statistics mistakes at position %1$s
+error.read.stats_mistakes_tsm = 位置 %1$s 处的 TimeseriesMetadata 存在 statistics 错误
 
 # TsFileSequenceReader / TsFileDeviceIterator — error reading a time series metadata block (2 sites)
-error.read.metadata_block_read_error = Error occurred while reading a time series metadata block.
+error.read.metadata_block_read_error = 读取时间序列 metadata block 时发生错误。
 
 # LazyTsFileDeviceIterator.getDevicesOfLeafNode — first param should be device leaf node
-error.read.device_leaf_node_required = the first param should be device leaf node.
+error.read.device_leaf_node_required = 第一个参数应为 device leaf node。
 
 # LazyTsFileDeviceIterator — next() must be called before accessing current device (3 sites)
-error.read.device_iterator_no_current = next() must be called before accessing current device
+error.read.device_iterator_no_current = 访问当前设备前必须先调用 next()
 
 # DeviceMetaIterator — non-device node detected
-error.read.non_device_node_detected = A non-device node detected: %1$s
+error.read.non_device_node_detected = 检测到非设备节点: %1$s
 
 # MetadataQuerierByFileImpl — spacePartitionStartPos > spacePartitionEndPos
-error.read.metadata_querier_illegal_arg = 'spacePartitionStartPos' should not be larger than 'spacePartitionEndPos'.
+error.read.metadata_querier_illegal_arg = 'spacePartitionStartPos' 不能大于 'spacePartitionEndPos'。
 
 # ExpressionOptimizer — unsupported IExpression type in binary expression
-error.read.expression_unsupported_binary_type = unsupported IExpression type: %1$s
+error.read.expression_unsupported_binary_type = 不支持的 IExpression 类型: %1$s
 
 # ExpressionOptimizer — StackOverflowError
-error.read.expression_stack_overflow = StackOverflowError is encountered.
+error.read.expression_stack_overflow = 遇到 StackOverflowError。
 
 # ExpressionOptimizer — unknown IExpression type
-error.read.expression_unknown_type = unknown IExpression type: %1$s
+error.read.expression_unknown_type = 未知的 IExpression 类型: %1$s
 
 # ExpressionOptimizer — unknown relation in IExpression
-error.read.expression_unknown_relation = unknown relation in IExpression:%1$s
+error.read.expression_unknown_relation = IExpression 中存在未知关系: %1$s
 
 # ExpressionOptimizer — size of selectSeries could not be 0
-error.read.expression_empty_select_series = size of selectSeries could not be 0
+error.read.expression_empty_select_series = selectSeries 的大小不能为 0
 
 # ExpressionOptimizer — IExpression should contain only SingleSeriesExpression
-error.read.expression_unexpected_type = IExpression should contains only SingleSeriesExpression but other type is found:%1$s
+error.read.expression_unexpected_type = IExpression 应只包含 SingleSeriesExpression，但发现其他类型: %1$s
 
 # ExpressionOptimizer — unrecognized QueryFilterOperatorType
-error.read.expression_unrecognized_operator = unrecognized QueryFilterOperatorType :%1$s
+error.read.expression_unrecognized_operator = 无法识别的 QueryFilterOperatorType: %1$s
 
 # ValueFilter — unsupported data type (7 satisfy methods, 1 key; arg = class name)
-error.read.value_filter_unsupported_type = Unsupported data type for value filter: %1$s
+error.read.value_filter_unsupported_type = value filter 不支持的数据类型: %1$s
 
 # ValueFilter — getTimeRanges not supported
-error.read.value_filter_no_time_ranges = Value filter does not support getTimeRanges()
+error.read.value_filter_no_time_ranges = Value filter 不支持 getTimeRanges()
 
 # Not filter — contains NOT (4 sites, 1 key; appended with filter.toString())
-error.read.filter_contains_not = This predicate contains a not! Did you forget to run this predicate through PredicateRemoveNotRewriter? %1$s
+error.read.filter_contains_not = 该谓词包含 not！是否忘记将谓词传给 PredicateRemoveNotRewriter? %1$s
 
 # Filter.deserialize — unsupported operator type
-error.read.filter_unsupported_operator = Unsupported operator type:%1$s
+error.read.filter_unsupported_operator = 不支持的 operator 类型: %1$s
 
 # TimeFilterOperators.In — set must not be null
-error.read.filter_timein_set_null = set must not be null!
+error.read.filter_timein_set_null = set 不能为 null！
 
 # ExtractTimeFilterOperators — unexpected extract field (2 sites)
-error.read.extract_unexpected_field = Unexpected extract field: %1$s
+error.read.extract_unexpected_field = 意外的 extract 字段: %1$s
 
 # ValueFilterApi — unsupported data type (14 sites, 1 key)
-error.read.filter_api_unsupported_type = Unsupported data type: %1$s
+error.read.filter_api_unsupported_type = 不支持的数据类型: %1$s
 
 # TagFilterBuilder — column is not a tag column
-error.read.tag_not_a_tag_column = Column '%1$s' is not a tag column
+error.read.tag_not_a_tag_column = 列 '%1$s' 不是 tag column
 
 # TimeGenerator.getValues — OR node present
-error.read.time_generator_or_get_values = getValues() method should not be invoked when there is OR operator in where clause
+error.read.time_generator_or_get_values = where 子句中存在 OR operator 时不应调用 getValues() 方法
 
 # TimeGenerator.getValues — path not in where clause
-error.read.time_generator_path_not_found_values = getValues() method should not be invoked by non-existent path in where clause
+error.read.time_generator_path_not_found_values = where 子句中不存在的 path 不应调用 getValues() 方法
 
 # TimeGenerator.getValue — OR node present
-error.read.time_generator_or_get_value = getValue() method should not be invoked when there is OR operator in where clause
+error.read.time_generator_or_get_value = where 子句中存在 OR operator 时不应调用 getValue() 方法
 
 # TimeGenerator.getValue — path not in where clause
-error.read.time_generator_path_not_found_value = getValue() method should not be invoked by non-existent path in where clause
+error.read.time_generator_path_not_found_value = where 子句中不存在的 path 不应调用 getValue() 方法
 
 # TimeGenerator.construct — unsupported ExpressionType
-error.read.time_generator_unsupported_expression = Unsupported ExpressionType when construct OperatorNode: %1$s
+error.read.time_generator_unsupported_expression = 构造 OperatorNode 时遇到不支持的 ExpressionType: %1$s
 
 # AndNode / OrNode / LeafNode — no more data (3 sites)
-error.read.node_no_more_data = no more data
+error.read.node_no_more_data = 没有更多数据
 
 # AbstractResultSet — column name not found
-error.read.result_set_column_not_found = Can't find columnName %1$s from result set
+error.read.result_set_column_not_found = 在 result set 中找不到 columnName %1$s
 
 # AbstractResultSet — field is null
-error.read.result_set_null_field = Field in columnIndex %1$s is null
+error.read.result_set_null_field = columnIndex %1$s 处的 Field 为 null
 
 # AbstractResultSet — column index out of bound
-error.read.result_set_index_out_of_bound = column index %1$s out of bound
+error.read.result_set_index_out_of_bound = column 索引 %1$s 越界
 
 # DataSetWithoutTimeGenerator — unsupported data type
-error.read.dataset_unsupported_type = UnSupported%1$s
+error.read.dataset_unsupported_type = 不支持 %1$s
 
 # SingleDeviceTsBlockReader — unsupported data type (3 sites, same key)
-error.read.block_reader_unsupported_type = Unsupported data type: %1$s
+error.read.block_reader_unsupported_type = 不支持的数据类型: %1$s
 
 # TableQueryExecutor — unsupported ordering
-error.read.table_query_unsupported_ordering = Unsupported ordering: %1$s
+error.read.table_query_unsupported_ordering = 不支持的 ordering: %1$s
 
 # TableQueryExecutor — no column exception
-error.read.table_query_no_column = No column: %1$s
+error.read.table_query_no_column = 没有 column: %1$s
 
 # TsFileTreeReaderBuilder — file must be set
-error.read.tree_reader_file_required = file must be set before build()
+error.read.tree_reader_file_required = 在 build() 之前必须设置 file
 
 # TsFileReaderBuilder — file must be non-null and non-directory
-error.read.reader_builder_file_non_null = The file must be a non-null and non-directory File.
+error.read.reader_builder_file_non_null = 文件必须是非空且非目录的 File。
 
 # --- read LOG messages ---
 
 # TsFileRestorableReader — file has no correct tail magic
-log.read.file_repair = File {} has no correct tail magic, try to repair...
+log.read.file_repair = 文件 {} 的 tail magic 不正确，尝试修复...
 
 # LocalTsFileInput — error getting file size
-log.read.local_input_size_error = Error happened while getting {} size
+log.read.local_input_size_error = 获取 {} 大小时出错
 
 # LocalTsFileInput — error getting current position
-log.read.local_input_position_error = Error happened while getting {} current position
+log.read.local_input_position_error = 获取 {} 当前位置时出错
 
 # LocalTsFileInput — error changing position
-log.read.local_input_position_change_error = Error happened while changing {} position to {}
+log.read.local_input_position_change_error = 将 {} 位置改为 {} 时出错
 
 # LocalTsFileInput — ClosedByInterruptException on read (2 sites, 1 key)
-log.read.local_input_interrupted = Current thread is interrupted by another thread when it is blocked in an I/O operation upon a channel.
+log.read.local_input_interrupted = 当前线程在 channel 上阻塞执行 I/O 操作时被其他线程中断。
 
 # LocalTsFileInput — error reading from current position
-log.read.local_input_read_current_error = Error happened while reading {} from current position
+log.read.local_input_read_current_error = 从当前位置读取 {} 时出错
 
 # LocalTsFileInput — error reading from position
-log.read.local_input_read_position_error = Error happened while reading {} from position {}
+log.read.local_input_read_position_error = 从位置 {} 读取 {} 时出错
 
 # LocalTsFileInput — error closing
-log.read.local_input_close_error = Error happened while closing {}
+log.read.local_input_close_error = 关闭 {} 时出错
 
 # TsFileSequenceReader — reading file metadata error
-log.read.sequence_reader_file_metadata_error = Something error happened while reading file metadata of file {}
+log.read.sequence_reader_file_metadata_error = 读取文件 {} 的 metadata 时出错
 
 # TsFileSequenceReader — deserializing TimeseriesMetadata error (multiple sites, same key)
-log.read.sequence_reader_tsm_deserialize_error = Something error happened while deserializing TimeseriesMetadata of file {}
+log.read.sequence_reader_tsm_deserialize_error = 反序列化文件 {} 的 TimeseriesMetadata 时出错
 
 # TsFileSequenceReader — deserializing MetadataIndexNode error (constant METADATA_INDEX_NODE_DESERIALIZE_ERROR, 8 sites)
-log.read.sequence_reader_metadata_index_node_error = Something error happened while deserializing MetadataIndexNode of file {}
+log.read.sequence_reader_metadata_index_node_error = 反序列化文件 {} 的 MetadataIndexNode 时出错
 
 # TsFileSequenceReader — reading chunk header error (2 sites, 1 key)
-log.read.sequence_reader_chunk_header_error = Exception {} happened while reading chunk header of {}
+log.read.sequence_reader_chunk_header_error = 读取 {} 的 chunk header 时发生异常 {}
 
 # TsFileSequenceReader — reading chunk error (3 sites, 1 key)
-log.read.sequence_reader_chunk_error = Exception {} happened while reading chunk of {}
+log.read.sequence_reader_chunk_error = 读取 {} 的 chunk 时发生异常 {}
 
 # TsFileSequenceReader — reading page header error
-log.read.sequence_reader_page_header_error = Exception {} happened while reading page header of {}
+log.read.sequence_reader_page_header_error = 读取 {} 的 page header 时发生异常 {}
 
 # TsFileSequenceReader — reading data error
-log.read.sequence_reader_data_error = Exception {} happened while reading data of {}
+log.read.sequence_reader_data_error = 读取 {} 的 data 时发生异常 {}
 
 # TsFileSequenceReader — getting all paths error
-log.read.sequence_reader_paths_error = Something error happened while getting all paths of file {}
+log.read.sequence_reader_paths_error = 获取文件 {} 的所有 paths 时出错
 
 # TsFileSequenceReader — generating MetadataIndex error (2 sites, 1 key)
-log.read.sequence_reader_metadata_index_error = Something error happened while generating MetadataIndex of file {}
+log.read.sequence_reader_metadata_index_error = 生成文件 {} 的 MetadataIndex 时出错
 
 # TsFileSequenceReader — deserializing MetadataIndex error (2 sites, 1 key; different from MetadataIndexNode constant)
-log.read.sequence_reader_deserialize_metadata_error = Something error happened while deserializing MetadataIndex of file {}
+log.read.sequence_reader_deserialize_metadata_error = 反序列化文件 {} 的 MetadataIndex 时出错
 
 # TsFileSequenceReader.selfCheck — cannot proceed warning
-log.read.sequence_reader_self_check_warn = TsFile {} self-check cannot proceed at position {} recovered, because : {}
+log.read.sequence_reader_self_check_warn = TsFile {} self-check 无法在位置 {} 继续，已恢复，原因: {}
 
 # TsFileSequenceReader.selfCheckWithInfo — file length info
-log.read.sequence_reader_file_length = file length: {}
+log.read.sequence_reader_file_length = 文件长度: {}
 
 # TsFileSequenceReader.selfCheckWithInfo — fast check error
-log.read.sequence_reader_fast_check_error = Error occurred while fast checking TsFile.
+log.read.sequence_reader_fast_check_error = 快速校验 TsFile 时发生错误。
 
 # TsFileSequenceReader.selfCheckWithInfo — statistics check error
-log.read.sequence_reader_stats_check_error = Error occurred while checking the statistics of chunk and its pages
+log.read.sequence_reader_stats_check_error = 校验 chunk 及其 pages 的 statistics 时发生错误
 
 # TsFileSequenceReader — collecting offset ranges error
-log.read.sequence_reader_collect_offset_error = Error occurred while collecting offset ranges of measurement nodes of file {}
+log.read.sequence_reader_collect_offset_error = 收集文件 {} 的 measurement node offset 范围时发生错误
 
 # TsFileSequenceReader.TimeseriesMetadataIterator — cannot read timeseries metadata
-log.read.sequence_reader_tsm_warn = Cannot read timeseries metadata from {},
+log.read.sequence_reader_tsm_warn = 无法从 {} 读取时间序列 metadata，
 
 # TsFileLastReader — cannot read timeseries metadata from file (2 sites, 1 key)
-log.read.last_reader_tsm_error = Cannot read timeseries metadata from {}
+log.read.last_reader_tsm_error = 无法从 {} 读取时间序列 metadata
 
 # TsFileLastReader — error while reading timeseries metadata (async)
-log.read.last_reader_tsm_meta_error = Error while reading timeseries metadata
+log.read.last_reader_tsm_meta_error = 读取时间序列 metadata 时出错
 
 # DeviceOrderedTsBlockReader — failed to construct reader
-log.read.block_reader_construct_error = Failed to construct reader for {}
+log.read.block_reader_construct_error = 为 {} 构造 reader 失败
 
 # SingleDeviceTsBlockReader — cannot fill measurements
-log.read.block_reader_fill_measurements_error = Cannot fill measurements
+log.read.block_reader_fill_measurements_error = 无法填充 measurements
 
 # TableResultSet — failed to close tsBlockReader
-log.read.table_result_set_close_error = Failed to close tsBlockReader
+log.read.table_result_set_close_error = 关闭 tsBlockReader 失败
 
 # DeviceMetaIterator — failed to load device meta data
-log.read.device_meta_iterator_error = Failed to load device meta data
+log.read.device_meta_iterator_error = 加载设备 meta data 失败
 
 # DeviceTableModelReader — close file reader exception
-log.read.v4_close_reader_error = Meet exception when close file reader:
+log.read.v4_close_reader_error = 关闭文件 reader 时发生异常:
 
 # === encoding ===
 
 # --- encoder error messages ---
 
 # Encoder — method not supported (8 sites, 1 key per type; parameterized on method name and class)
-error.encoding.encoder_method_not_supported = Method encode %1$s is not supported by Encoder
+error.encoding.encoder_method_not_supported = Encoder 不支持 encode 方法 %1$s
 
 # FloatEncoder / FloatDecoder — data type not supported (3+3 sites; same English text)
-error.encoding.float_encoder_unsupported_type = data type %1$s is not supported by FloatEncoder
+error.encoding.float_encoder_unsupported_type = FloatEncoder 不支持数据类型 %1$s
 
 # FloatDecoder — encoding not supported
-error.encoding.float_decoder_unsupported_encoding = %1$s encoding is not supported by FloatDecoder
+error.encoding.float_decoder_unsupported_encoding = FloatDecoder 不支持 %1$s encoding
 
 # FloatEncoder — encoding not supported
-error.encoding.float_encoder_unsupported_encoding = %1$s encoding is not supported by FloatEncoder
+error.encoding.float_encoder_unsupported_encoding = FloatEncoder 不支持 %1$s encoding
 
 # PlainEncoder — BigDecimal not supported
-error.encoding.plain_encoder_bigdecimal_unsupported = tsfile-encoding PlainEncoder: current version does not support BigDecimal value encoding
+error.encoding.plain_encoder_bigdecimal_unsupported = tsfile-encoding PlainEncoder: 当前版本不支持 BigDecimal 值的编码
+
+# RleEncoder/RleDecoder — getClass().getName() sites (8 RleEncoder throws; skip — data-only)
 
 # RleDecoder — method not supported (8 sites, 1 key; note typo "supproted" preserved for backward compat)
-error.encoding.rle_decoder_method_not_supported = Method %1$s is not supproted by RleDecoder
+error.encoding.rle_decoder_method_not_supported = RleDecoder 不支持方法 %1$s
 
 # RleDecoder — unknown encoding mode
-error.encoding.rle_decoder_unknown_mode = tsfile-encoding IntRleDecoder: unknown encoding mode %1$s
+error.encoding.rle_decoder_unknown_mode = tsfile-encoding IntRleDecoder: 未知的 encoding mode %1$s
 
 # RleDecoder — bitPackedGroupCount < 1
-error.encoding.rle_decoder_bit_packed_group_count = tsfile-encoding IntRleDecoder: bitPackedGroupCount %1$d, smaller than 1
+error.encoding.rle_decoder_bit_packed_group_count = tsfile-encoding IntRleDecoder: bitPackedGroupCount %1$d 小于 1
 
 # IntRleDecoder / LongRleDecoder — not a valid mode
-error.encoding.rle_decoder_invalid_mode_int = tsfile-encoding IntRleDecoder: not a valid mode %1$s
-error.encoding.rle_decoder_invalid_mode_long = tsfile-encoding LongRleDecoder: not a valid mode %1$s
+error.encoding.rle_decoder_invalid_mode_int = tsfile-encoding IntRleDecoder: 不是有效的 mode %1$s
+error.encoding.rle_decoder_invalid_mode_long = tsfile-encoding LongRleDecoder: 不是有效的 mode %1$s
 
 # BitmapDecoder — method not supported (7 sites, 1 key)
-error.encoding.bitmap_decoder_method_not_supported = Method %1$s is not supported by BitmapDecoder
+error.encoding.bitmap_decoder_method_not_supported = BitmapDecoder 不支持方法 %1$s
 
 # FloatDecoder — method not supported (5 sites, 1 key)
-error.encoding.float_decoder_method_not_supported = Method %1$s is not supported by FloatDecoder
+error.encoding.float_decoder_method_not_supported = FloatDecoder 不支持方法 %1$s
 
 # PlainDecoder — BigDecimal not supported
-error.encoding.plain_decoder_bigdecimal_unsupported = Method readBigDecimal is not supported by PlainDecoder
+error.encoding.plain_decoder_bigdecimal_unsupported = PlainDecoder 不支持 readBigDecimal 方法
 
 # Decoder — method not supported (8 sites, 1 key)
-error.encoding.decoder_method_not_supported = Method %1$s is not supported by Decoder
+error.encoding.decoder_method_not_supported = Decoder 不支持方法 %1$s
 
 # Decoder.getDecoderByType — encoding+type combination not found (many sites, 1 key using ERROR_MSG)
-error.encoding.decoder_not_found = Decoder not found: %1$s , DataType is : %2$s
+error.encoding.decoder_not_found = 未找到 Decoder: %1$s，DataType: %2$s
 
 # GorillaDecoderV1 — reading from empty buffer
-error.encoding.gorilla_empty_buffer = Reading from empty buffer
+error.encoding.gorilla_empty_buffer = 从空 buffer 读取
 
 # CamelDecoder — no more data
-error.encoding.camel_no_more_data = No more data to decode
+error.encoding.camel_no_more_data = 没有更多数据可解码
 
 # CamelDecoder — unexpected empty block
-error.encoding.camel_unexpected_empty_block = Unexpected empty block
+error.encoding.camel_unexpected_empty_block = 意外的空 block
 
 # FloatSprintzDecoder / IntSprintzDecoder / DoubleSprintzDecoder / LongSprintzDecoder — unsupported predictive method (4 sites, 1 key)
-error.encoding.sprintz_unsupported_predict_method = Sprintz predictive method {} is not supported.
+error.encoding.sprintz_unsupported_predict_method = 不支持 Sprintz 预测方法 {}。
 
 # FloatSprintzEncoder / IntSprintzEncoder / DoubleSprintzEncoder / LongSprintzEncoder — unsupported predictive method (4 sites, 1 key)
-error.encoding.sprintz_encoder_unsupported_predict_method = Config: Predict Method {} of SprintzEncoder is not supported.
+error.encoding.sprintz_encoder_unsupported_predict_method = Config: SprintzEncoder 不支持预测方法 {}。
 
 # TSEncodingBuilder — unsupported encoding type
-error.encoding.ts_encoding_builder_unsupported = Unsupported encoding: %1$s
+error.encoding.ts_encoding_builder_unsupported = 不支持的 encoding: %1$s
 
 # TSEncodingBuilder — data type not supported (many sites using ERROR_MSG pattern, 1 key)
-error.encoding.ts_encoding_builder_unsupported_type = %1$s doesn't support data type: %2$s
+error.encoding.ts_encoding_builder_unsupported_type = %1$s 不支持数据类型: %2$s
 
 # --- encoder LOG messages ---
 
 # DeltaBinaryEncoder / RegularDataEncoder — flush data to stream failed (2 sites, 1 key)
-log.encoding.flush_data_failed = flush data to stream failed!
+log.encoding.flush_data_failed = 刷新数据到流失败！
 
 # DoubleSprintzEncoder — encoding error
-log.encoding.sprintz_double_encode_error = Error occured when encoding INT32 Type value with with Sprintz
+log.encoding.sprintz_double_encode_error = 使用 Sprintz 编码 INT32 类型值时发生错误
 
 # FloatSprintzEncoder — encoding error
-log.encoding.sprintz_float_encode_error = Error occured when encoding Float Type value with with Sprintz
+log.encoding.sprintz_float_encode_error = 使用 Sprintz 编码 Float 类型值时发生错误
 
 # IntSprintzEncoder — encoding error
-log.encoding.sprintz_int_encode_error = Error occured when encoding INT32 Type value with with Sprintz
+log.encoding.sprintz_int_encode_error = 使用 Sprintz 编码 INT32 类型值时发生错误
 
 # LongSprintzEncoder — encoding error
-log.encoding.sprintz_long_encode_error = Error occured when encoding INT64 Type value with with Sprintz
+log.encoding.sprintz_long_encode_error = 使用 Sprintz 编码 INT64 类型值时发生错误
 
 # DictionaryEncoder — flush error
-log.encoding.dictionary_encoder_flush_error = tsfile-encoding DictionaryEncoder: error occurs when flushing
+log.encoding.dictionary_encoder_flush_error = tsfile-encoding DictionaryEncoder: 刷新时发生错误
 
 # PlainEncoder — encode Binary error
-log.encoding.plain_encoder_binary_error = tsfile-encoding PlainEncoder: error occurs when encode Binary value {}
+log.encoding.plain_encoder_binary_error = tsfile-encoding PlainEncoder: 编码 Binary 值 {} 时发生错误
 
 # RleEncoder — flush rle run error (context-carrying message)
-log.encoding.rle_flush_rle_run_error = tsfile-encoding RleEncoder : error occurs when writing nums to OutputStram when flushing left nums. numBufferedValues {}, repeatCount {}, bitPackedGroupCount{}, isBitPackRun {}, isBitWidthSaved {}
+log.encoding.rle_flush_rle_run_error = tsfile-encoding RleEncoder: 刷新剩余 nums 时向 OutputStram 写入 nums 发生错误。numBufferedValues {}，repeatCount {}，bitPackedGroupCount {}，isBitPackRun {}，isBitWidthSaved {}
 
 # RleEncoder — write full rle run debug
-log.encoding.rle_write_full_rle_run = tsfile-encoding RleEncoder : write full rle run to stream
+log.encoding.rle_write_full_rle_run = tsfile-encoding RleEncoder: 向流写入完整的 rle run
 
 # RleEncoder — writing full rle run error
-log.encoding.rle_full_rle_run_error =  error occurs when writing full rle run to OutputStram when repeatCount = {}.numBufferedValues {}, repeatCount {}, bitPackedGroupCount{}, isBitPackRun {}, isBitWidthSaved {}
+log.encoding.rle_full_rle_run_error =  当 repeatCount = {} 时，向 OutputStram 写入完整 rle run 发生错误。numBufferedValues {}，repeatCount {}，bitPackedGroupCount {}，isBitPackRun {}，isBitWidthSaved {}
 
 # RleEncoder — writing num error when repeatCount > min
-log.encoding.rle_write_num_error = tsfile-encoding RleEncoder : error occurs when writing num to OutputStram when repeatCount > {}.numBufferedValues {}, repeatCount {}, bitPackedGroupCount{}, isBitPackRun {}, isBitWidthSaved {}
+log.encoding.rle_write_num_error = tsfile-encoding RleEncoder: 当 repeatCount > {} 时，向 OutputStram 写入 num 发生错误。numBufferedValues {}，repeatCount {}，bitPackedGroupCount {}，isBitPackRun {}，isBitWidthSaved {}
 
 # --- decoder LOG messages ---
 
 # SinglePrecisionDecoderV1 — cannot read first float
-log.encoding.single_precision_v1_first_float_error = SinglePrecisionDecoderV1 cannot read first float number
+log.encoding.single_precision_v1_first_float_error = SinglePrecisionDecoderV1 无法读取首个 float 数字
 
 # SinglePrecisionDecoderV1 — cannot read following float
-log.encoding.single_precision_v1_following_float_error = SinglePrecisionDecoderV1 cannot read following float number
+log.encoding.single_precision_v1_following_float_error = SinglePrecisionDecoderV1 无法读取后续 float 数字
 
 # DoublePrecisionDecoderV1 — cannot read first double
-log.encoding.double_precision_v1_first_double_error = DoublePrecisionDecoderV1 cannot read first double number
+log.encoding.double_precision_v1_first_double_error = DoublePrecisionDecoderV1 无法读取首个 double 数字
 
 # DoublePrecisionDecoderV1 — cannot read following double
-log.encoding.double_precision_v1_following_double_error = DoublePrecisionDecoderV1 cannot read following double number
+log.encoding.double_precision_v1_following_double_error = DoublePrecisionDecoderV1 无法读取后续 double 数字
 
 # GorillaDecoderV1 — fill buffer failed
-log.encoding.gorilla_fill_buffer_failed = Failed to fill a new buffer, because there is no byte to read
+log.encoding.gorilla_fill_buffer_failed = 填充新 buffer 失败，因为没有可读的字节
 
 # IntRleDecoder — reading error
-log.encoding.int_rle_decoder_read_error = tsfile-encoding IntRleDecoder: error occurs when reading all encoding number, length is {}, bit width is {}
+log.encoding.int_rle_decoder_read_error = tsfile-encoding IntRleDecoder: 读取所有 encoding number 时发生错误，length {}，bit width {}
 
 # LongRleDecoder — reading error (same text but different logger)
-log.encoding.long_rle_decoder_read_error = tsfile-encoding IntRleDecoder: error occurs when reading all encoding number, length is {}, bit width is {}
+log.encoding.long_rle_decoder_read_error = tsfile-encoding IntRleDecoder: 读取所有 encoding number 时发生错误，length {}，bit width {}
 
 # DictionaryDecoder — decoding error
-log.encoding.dictionary_decoder_error = tsfile-decoding DictionaryDecoder: error occurs when decoding
+log.encoding.dictionary_decoder_error = tsfile-decoding DictionaryDecoder: 解码时发生错误
 
 # FloatSprintzDecoder / IntSprintzDecoder / DoubleSprintzDecoder / LongSprintzDecoder — readInt error (4 sites, 1 key)
-log.encoding.sprintz_decoder_read_error = Error occured when readInt with Sprintz Decoder.
+log.encoding.sprintz_decoder_read_error = 使用 Sprintz Decoder 执行 readInt 时发生错误。
 
 # TSEncodingBuilder — max string length negative value warning
-log.encoding.ts_encoding_max_string_length_negative = cannot set max string length to negative value, replaced with default value:{}
+log.encoding.ts_encoding_max_string_length_negative = max string length 不能设置为负值，已替换为默认值: {}
 
 # TSEncodingBuilder — max point number bad format warning
-log.encoding.ts_encoding_max_point_number_format = The format of max point number {} is not correct. Using default float precision.
+log.encoding.ts_encoding_max_point_number_format = max point number {} 格式不正确。使用默认 float 精度。
 
 # TSEncodingBuilder — max point number negative value warning
-log.encoding.ts_encoding_max_point_number_negative = cannot set max point number to negative value, replaced with default value:{}
+log.encoding.ts_encoding_max_point_number_negative = max point number 不能设置为负值，已替换为默认值: {}
 
 # IntZigzagEncoder — constructor debug
 log.encoding.int_zigzag_encoder_init = tsfile-encoding IntZigzagEncoder: int zigzag encoder
@@ -794,7 +796,7 @@ log.encoding.int_zigzag_encoder_init = tsfile-encoding IntZigzagEncoder: int zig
 log.encoding.long_zigzag_encoder_init = tsfile-encoding LongZigzagEncoder: long zigzag encoder
 
 # BitmapEncoder — constructor debug
-log.encoding.bitmap_encoder_init = tsfile-encoding BitmapEncoder: init bitmap encoder
+log.encoding.bitmap_encoder_init = tsfile-encoding BitmapEncoder: 初始化 bitmap encoder
 
 # IntZigzagDecoder — constructor debug
 log.encoding.int_zigzag_decoder_init = tsfile-decoding IntZigzagDecoder: int zigzag decoder
@@ -803,301 +805,311 @@ log.encoding.int_zigzag_decoder_init = tsfile-decoding IntZigzagDecoder: int zig
 log.encoding.long_zigzag_decoder_init = tsfile-encoding LongZigzagDecoder: long zigzag decoder
 
 # BitmapDecoder — constructor debug
-log.encoding.bitmap_decoder_init = tsfile-encoding BitmapDecoder: init bitmap decoder
+log.encoding.bitmap_decoder_init = tsfile-encoding BitmapDecoder: 初始化 bitmap decoder
 
 # BitmapDecoder — page data debug (2 args: number, byteArrayLength)
-log.encoding.bitmap_decoder_page_data = tsfile-encoding BitmapDecoder: number {} in current page, byte length {}
+log.encoding.bitmap_decoder_page_data = tsfile-encoding BitmapDecoder: 当前 page 中数量 {}，byte length {}
 
 # FloatDecoder — init decoder debug (6 keys for 6 branches)
-log.encoding.float_decoder_init_int_rle = tsfile-encoding FloatDecoder: init decoder using int-rle and float
-log.encoding.float_decoder_init_long_rle = tsfile-encoding FloatDecoder: init decoder using long-rle and double
-log.encoding.float_decoder_init_int_delta = tsfile-encoding FloatDecoder: init decoder using int-delta and float
-log.encoding.float_decoder_init_long_delta = tsfile-encoding FloatDecoder: init decoder using long-delta and double
-log.encoding.float_decoder_init_int_rlbe = tsfile-encoding FloatDecoder: init decoder using int-rlbe and float
-log.encoding.float_decoder_init_long_rlbe = tsfile-encoding FloatDecoder: init decoder using long-rlbe and double
+log.encoding.float_decoder_init_int_rle = tsfile-encoding FloatDecoder: 使用 int-rle 和 float 初始化 decoder
+log.encoding.float_decoder_init_long_rle = tsfile-encoding FloatDecoder: 使用 long-rle 和 double 初始化 decoder
+log.encoding.float_decoder_init_int_delta = tsfile-encoding FloatDecoder: 使用 int-delta 和 float 初始化 decoder
+log.encoding.float_decoder_init_long_delta = tsfile-encoding FloatDecoder: 使用 long-delta 和 double 初始化 decoder
+log.encoding.float_decoder_init_int_rlbe = tsfile-encoding FloatDecoder: 使用 int-rlbe 和 float 初始化 decoder
+log.encoding.float_decoder_init_long_rlbe = tsfile-encoding FloatDecoder: 使用 long-rlbe 和 double 初始化 decoder
 
 # === file ===
 
 # MetaMarker — unexpected marker byte
-error.file.unexpected_marker = Unexpected marker %1$s
+error.file.unexpected_marker = 意外的 marker %1$s
 
 # AbstractAlignedChunkMetadata — unsupported getNewType/setNewType (2 sites, 1 key)
-error.file.aligned_chunk_metadata_new_type_unsupported = AlignedChunkMetadata doesn't support setNewType method
+error.file.aligned_chunk_metadata_new_type_unsupported = AlignedChunkMetadata 不支持 setNewType 方法
 
 # AbstractAlignedChunkMetadata — serializeTo not supported
-error.file.aligned_chunk_metadata_serialize_unsupported = VectorChunkMetadata doesn't support serial method
+error.file.aligned_chunk_metadata_serialize_unsupported = VectorChunkMetadata 不支持 serial 方法
 
 # MetadataIndexConstructor — utility class guard
-error.file.utility_class = Utility class
+error.file.utility_class = 工具类
 
 # TsFileMetadata — encryptType missing for encryptLevel 1 or 2 (2 sites, 1 key with level arg)
-error.file.tsfile_metadata_no_encrypt_type = TsfileMetadata lack of encryptType while encryptLevel is %1$s
+error.file.tsfile_metadata_no_encrypt_type = encryptLevel 为 %1$s 时 TsfileMetadata 缺少 encryptType
 
 # TsFileMetadata — encryptKey missing for encryptLevel 1 or 2 (2 sites, 1 key with level arg)
-error.file.tsfile_metadata_no_encrypt_key = TsfileMetadata lack of encryptKey while encryptLevel is %1$s
+error.file.tsfile_metadata_no_encrypt_key = encryptLevel 为 %1$s 时 TsfileMetadata 缺少 encryptKey
 
 # TsFileMetadata — encryptKey null/empty for encryptLevel 1 or 2 (2 sites, 1 key with level arg)
-error.file.tsfile_metadata_null_encrypt_key = TsfileMetadata null encryptKey while encryptLevel is %1$s
+error.file.tsfile_metadata_null_encrypt_key = encryptLevel 为 %1$s 时 TsfileMetadata 的 encryptKey 为 null
 
 # TsFileMetadata — unsupported encryptLevel
-error.file.tsfile_metadata_unsupported_encrypt_level = Unsupported encryptLevel: %1$s
+error.file.tsfile_metadata_unsupported_encrypt_level = 不支持的 encryptLevel: %1$s
 
 # TableSchema — duplicate column name (4 sites, 1 key)
-error.file.table_schema_duplicate_column = Each column name in the table should be unique(case insensitive).
+error.file.table_schema_duplicate_column = table 中每个 column name 必须唯一（不区分大小写）。
 
 # ColumnSchemaBuilder — name must be non-empty
-error.file.column_schema_builder_name_empty = Column name must be a non empty string
+error.file.column_schema_builder_name_empty = Column name 必须是非空字符串
 
 # ColumnSchemaBuilder — name must be set before building
-error.file.column_schema_builder_name_not_set = Column name must be set before building
+error.file.column_schema_builder_name_not_set = 构建前必须先设置 column name
 
 # ColumnSchemaBuilder — data type must be set before building
-error.file.column_schema_builder_type_not_set = Column data type must be set before building
+error.file.column_schema_builder_type_not_set = 构建前必须先设置 column 数据类型
 
 # StringArrayDeviceID — all segments are null
-error.file.device_id_all_segments_null = All segments are null
+error.file.device_id_all_segments_null = 所有 segments 均为 null
 
 # Statistics — unsupported stat operation (many sites across subclasses; args: type name, op name)
-error.file.stats_unsupported = %1$s statistics does not support: %2$s
+error.file.stats_unsupported = %1$s statistics 不支持: %2$s
 
 # --- file LOG messages ---
 
 # IDeviceID — using default inefficient serialized size implementation
-log.file.device_id_default_serialized_size = Using default inefficient implementation of serialized size by {}
+log.file.device_id_default_serialized_size = {} 正在使用默认的低效 serialized size 实现
 
 # IDeviceID — failed to serialize device ID
-log.file.device_id_serialize_failed = Failed to serialize device ID: {}
+log.file.device_id_serialize_failed = 序列化设备 ID 失败: {}
 
 # Statistics — statistics classes mismatched, no merge
-log.file.stats_classes_mismatched = Statistics classes mismatched,no merge: {} v.s. {}
+log.file.stats_classes_mismatched = Statistics 类不匹配，不合并: {} vs {}
 
 # === external ===
 
 # ArrayUtils.remove — index out of bounds
-error.external.array_index_out_of_bounds = Index: %1$s, Length: %2$s
+error.external.array_index_out_of_bounds = Index: %1$s，Length: %2$s
 
 # ArrayUtils.addAll — incompatible array types
-error.external.array_incompatible_types = Cannot store %1$s in an array of %2$s
+error.external.array_incompatible_types = 无法将 %1$s 存入 %2$s 类型的数组
 
 # Validate.isTrue() — default false expression
-error.external.validate_expression_false = The validated expression is false
+error.external.validate_expression_false = 校验的表达式为 false
 
 # Validate.isTrue(boolean, String, long) — formatted message with long value
-error.external.validate_size_too_large = Request %1$,d exceeds maximum %2$,d
+# (caller passes String.format'd message; key used as wrapper for the pattern arg itself)
+error.external.validate_size_too_large = 请求 %1$,d 超过最大值 %2$,d
 
 # IOUtils.toByteArray — cannot read more than max bytes
-error.external.io_cannot_read_max_bytes = Cannot read more than %1$,d into a byte array
+error.external.io_cannot_read_max_bytes = 无法读取超过 %1$,d 字节到 byte 数组
 
 # IOUtils.toByteArray — size must be non-negative
-error.external.io_size_non_negative = Size must be equal or greater than zero: %1$s
+error.external.io_size_non_negative = 大小必须大于等于 0: %1$s
 
 # IOUtils.toByteArray — unexpected read size
-error.external.io_unexpected_read_size = Unexpected read size, current: %1$s, expected: %2$s
+error.external.io_unexpected_read_size = 意外的读取大小，当前: %1$s，期望: %2$s
 
 # IOUtils.toString — null input stream supplier
 error.external.io_null_input = input
 
 # FileUtils.requireDirectoryExists — not a directory
-error.external.file_not_a_directory = Parameter '%1$s' is not a directory: '%2$s'
+error.external.file_not_a_directory = 参数 '%1$s' 不是目录: '%2$s'
 
 # FileUtils.requireDirectoryExists — directory does not exist
-error.external.file_directory_not_exist = Directory '%1$s' does not exist.
+error.external.file_directory_not_exist = 目录 '%1$s' 不存在。
 
 # FileUtils.listFiles — I/O error listing directory
-error.external.file_list_io_error = Unknown I/O error listing contents of directory: %1$s
+error.external.file_list_io_error = 列出目录内容时发生未知 I/O 错误: %1$s
 
 # FileUtils.forceDelete — cannot delete file
-error.external.file_cannot_delete = Cannot delete file: %1$s
+error.external.file_cannot_delete = 无法删除文件: %1$s
 
 # FileUtils.forceDelete — file does not exist
-error.external.file_not_exist = File does not exist: %1$s
+error.external.file_not_exist = 文件不存在: %1$s
 
 # FileUtils.moveFile — failed to delete original after copy
-error.external.file_move_delete_original = Failed to delete original file '%1$s' after copy to '%2$s'
+error.external.file_move_delete_original = 复制到 '%2$s' 后删除原文件 '%1$s' 失败
 
 # FileUtils.checkFileExists — not a file
-error.external.file_param_not_a_file = Parameter '%1$s' is not a file: %2$s
+error.external.file_param_not_a_file = 参数 '%1$s' 不是文件: %2$s
 
 # FileUtils.checkFileExists — source does not exist
-error.external.file_source_not_exist = Source '%1$s' does not exist
+error.external.file_source_not_exist = 源 '%1$s' 不存在
 
 # FileUtils.requireAbsent — file already exists
-error.external.file_already_exists = File element in parameter '%1$s' already exists: '%2$s'
+error.external.file_already_exists = 参数 '%1$s' 中的文件元素已存在: '%2$s'
 
 # FileUtils.copyFile — cannot set file time
-error.external.file_cannot_set_time = Cannot set the file time.
+error.external.file_cannot_set_time = 无法设置文件时间。
 
 # FileUtils.requireCanonicalPathsNotEquals — canonical paths equal
-error.external.file_canonical_paths_equal = File canonical paths are equal: '%1$s' (file1='%2$s', file2='%3$s')
+error.external.file_canonical_paths_equal = 文件 canonical paths 相等: '%1$s'（file1='%2$s'，file2='%3$s'）
 
 # FileUtils.mkdirs — cannot create directory
-error.external.file_cannot_create_directory = Cannot create directory '%1$s'.
+error.external.file_cannot_create_directory = 无法创建目录 '%1$s'。
+
+# FileUtils.validateMoveParameters — source does not exist (same key as checkFileExists for source)
+# (reuses error.external.file_source_not_exist)
 
 # FileUtils.requireExistsChecked — file system element does not exist
-error.external.file_element_not_exist = File system element for parameter '%1$s' does not exist: '%2$s'
+error.external.file_element_not_exist = 参数 '%1$s' 的文件系统元素不存在: '%2$s'
+
+# FileUtils.requireDirectory — not a directory (same pattern as requireDirectoryExists)
+# (reuses error.external.file_not_a_directory)
 
 # FileUtils.moveDirectory — cannot move to subdirectory of itself
-error.external.file_move_to_subdirectory = Cannot move directory: %1$s to a subdirectory of itself: %2$s
+error.external.file_move_to_subdirectory = 无法将目录 %1$s 移动到其自身的子目录: %2$s
 
 # FileUtils.moveDirectory — failed to delete original directory after copy
-error.external.file_move_delete_directory = Failed to delete original directory '%1$s' after copy to '%2$s'
+error.external.file_move_delete_directory = 复制到 '%2$s' 后删除原目录 '%1$s' 失败
 
 # FileUtils.requireCanWrite — file is not writable
-error.external.file_not_writable = File parameter '%1$s is not writable: '%2$s'
+error.external.file_not_writable = 文件参数 '%1$s 不可写: '%2$s'
 
 # FilenameUtils.requireNonNullChars — null character in path
-error.external.filename_null_char = Null character present in file/path name. There are no known legitimate use cases for such data, but several injection attacks may use it
+error.external.filename_null_char = 文件/路径名中包含 null 字符。此类数据没有已知的合法用例，但可能被多种注入攻击利用
 
 # FilenameUtils.indexOfExtension — NTFS ADS separator in file name
-error.external.filename_ntfs_ads_forbidden = NTFS ADS separator (':') in file name is forbidden.
+error.external.filename_ntfs_ads_forbidden = 文件名中禁止使用 NTFS ADS 分隔符（':')。
 
 # FilenameUtils.flipSeparator — invalid separator character
 error.external.filename_invalid_separator = %1$s
 
 # PathUtils.setReadOnly — DOS or POSIX not available
-error.external.path_file_ops_not_available = DOS or POSIX file operations not available for '%1$s', linkOptions %2$s
+error.external.path_file_ops_not_available = '%1$s' 不支持 DOS 或 POSIX 文件操作，linkOptions %2$s
 
 # PathUtils.deleteFile — is a directory, not a file
 error.external.path_is_directory = %1$s
 
 # PathUtils.deleteFile — I/O error
-error.external.path_set_readonly_io_error = DOS or POSIX file operations not available for '%1$s', linkOptions %2$s
+error.external.path_set_readonly_io_error = '%1$s' 不支持 DOS 或 POSIX 文件操作，linkOptions %2$s
 
 # ReaderInputStream.checkMinBufferSize — buffer too small
-error.external.reader_input_stream_buffer_too_small = Buffer size %1$,d must be at least %2$s for a CharsetEncoder %3$s.
+error.external.reader_input_stream_buffer_too_small = Buffer size %1$,d 必须至少为 %2$s（CharsetEncoder %3$s）。
 
 # ReaderInputStream.read — index out of bounds
-error.external.reader_input_stream_index_out_of_bounds = Array size=%1$s, offset=%2$s, length=%3$s
+error.external.reader_input_stream_index_out_of_bounds = Array size=%1$s，offset=%2$s，length=%3$s
 
 # UnsynchronizedByteArrayInputStream — length cannot be negative
-error.external.ubais_length_negative = length cannot be negative
+error.external.ubais_length_negative = length 不能为负
 
 # UnsynchronizedByteArrayInputStream — offset cannot be negative
-error.external.ubais_offset_negative = offset cannot be negative
+error.external.ubais_offset_negative = offset 不能为负
 
 # UnsynchronizedByteArrayInputStream.skip — skipping backward not supported
-error.external.ubais_skip_backward = Skipping backward is not supported
+error.external.ubais_skip_backward = 不支持向后 skip
 
 # UnsynchronizedByteArrayOutputStream — negative initial size
-error.external.ubaos_negative_initial_size = Negative initial size: %1$s
+error.external.ubaos_negative_initial_size = 初始大小为负: %1$s
 
 # UnsynchronizedByteArrayOutputStream.write — offset/length out of bounds
-error.external.ubaos_offset_length_out_of_bounds = offset=%1$,d, length=%2$,d
+error.external.ubaos_offset_length_out_of_bounds = offset=%1$,d，length=%2$,d
+
+# ByteArrayOutputStream — negative initial size (same as UBAOS)
+# (reuses error.external.ubaos_negative_initial_size)
 
 # WriterOutputStream — UTF-16 IBM JDK broken support
-error.external.writer_output_stream_utf16_ibm = UTF-16 requested when running on an IBM JDK with broken UTF-16 support. Please find a JDK that supports UTF-16 if you intend to use UF-16 with WriterOutputStream
+error.external.writer_output_stream_utf16_ibm = 在 UTF-16 支持有问题的 IBM JDK 上请求 UTF-16。如需在 WriterOutputStream 中使用 UTF-16，请寻找支持 UTF-16 的 JDK
 
 # WriterOutputStream.processInput — unexpected coder result
-error.external.writer_output_stream_unexpected_coder = Unexpected coder result
+error.external.writer_output_stream_unexpected_coder = 意外的 coder 结果
 
 # AbstractOrigin.getFile — not supported
-error.external.abstract_origin_get_file = %1$s#getFile() for %2$s origin %3$s
+error.external.abstract_origin_get_file = %1$s#getFile()，origin %2$s %3$s
 
 # AbstractOrigin.getPath — not supported
-error.external.abstract_origin_get_path = %1$s#getPath() for %2$s origin %3$s
+error.external.abstract_origin_get_path = %1$s#getPath()，origin %2$s %3$s
 
 # AbstractStreamBuilder.throwIae — request exceeds maximum
-error.external.stream_builder_request_exceeds_max = Request %1$,d exceeds maximum %2$,d
+error.external.stream_builder_request_exceeds_max = 请求 %1$,d 超过最大值 %2$,d
 
 # AbstractOriginSupplier.checkOrigin — origin is null
 error.external.origin_null = origin == null
 
-# AbstractEmptyMapIterator — iterator contains no elements
-error.external.empty_map_iterator_no_elements = Iterator contains no elements
+# AbstractEmptyMapIterator — iterator contains no elements (3 operations: setValue, getKey, getValue)
+error.external.empty_map_iterator_no_elements = Iterator 不包含任何元素
 
-# AbstractEmptyIterator — iterator contains no elements
-error.external.empty_iterator_no_elements = Iterator contains no elements
+# AbstractEmptyIterator — iterator contains no elements (3 operations: remove, next, previous)
+error.external.empty_iterator_no_elements = Iterator 不包含任何元素
 
 # AbstractLinkedMap — map is empty (first/last)
-error.external.linked_map_empty = Map is empty
+error.external.linked_map_empty = Map 为空
 
 # AbstractLinkedMap — index less than zero
-error.external.linked_map_index_negative = Index %1$s is less than zero
+error.external.linked_map_index_negative = Index %1$s 小于 0
 
 # AbstractLinkedMap — index invalid for size
-error.external.linked_map_index_invalid = Index %1$s is invalid for size %2$s
+error.external.linked_map_index_invalid = Index %1$s 对于 size %2$s 无效
 
 # AbstractHashedMap — initial capacity negative
-error.external.hashed_map_capacity_negative = Initial capacity must be a non negative number
+error.external.hashed_map_capacity_negative = 初始容量必须是非负数
 
 # AbstractHashedMap — load factor not positive
-error.external.hashed_map_load_factor_invalid = Load factor must be greater than 0
+error.external.hashed_map_load_factor_invalid = Load factor 必须大于 0
 
-# AbstractHashedMap constants — iterator state errors
-error.external.map_no_next_entry = No next() entry in the iteration
-error.external.map_no_previous_entry = No previous() entry in the iteration
-error.external.map_remove_invalid = remove() can only be called once after next()
-error.external.map_getkey_invalid = getKey() can only be called after next() and before remove()
-error.external.map_getvalue_invalid = getValue() can only be called after next() and before remove()
-error.external.map_setvalue_invalid = setValue() can only be called after next() and before remove()
+# AbstractHashedMap constants — iterator state errors (6 constants → 6 keys)
+error.external.map_no_next_entry = 迭代中没有 next() entry
+error.external.map_no_previous_entry = 迭代中没有 previous() entry
+error.external.map_remove_invalid = next() 之后 remove() 只能调用一次
+error.external.map_getkey_invalid = getKey() 只能在 next() 之后、remove() 之前调用
+error.external.map_getvalue_invalid = getValue() 只能在 next() 之后、remove() 之前调用
+error.external.map_setvalue_invalid = setValue() 只能在 next() 之后、remove() 之前调用
 
 # LRUMap — max size constraint
-error.external.lrumap_max_size_positive = LRUMap max size must be greater than 0
+error.external.lrumap_max_size_positive = LRUMap max size 必须大于 0
 
-# LRUMap — initial size vs max size constraint (note: typo "greather" preserved)
-error.external.lrumap_initial_exceeds_max = LRUMap initial size must not be greather than max size
+# LRUMap — initial size vs max size constraint (note: typo "greather" preserved for behaviour parity)
+error.external.lrumap_initial_exceeds_max = LRUMap initial size 不能大于 max size
 
 # LRUMap.moveToMRU — entry.before is null
-error.external.lrumap_entry_before_null = Entry.before is null. This should not occur if your keys are immutable, and you have used synchronization properly.
+error.external.lrumap_entry_before_null = Entry.before 为 null。如果你的 keys 是不可变的且正确使用了同步，则不应发生这种情况。
 
 # LRUMap.moveToMRU — cannot move header to MRU
-error.external.lrumap_cannot_move_header = Can't move header to MRU This should not occur if your keys are immutable, and you have used synchronization properly.
+error.external.lrumap_cannot_move_header = 无法将 header 移至 MRU。如果你的 keys 是不可变的且正确使用了同步，则不应发生这种情况。
 
 # LRUMap.addMapping — entry.after is null (scanUntilRemovable path)
-error.external.lrumap_entry_after_null = Entry.after=null, header.after=%1$s header.before=%2$s key=%3$s value=%4$s size=%5$s maxSize=%6$s This should not occur if your keys are immutable, and you have used synchronization properly.
+error.external.lrumap_entry_after_null = Entry.after=null，header.after=%1$s header.before=%2$s key=%3$s value=%4$s size=%5$s maxSize=%6$s。如果你的 keys 是不可变的且正确使用了同步，则不应发生这种情况。
 
 # LRUMap.addMapping — reuse is null
-error.external.lrumap_reuse_null = reuse=null, header.after=%1$s header.before=%2$s key=%3$s value=%4$s size=%5$s maxSize=%6$s This should not occur if your keys are immutable, and you have used synchronization properly.
+error.external.lrumap_reuse_null = reuse=null，header.after=%1$s header.before=%2$s key=%3$s value=%4$s size=%5$s maxSize=%6$s。如果你的 keys 是不可变的且正确使用了同步，则不应发生这种情况。
 
 # LRUMap.reuseMapping — loop is null (entry not found)
-error.external.lrumap_loop_null = Entry.next=null, data[removeIndex]=%1$s previous=%2$s key=%3$s value=%4$s size=%5$s maxSize=%6$s This should not occur if your keys are immutable, and you have used synchronization properly.
+error.external.lrumap_loop_null = Entry.next=null，data[removeIndex]=%1$s previous=%2$s key=%3$s value=%4$s size=%5$s maxSize=%6$s。如果你的 keys 是不可变的且正确使用了同步，则不应发生这种情况。
 
 # LRUMap.reuseMapping — NullPointerException
-error.external.lrumap_npe = NPE, entry=%1$s entryIsHeader=%2$s key=%3$s value=%4$s size=%5$s maxSize=%6$s This should not occur if your keys are immutable, and you have used synchronization properly.
+error.external.lrumap_npe = NPE，entry=%1$s entryIsHeader=%2$s key=%3$s value=%4$s size=%5$s maxSize=%6$s。如果你的 keys 是不可变的且正确使用了同步，则不应发生这种情况。
 
 # ComparatorChain.checkChainIntegrity — must contain at least one comparator
-error.external.comparator_chain_empty = ComparatorChains must contain at least one Comparator
+error.external.comparator_chain_empty = ComparatorChain 必须至少包含一个 Comparator
 
 # === encrypt ===
 
 # IEncryptor.getEncryptor — class not found (class name arg)
-error.encrypt.encryptor_class_not_found = Get encryptor class failed, class not found: %1$s
+error.encrypt.encryptor_class_not_found = 获取 encryptor class 失败，class not found: %1$s
 
 # IEncryptor.getEncryptor — no constructor (class name arg)
-error.encrypt.encryptor_no_constructor = Get constructor for encryptor failed: %1$s
+error.encrypt.encryptor_no_constructor = 获取 encryptor 构造函数失败: %1$s
 
 # IEncryptor.getEncryptor — instantiation failed (class name arg)
-error.encrypt.encryptor_instantiation_failed = New encryptor instance failed: %1$s
+error.encrypt.encryptor_instantiation_failed = 实例化 encryptor 失败: %1$s
 
 # IDecryptor.getDecryptor — class not found (class name arg)
-error.encrypt.decryptor_class_not_found = Get decryptor class failed, class not found: %1$s
+error.encrypt.decryptor_class_not_found = 获取 decryptor class 失败，class not found: %1$s
 
 # IDecryptor.getDecryptor — no constructor (class name arg)
-error.encrypt.decryptor_no_constructor = Get constructor for decryptor failed: %1$s
+error.encrypt.decryptor_no_constructor = 获取 decryptor 构造函数失败: %1$s
 
 # IDecryptor.getDecryptor — instantiation failed (class name arg)
-error.encrypt.decryptor_instantiation_failed = New decryptor instance failed: %1$s
+error.encrypt.decryptor_instantiation_failed = 实例化 decryptor 失败: %1$s
 
 # EncryptUtils.getEncryptKeyFromToken — key derivation failed
-error.encrypt.key_derivation_failed = Error deriving key from token
+error.encrypt.key_derivation_failed = 从 token 派生 key 失败
 
 # EncryptUtils.deriveKeyInternal — dkLen not positive (value arg)
-error.encrypt.dklen_not_positive = main key's dkLen must be positive integer: %1$s
+error.encrypt.dklen_not_positive = main key 的 dkLen 必须为正整数: %1$s
 
 # EncryptUtils.deriveKeyInternal — dkLen too long (value arg)
-error.encrypt.dklen_too_long = main key's dkLen is too long: %1$s
+error.encrypt.dklen_too_long = main key 的 dkLen 过长: %1$s
 
 # EncryptUtils.getNormalKeyStr / generateEncryptParameter — SHA-256 not found
-error.encrypt.sha256_not_found = SHA-256 algorithm not found while using SHA-256 to generate data key
+error.encrypt.sha256_not_found = 使用 SHA-256 生成 data key 时找不到 SHA-256 算法
 
 # EncryptUtils.getEncrypt — class not found (encryptType arg)
-error.encrypt.encrypt_class_not_found = Get encryptor class failed: %1$s
+error.encrypt.encrypt_class_not_found = 获取 encryptor class 失败: %1$s
 
 # EncryptUtils.getEncrypt — no constructor (encryptType arg)
-error.encrypt.encrypt_no_constructor = Get constructor for encryptor failed: %1$s
+error.encrypt.encrypt_no_constructor = 获取 encryptor 构造函数失败: %1$s
 
 # EncryptUtils.getEncrypt — instantiation failed (encryptType arg)
-error.encrypt.encrypt_instantiation_failed = New encryptor instance failed: %1$s
+error.encrypt.encrypt_instantiation_failed = 实例化 encryptor 失败: %1$s
 
 # === compress ===
 
@@ -1108,134 +1120,134 @@ error.compress.type_not_supported_null = NULL
 error.compress.type_not_supported = %1$s
 
 # NoCompressor — compress not supported (3 method variants, 1 key)
-error.compress.no_compressor_not_supported = No Compressor does not support compression function
+error.compress.no_compressor_not_supported = NoCompressor 不支持压缩功能
 
 # NoUnCompressor — uncompress ByteBuffer not supported
-error.compress.no_uncompressor_not_supported = NoUnCompressor does not support this method.
+error.compress.no_uncompressor_not_supported = NoUnCompressor 不支持此方法。
 
 # LZ4UnCompressor / GZIPUnCompressor / LZMA2UnCompressor — getUncompressedLength not supported (6 sites, 1 key)
-error.compress.get_uncompress_length_unsupported = unsupported get uncompress length
+error.compress.get_uncompress_length_unsupported = 不支持获取 uncompress length
 
 # --- compress LOG messages ---
 
 # SnappyUnCompressor — uncompress input byte error (2 sites, 1 key)
-log.compress.snappy_uncompress_error = tsfile-compression SnappyUnCompressor: errors occurs when uncompress input byte
+log.compress.snappy_uncompress_error = tsfile-compression SnappyUnCompressor: 解压输入字节时发生错误
 
 # LZ4UnCompressor — uncompress input byte error (3 sites, 1 key)
-log.compress.lz4_uncompress_error = tsfile-compression LZ4UnCompressor: errors occurs when uncompress input byte
+log.compress.lz4_uncompress_error = tsfile-compression LZ4UnCompressor: 解压输入字节时发生错误
 
 # === fileSystem ===
 
 # HDFSOutputFactory / OSFileOutputFactory — init error: get input class
-log.fs.hdfs_output_factory_init_error = Failed to get HDFSInput in Hadoop file system. Please check your dependency of Hadoop module.
-log.fs.os_output_factory_init_error = Failed to get OSInput in object storage. Please check your dependency of object storage module.
+log.fs.hdfs_output_factory_init_error = 在 Hadoop file system 中获取 HDFSInput 失败。请检查 Hadoop 模块的依赖。
+log.fs.os_output_factory_init_error = 在 object storage 中获取 OSInput 失败。请检查 object storage 模块的依赖。
 
 # HDFSOutputFactory / OSFileOutputFactory — getTsFileOutput error (path arg)
-log.fs.hdfs_output_factory_get_error = Failed to get TsFile output of file: {}. Please check your dependency of Hadoop module.
-log.fs.os_output_factory_get_error = Failed to get TsFile output of file: {}. Please check your dependency of object storage module.
+log.fs.hdfs_output_factory_get_error = 获取文件 {} 的 TsFile output 失败。请检查 Hadoop 模块的依赖。
+log.fs.os_output_factory_get_error = 获取文件 {} 的 TsFile output 失败。请检查 object storage 模块的依赖。
 
 # LocalFSOutputFactory — getTsFileOutput error (path arg)
-log.fs.local_output_factory_get_error = Failed to get TsFile output of file: {},
+log.fs.local_output_factory_get_error = 获取文件 {} 的 TsFile output 失败，
 
 # HDFSFactory — init error
-log.fs.hdfs_factory_init_error = Failed to get Hadoop file system. Please check your dependency of Hadoop module.
+log.fs.hdfs_factory_init_error = 获取 Hadoop file system 失败。请检查 Hadoop 模块的依赖。
 
 # OSFSFactory — init error
-log.fs.os_factory_init_error = Failed to get object storage. Please check your dependency of object storage module.
+log.fs.os_factory_init_error = 获取 object storage 失败。请检查 object storage 模块的依赖。
 
 # HDFSFactory.getFileWithParent — get file error (path arg)
-log.fs.hdfs_factory_get_file_with_parent_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+log.fs.hdfs_factory_get_file_with_parent_error = 获取文件 {} 失败。请检查 Hadoop 模块的依赖。
 
 # HDFSFactory.getFile(String) — get file error (path arg)
-log.fs.hdfs_factory_get_file_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+log.fs.hdfs_factory_get_file_error = 获取文件 {} 失败。请检查 Hadoop 模块的依赖。
 
 # HDFSFactory.getFile(String, String) — get file error (path arg)
-log.fs.hdfs_factory_get_file2_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+log.fs.hdfs_factory_get_file2_error = 获取文件 {} 失败。请检查 Hadoop 模块的依赖。
 
 # HDFSFactory.getFile(File, String) — get file error (path arg)
-log.fs.hdfs_factory_get_file3_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+log.fs.hdfs_factory_get_file3_error = 获取文件 {} 失败。请检查 Hadoop 模块的依赖。
 
 # HDFSFactory.getFile(URI) — get file error (uri arg)
-log.fs.hdfs_factory_get_file_uri_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+log.fs.hdfs_factory_get_file_uri_error = 获取文件 {} 失败。请检查 Hadoop 模块的依赖。
 
 # HDFSFactory.getBufferedReader — error (path arg)
-log.fs.hdfs_factory_get_reader_error = Failed to get buffered reader for {}. Please check your dependency of Hadoop module.
+log.fs.hdfs_factory_get_reader_error = 获取 {} 的 buffered reader 失败。请检查 Hadoop 模块的依赖。
 
 # HDFSFactory.getBufferedWriter — error (path arg)
-log.fs.hdfs_factory_get_writer_error = Failed to get buffered writer for {}. Please check your dependency of Hadoop module.
+log.fs.hdfs_factory_get_writer_error = 获取 {} 的 buffered writer 失败。请检查 Hadoop 模块的依赖。
 
 # HDFSFactory.getBufferedInputStream — error (path arg)
-log.fs.hdfs_factory_get_input_stream_error = Failed to get buffered input stream for {}. Please check your dependency of Hadoop module.
+log.fs.hdfs_factory_get_input_stream_error = 获取 {} 的 buffered input stream 失败。请检查 Hadoop 模块的依赖。
 
 # HDFSFactory.getBufferedOutputStream — error (path arg)
-log.fs.hdfs_factory_get_output_stream_error = Failed to get buffered output stream for {}. Please check your dependency of Hadoop module.
+log.fs.hdfs_factory_get_output_stream_error = 获取 {} 的 buffered output stream 失败。请检查 Hadoop 模块的依赖。
 
 # HDFSFactory.listFilesBySuffix — error (folder, suffix args)
-log.fs.hdfs_factory_list_suffix_error = Failed to list files in {} with SUFFIX {}. Please check your dependency of Hadoop module.
+log.fs.hdfs_factory_list_suffix_error = 列出 {} 中后缀为 {} 的文件失败。请检查 Hadoop 模块的依赖。
 
 # HDFSFactory.listFilesByPrefix — error (folder, prefix args)
-log.fs.hdfs_factory_list_prefix_error = Failed to list files in {} with PREFIX {}. Please check your dependency of Hadoop module.
+log.fs.hdfs_factory_list_prefix_error = 列出 {} 中前缀为 {} 的文件失败。请检查 Hadoop 模块的依赖。
 
 # OSFSFactory.getFileWithParent — error (path arg)
-log.fs.os_factory_get_file_with_parent_error = Failed to get file: {}. Please check your dependency of object storage module.
+log.fs.os_factory_get_file_with_parent_error = 获取文件 {} 失败。请检查 object storage 模块的依赖。
 
 # OSFSFactory.getFile(String) — error (path arg)  [note: message says Hadoop module — matching original]
-log.fs.os_factory_get_file_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+log.fs.os_factory_get_file_error = 获取文件 {} 失败。请检查 Hadoop 模块的依赖。
 
 # OSFSFactory.getFile(String, String) — error (path arg) [matches original]
-log.fs.os_factory_get_file2_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+log.fs.os_factory_get_file2_error = 获取文件 {} 失败。请检查 Hadoop 模块的依赖。
 
 # OSFSFactory.getFile(File, String) — error (path arg) [matches original]
-log.fs.os_factory_get_file3_error = Failed to get file: {}. Please check your dependency of Hadoop module.
+log.fs.os_factory_get_file3_error = 获取文件 {} 失败。请检查 Hadoop 模块的依赖。
 
 # OSFSFactory.getFile(URI) — error (uri arg)
-log.fs.os_factory_get_file_uri_error = Failed to get file: {}. Please check your dependency of object storage module.
+log.fs.os_factory_get_file_uri_error = 获取文件 {} 失败。请检查 object storage 模块的依赖。
 
 # OSFSFactory.getBufferedReader — error (path arg)
-log.fs.os_factory_get_reader_error = Failed to get buffered reader for {}. Please check your dependency of object storage module.
+log.fs.os_factory_get_reader_error = 获取 {} 的 buffered reader 失败。请检查 object storage 模块的依赖。
 
 # OSFSFactory.getBufferedWriter — error (path arg)
-log.fs.os_factory_get_writer_error = Failed to get buffered writer for {}. Please check your dependency of object storage module.
+log.fs.os_factory_get_writer_error = 获取 {} 的 buffered writer 失败。请检查 object storage 模块的依赖。
 
 # OSFSFactory.getBufferedInputStream — error (path arg)
-log.fs.os_factory_get_input_stream_error = Failed to get buffered input stream for {}. Please check your dependency of object storage module.
+log.fs.os_factory_get_input_stream_error = 获取 {} 的 buffered input stream 失败。请检查 object storage 模块的依赖。
 
 # OSFSFactory.getBufferedOutputStream — error (path arg)
-log.fs.os_factory_get_output_stream_error = Failed to get buffered output stream for {}. Please check your dependency of object storage module.
+log.fs.os_factory_get_output_stream_error = 获取 {} 的 buffered output stream 失败。请检查 object storage 模块的依赖。
 
 # OSFSFactory.listFilesBySuffix — error (folder, suffix args)
-log.fs.os_factory_list_suffix_error = Failed to list files in {} with SUFFIX {}. Please check your dependency of object storage module.
+log.fs.os_factory_list_suffix_error = 列出 {} 中后缀为 {} 的文件失败。请检查 object storage 模块的依赖。
 
 # OSFSFactory.listFilesByPrefix — error (folder, prefix args)
-log.fs.os_factory_list_prefix_error = Failed to list files in {} with PREFIX {}. Please check your dependency of object storage module.
+log.fs.os_factory_list_prefix_error = 列出 {} 中前缀为 {} 的文件失败。请检查 object storage 模块的依赖。
 
 # OSFSFactory.copyFile — unsupported copy direction (srcType, destType args)
-error.fs.os_factory_copy_unsupported = Doesn't support copy file from %1$s to %2$s.
+error.fs.os_factory_copy_unsupported = 不支持从 %1$s 复制文件到 %2$s。
 
 # LocalFSFactory — buffered reader/writer/stream errors (4 sites, 4 keys)
-log.fs.local_factory_get_reader_error = Failed to get buffered reader for {}.
-log.fs.local_factory_get_writer_error = Failed to get buffered writer for {}.
-log.fs.local_factory_get_input_stream_error = Failed to get buffered input stream for {}.
-log.fs.local_factory_get_output_stream_error = Failed to get buffered output stream for {}.
+log.fs.local_factory_get_reader_error = 获取 {} 的 buffered reader 失败。
+log.fs.local_factory_get_writer_error = 获取 {} 的 buffered writer 失败。
+log.fs.local_factory_get_input_stream_error = 获取 {} 的 buffered input stream 失败。
+log.fs.local_factory_get_output_stream_error = 获取 {} 的 buffered output stream 失败。
 
 # HybridFSFactory.moveFile — unsupported cross-type move (srcType, destType args)
-error.fs.hybrid_factory_move_unsupported = Doesn't support move file from %1$s to %2$s.
+error.fs.hybrid_factory_move_unsupported = 不支持从 %1$s 移动文件到 %2$s。
 
 # HybridFSFactory.copyFile — unsupported cross-type copy (srcType, destType args)
-error.fs.hybrid_factory_copy_unsupported = Doesn't support move file from %1$s to %2$s.
+error.fs.hybrid_factory_copy_unsupported = 不支持从 %1$s 移动文件到 %2$s。
 
 # OSFileInputFactory / HDFSInputFactory — init error
-log.fs.os_input_factory_init_error = Failed to get OSInput in object storage. Please check your dependency of object storage module.
-log.fs.hdfs_input_factory_init_error = Failed to get HDFSInput in Hadoop file system. Please check your dependency of Hadoop module.
+log.fs.os_input_factory_init_error = 在 object storage 中获取 OSInput 失败。请检查 object storage 模块的依赖。
+log.fs.hdfs_input_factory_init_error = 在 Hadoop file system 中获取 HDFSInput 失败。请检查 Hadoop 模块的依赖。
 
 # OSFileInputFactory.getTsFileInput — error (path arg)
-error.fs.os_input_factory_get_error = Failed to get TsFile input of file: %1$s. Please check your dependency of object storage module.
+error.fs.os_input_factory_get_error = 获取文件 %1$s 的 TsFile input 失败。请检查 object storage 模块的依赖。
 
 # HDFSInputFactory.getTsFileInput — error (path arg)
-error.fs.hdfs_input_factory_get_error = Failed to get TsFile input of file: %1$s. Please check your dependency of Hadoop module.
+error.fs.hdfs_input_factory_get_error = 获取文件 %1$s 的 TsFile input 失败。请检查 Hadoop 模块的依赖。
 
 # FSUtils — load file system class error (fsType name arg)
-log.fs.fsutils_load_class_error = Failed to get {} file system. Please check your dependency of {} module.
+log.fs.fsutils_load_class_error = 获取 {} file system 失败。请检查 {} 模块的依赖。
 
 # === utils ===
 
@@ -1243,296 +1255,296 @@ log.fs.fsutils_load_class_error = Failed to get {} file system. Please check you
 error.utils.buffer_size_not_positive = Buffer size <= 0
 
 # NoSyncBufferedInputStream — stream closed (2 sites, 1 key)
-error.utils.stream_closed = Stream closed
+error.utils.stream_closed = 流已关闭
 
 # NoSyncBufferedInputStream — buffer size <= 0
 error.utils.buffer_size_not_positive_input = Buffer size <= 0
 
 # NoSyncBufferedInputStream — index out of bounds
-error.utils.index_out_of_bounds_read = Index out of bounds
+error.utils.index_out_of_bounds_read = 索引越界
 
 # NoSyncBufferedInputStream — resetting to invalid mark
-error.utils.reset_invalid_mark = Resetting to invalid mark
+error.utils.reset_invalid_mark = 重置到无效的 mark
 
 # PublicBAOS — index out of bounds
-error.utils.public_baos_index_out_of_bounds = Index out of bounds
+error.utils.public_baos_index_out_of_bounds = 索引越界
 
 # Loader — null input object
-error.utils.loader_null_input = Input object cannot be null
+error.utils.loader_null_input = 输入对象不能为 null
 
 # FilterDeserialize — unsupported operator type (type arg)
-error.utils.filter_unsupported_operator_type = Unsupported operator type:%1$s
+error.utils.filter_unsupported_operator_type = 不支持的 operator 类型: %1$s
 
 # FilterDeserialize — unsupported class serialize id (used for 15 methods via constant; id arg)
-error.utils.filter_unsupported_class_id = Unsupported class serialize id:%1$s
+error.utils.filter_unsupported_class_id = 不支持的 class serialize id: %1$s
 
 # ReadWriteForEncodingUtils — too many bytes for bit width (paddedByteNum arg; 4 sites, 1 key)
-error.utils.too_long_byte_format = Too long byte number %1$s
+error.utils.too_long_byte_format = 字节数过长 %1$s
 
 # BytesUtils — invalid input: desc.length - offset < 4 (intToBytes float variant)
-error.utils.bytes_desc_offset_too_short = Invalid input: desc.length - offset < 4
+error.utils.bytes_desc_offset_too_short = 无效输入: desc.length - offset < 4
 
 # BytesUtils — invalid input: i > 0xFFFF
-error.utils.bytes_int_too_large = Invalid input: %1$s > 0xFFFF
+error.utils.bytes_int_too_large = 无效输入: %1$s > 0xFFFF
 
 # BytesUtils — invalid input: ret.length != 2
-error.utils.bytes_ret_length_not_two = Invalid input: ret.length != 2
+error.utils.bytes_ret_length_not_two = 无效输入: ret.length != 2
 
 # BytesUtils — row count too large
-error.utils.bytes_row_count_too_large = Row count is larger than Integer.MAX_VALUE
+error.utils.bytes_row_count_too_large = 行数大于 Integer.MAX_VALUE
 
 # BytesUtils — invalid input: bytes.length - offset < 4
-error.utils.bytes_offset_too_short_4 = Invalid input: bytes.length - offset < 4
+error.utils.bytes_offset_too_short_4 = 无效输入: bytes.length - offset < 4
 
 # BytesUtils — invalid input: b.length != 4
-error.utils.bytes_b_length_not_four = Invalid input: b.length != 4
+error.utils.bytes_b_length_not_four = 无效输入: b.length != 4
 
 # BytesUtils — invalid input: b.length - offset < 4
-error.utils.bytes_b_offset_too_short_4 = Invalid input: b.length - offset < 4
+error.utils.bytes_b_offset_too_short_4 = 无效输入: b.length - offset < 4
 
 # BytesUtils — invalid input: bytes.length - offset < 8
-error.utils.bytes_offset_too_short_8 = Invalid input: bytes.length - offset < 8
+error.utils.bytes_offset_too_short_8 = 无效输入: bytes.length - offset < 8
 
 # BytesUtils — invalid input: b.length != 1
-error.utils.bytes_b_length_not_one = Invalid input: b.length != 1
+error.utils.bytes_b_length_not_one = 无效输入: b.length != 1
 
 # BytesUtils — invalid input: b.length - offset < 1
-error.utils.bytes_b_offset_too_short_1 = Invalid input: b.length - offset < 1
+error.utils.bytes_b_offset_too_short_1 = 无效输入: b.length - offset < 1
 
 # BytesUtils — invalid input: byteNum.length - offset < len
-error.utils.bytes_bytenum_offset_too_short = Invalid input: byteNum.length - offset < len
+error.utils.bytes_bytenum_offset_too_short = 无效输入: byteNum.length - offset < len
 
 # BytesUtils.intToBytes — cannot convert int to byte array (3 args: srcNum, pos, width)
-log.utils.bytes_int_to_bytes_error = tsfile-common BytesUtils: cannot convert an integer {} to a byte array, pos {}, width {}
+log.utils.bytes_int_to_bytes_error = tsfile-common BytesUtils: 无法将 integer {} 转换为 byte 数组，pos {}，width {}
 
 # BytesUtils.longToBytes — cannot convert long to byte array (3 args: srcNum, pos, width)
-log.utils.bytes_long_to_bytes_error = tsfile-common BytesUtils: cannot convert a long {} to a byte array, pos {}, width {}
+log.utils.bytes_long_to_bytes_error = tsfile-common BytesUtils: 无法将 long {} 转换为 byte 数组，pos {}，width {}
 
 # TsFileSketchTool — cannot load file (filename arg)
-error.utils.sketch_tool_cannot_load = Cannot load file %1$s because the file has crashed.
+error.utils.sketch_tool_cannot_load = 无法加载文件 %1$s，因为文件已损坏。
 
 # ReadWriteIOUtils — short read (expectedLen, readLen args; 7 sites use String.format directly)
-error.utils.rwio_short_read = Intend to read %1$d bytes but %2$d are actually returned
+error.utils.rwio_short_read = 期望读取 %1$d 字节，但实际返回 %2$d 字节
 
 # ReadWriteIOUtils — string list must not be null (2 sites, 1 key)
-error.utils.rwio_stringlist_null = stringList must not be null!
+error.utils.rwio_stringlist_null = stringList 不能为 null！
 
 # ReadWriteIOUtils — set must not be null (2 sites via SET_NOT_NULL_MSG constant)
-error.utils.rwio_set_null = set must not be null!
+error.utils.rwio_set_null = set 不能为 null！
 
 # StringContainer — index out of bounds (getSubString; 1 site)
-error.utils.string_container_index_out_of_bounds = Index: %1$d, Real Index: %2$d, Size: %3$d
+error.utils.string_container_index_out_of_bounds = Index: %1$d，Real Index: %2$d，Size: %3$d
 
 # StringContainer — start index out of bounds (getSubStringContainer)
-error.utils.string_container_start_index_out_of_bounds = start Index: %1$d, Real start Index: %2$d, Size: %3$d
+error.utils.string_container_start_index_out_of_bounds = start Index: %1$d，Real start Index: %2$d，Size: %3$d
 
 # StringContainer — end index out of bounds (getSubStringContainer)
-error.utils.string_container_end_index_out_of_bounds = end Index: %1$d, Real end Index: %2$d, Size: %3$d
+error.utils.string_container_end_index_out_of_bounds = end Index: %1$d，Real end Index: %2$d，Size: %3$d
 
 # TimeDuration — unsupported operation
-error.utils.time_duration_unsupported = unsupported operation
+error.utils.time_duration_unsupported = 不支持的操作
 
 # DateUtils — date expression null or empty (2 sites, 1 key)
-error.utils.date_expression_null_or_empty = Date expression is null or empty.
+error.utils.date_expression_null_or_empty = 日期表达式为 null 或为空。
 
 # DateUtils — invalid date format (parse exception)
-error.utils.date_invalid_format = Invalid date format. Please use YYYY-MM-DD format.
+error.utils.date_invalid_format = 无效的日期格式。请使用 YYYY-MM-DD 格式。
 
 # DateUtils — year out of range (dateExpression arg)
-error.utils.date_year_out_of_range = Year must be between 1000 and 9999.
+error.utils.date_year_out_of_range = 年份必须在 1000 到 9999 之间。
 
 # DateUtils — invalid date format (parseIntToLocalDate)
-error.utils.date_invalid_format_local = Invalid date format.
+error.utils.date_invalid_format_local = 无效的日期格式。
 
 # TsFileGeneratorUtils — invalid input (value arg)
-error.utils.generator_invalid_input = Invalid input: %1$s
+error.utils.generator_invalid_input = 无效输入: %1$s
 
 # FSUtils — failed to get file system (fsType name arg — used with string concat in original)
-log.fs.fsutils_class_not_found = Failed to get {} file system. Please check your dependency of {} module.
+log.fs.fsutils_class_not_found = 获取 {} file system 失败。请检查 {} 模块的依赖。
 
 # === tools ===
 
 # ArrowSourceReader / ParquetSourceReader / CsvSourceReader — inferSchema called in schema mode
-error.tools.infer_schema_not_in_auto_mode = inferSchema() is only available in auto mode
+error.tools.infer_schema_not_in_auto_mode = inferSchema() 仅在 auto 模式下可用
 
 # CsvSourceReader.inferSchema — inferSchema called in schema mode (more descriptive variant)
-error.tools.infer_schema_not_in_auto_mode_csv = inferSchema() is only available in auto mode (no schema provided)
+error.tools.infer_schema_not_in_auto_mode_csv = inferSchema() 仅在 auto 模式下可用（未提供 schema）
 
 # ArrowSourceReader / ParquetSourceReader / CsvSourceReader — failed to infer schema
-error.tools.infer_schema_failed = Failed to infer schema from: %1$s
+error.tools.infer_schema_failed = 推断 schema 失败: %1$s
 
 # CsvSourceReader.inferSchema — CSV file is empty
-error.tools.csv_file_empty = CSV file is empty: %1$s
+error.tools.csv_file_empty = CSV 文件为空: %1$s
 
 # CsvSourceReader.validateColumnCount — column count mismatch
-error.tools.csv_column_count_mismatch = Column count mismatch: schema defines %1$s columns but CSV header has %2$s columns in %3$s
+error.tools.csv_column_count_mismatch = 列数不匹配: schema 定义了 %1$s 列，但 CSV header 有 %2$s 列，文件 %3$s
 
 # TimeConverter — time value cannot be null (2 sites, 1 key)
-error.tools.time_value_null = Time value cannot be null
+error.tools.time_value_null = 时间值不能为 null
 
 # TimeConverter.toNanos / fromNanos — unknown precision (2 sites, 1 key)
-error.tools.unknown_precision = Unknown precision: %1$s
+error.tools.unknown_precision = 未知精度: %1$s
 
 # TsFileTool.parseBlockSize — unsupported block_size unit
-error.tools.block_size_unsupported_unit = block_size only supports units of K, M, G, or numbers
+error.tools.block_size_unsupported_unit = block_size 仅支持 K、M、G 单位或数字
 
 # SchemaParser.parseIdColumns — invalid id_columns format
-error.tools.schema_id_columns_invalid = The data format of id_columns is incorrect
+error.tools.schema_id_columns_invalid = id_columns 的数据格式不正确
 
 # SchemaParser.parseCsvColumns — invalid csv_columns format
-error.tools.schema_csv_columns_invalid = The data format of csv_columns is incorrect
+error.tools.schema_csv_columns_invalid = csv_columns 的数据格式不正确
 
 # SchemaParser — has_header not true/false
-error.tools.schema_has_header_invalid = The data format of has_header is incorrect
+error.tools.schema_has_header_invalid = has_header 的数据格式不正确
 
 # SchemaParser.validateParams — time_precision not supported
-error.tools.schema_time_precision_unsupported = The time_precision parameter only supports ms,us,ns
+error.tools.schema_time_precision_unsupported = time_precision 参数仅支持 ms、us、ns
 
 # SchemaParser.validateParams — separator invalid
-error.tools.schema_separator_invalid = separator must be ",", tab, or ";"
+error.tools.schema_separator_invalid = separator 必须为 ","、tab 或 ";"
 
 # SchemaParser.validateParams — table_name required
-error.tools.schema_table_name_required = table_name is required
+error.tools.schema_table_name_required = table_name 是必需的
 
 # SchemaParser.validateParams — id_columns required
-error.tools.schema_id_columns_required = id_columns is required
+error.tools.schema_id_columns_required = id_columns 是必需的
 
 # SchemaParser.validateParams — csv_columns required
-error.tools.schema_csv_columns_required = csv_columns is required
+error.tools.schema_csv_columns_required = csv_columns 是必需的
 
 # SchemaParser.validateParams — time_column required
-error.tools.schema_time_column_required = time_column is required
+error.tools.schema_time_column_required = time_column 是必需的
 
 # SchemaParser.validateParams — time_column value not in csv_columns
-error.tools.schema_time_column_not_in_csv = The value %1$s of time_column is not in csv_columns
+error.tools.schema_time_column_not_in_csv = time_column 的值 %1$s 不在 csv_columns 中
 
 # SchemaParser.validateParams — id_columns value not in csv_columns
-error.tools.schema_id_column_not_in_csv = The value %1$s of id_columns is not in csv_columns
+error.tools.schema_id_column_not_in_csv = id_columns 的值 %1$s 不在 csv_columns 中
 
 # ImportSchemaParser — has_header not true/false
-error.tools.import_has_header_invalid = has_header must be true or false
+error.tools.import_has_header_invalid = has_header 必须为 true 或 false
 
 # ImportSchemaParser.parseTagColumn — invalid tag_columns format
-error.tools.import_tag_columns_invalid = Invalid tag_columns format: %1$s
+error.tools.import_tag_columns_invalid = 无效的 tag_columns 格式: %1$s
 
 # ImportSchemaParser.parseSourceColumn — invalid source_columns format
-error.tools.import_source_columns_invalid = Invalid source_columns format: %1$s
+error.tools.import_source_columns_invalid = 无效的 source_columns 格式: %1$s
 
 # ImportSchemaParser.resolveDataType — unknown data type
-error.tools.import_unknown_data_type = Unknown data type: %1$s
+error.tools.import_unknown_data_type = 未知数据类型: %1$s
 
 # ImportSchemaParser.validate — time_precision not supported
-error.tools.import_time_precision_unsupported = time_precision must be ms, us, ns, or s
+error.tools.import_time_precision_unsupported = time_precision 必须为 ms、us、ns 或 s
 
 # ImportSchemaParser.validate — separator invalid
-error.tools.import_separator_invalid = separator must be ",", tab, or ";"
+error.tools.import_separator_invalid = separator 必须为 ","、tab 或 ";"
 
 # ImportSchemaParser.validate — table_name required
-error.tools.import_table_name_required = table_name is required
+error.tools.import_table_name_required = table_name 是必需的
 
 # ImportSchemaParser.validate — time_column required
-error.tools.import_time_column_required = time_column is required
+error.tools.import_time_column_required = time_column 是必需的
 
 # ImportSchemaParser.validate — source_columns required
-error.tools.import_source_columns_required = source_columns is required
+error.tools.import_source_columns_required = source_columns 是必需的
 
 # ImportSchemaParser.validate — time_column not found in source_columns
-error.tools.import_time_column_not_found = time_column '%1$s' not found in source_columns
+error.tools.import_time_column_not_found = source_columns 中找不到 time_column '%1$s'
 
 # ImportSchemaParser.validate — tag_columns entry not found in source_columns
-error.tools.import_tag_column_not_found = tag_columns '%1$s' not found in source_columns
+error.tools.import_tag_column_not_found = source_columns 中找不到 tag_columns '%1$s'
 
 # AutoSchemaInferer.detectTimeColumn — no time column found
-error.tools.auto_no_time_column = No time column found. Auto mode requires exactly one column named 'time' or 'TIME'.
+error.tools.auto_no_time_column = 找不到时间列。auto 模式要求恰好有一个名为 'time' 或 'TIME' 的列。
 
 # AutoSchemaInferer.detectTimeColumn — ambiguous time column
-error.tools.auto_ambiguous_time_column = Ambiguous time column: found multiple columns matching 'time'/'TIME': %1$s
+error.tools.auto_ambiguous_time_column = 时间列不明确: 找到多个匹配 'time'/'TIME' 的列: %1$s
 
 # TabletBuilder.resolveTimeColumnIndex — time column not found in source columns
-error.tools.tablet_time_column_not_found = Time column '%1$s' not found in source columns
+error.tools.tablet_time_column_not_found = 源列中找不到 time column '%1$s'
 
 # DateTimeUtils.convertDatetimeStrToLong — failed to convert timestamp (depth >= 2)
-error.tools.datetime_convert_failed = Failed to convert %1$s to millisecond, zone offset is %2$s, please input like 2011-12-03T10:15:30 or 2011-12-03T10:15:30+01:00
+error.tools.datetime_convert_failed = 将 %1$s 转换为毫秒失败，zone offset 为 %2$s，请输入类似 2011-12-03T10:15:30 或 2011-12-03T10:15:30+01:00 的格式
 
 # DateTimeUtils.convertDatetimeStrToLong — time-region not supported
-error.tools.datetime_time_region_unsupported = %1$s with [time-region] at end is not supported now, please input like 2011-12-03T10:15:30 or 2011-12-03T10:15:30+01:00
+error.tools.datetime_time_region_unsupported = 暂不支持末尾带 [time-region] 的 %1$s，请输入类似 2011-12-03T10:15:30 或 2011-12-03T10:15:30+01:00 的格式
 
 # --- tools LOG messages ---
 
 # ImportExecutor — failed to create output directory
-log.tools.executor_create_dir_failed = Failed to create output directory: %1$s
+log.tools.executor_create_dir_failed = 创建输出目录失败: %1$s
 
 # ImportExecutor — failed to write chunk
-log.tools.executor_write_chunk_failed = Failed to write chunk %1$s to %2$s
+log.tools.executor_write_chunk_failed = 写入 chunk %1$s 到 %2$s 失败
 
 # ImportExecutor — no data read from source
-log.tools.executor_no_data = No data read from source: %1$s
+log.tools.executor_no_data = 从源 %1$s 未读取到数据
 
 # ImportExecutor — failed to rename indexed file to single name
-log.tools.executor_rename_failed = Failed to rename %1$s to %2$s
+log.tools.executor_rename_failed = 将 %1$s 重命名为 %2$s 失败
 
 # ImportExecutor.writeTsFile — failed to write file
-log.tools.executor_write_file_failed = Failed to write file: %1$s
+log.tools.executor_write_file_failed = 写入文件失败: %1$s
 
 # ImportExecutor.writeTsFile — failed to close file
-log.tools.executor_close_file_failed = Failed to close file: %1$s
+log.tools.executor_close_file_failed = 关闭文件失败: %1$s
 
 # ImportExecutor.deleteFile — failed to delete file
-log.tools.executor_delete_failed = Failed to delete: %1$s
+log.tools.executor_delete_failed = 删除失败: %1$s
 
 # TsFileTool — failed to parse schema file
-log.tools.tool_parse_schema_failed = Failed to parse schema file: %1$s
+log.tools.tool_parse_schema_failed = 解析 schema 文件失败: %1$s
 
 # TsFileTool — failed to await termination
-log.tools.tool_await_termination_failed = Failed to await termination
+log.tools.tool_await_termination_failed = 等待终止失败
 
 # TsFileTool — directory or file has completed execution
-log.tools.tool_execution_completed = The %1$s directory or file has completed execution
+log.tools.tool_execution_completed = %1$s 目录或文件已完成执行
 
 # TsFileTool — failed to process file
-log.tools.tool_process_file_failed = Failed to process file: %1$s
+log.tools.tool_process_file_failed = 处理文件失败: %1$s
 
 # TsFileTool — file successfully generated
-log.tools.tool_file_generated = %1$s.tsfile successfully generated
+log.tools.tool_file_generated = %1$s.tsfile 生成成功
 
 # TsFileTool — failed to copy file
-log.tools.tool_copy_file_failed = Failed to copy file: %1$s
+log.tools.tool_copy_file_failed = 复制文件失败: %1$s
 
 # TsFileTool — error parsing command line options
-log.tools.tool_parse_cli_error = Error parsing command line options
+log.tools.tool_parse_cli_error = 解析命令行选项时出错
 
 # TsFileTool.validateParams — source is required
-log.tools.tool_source_required = Missing required parameters. --source/-s is required
+log.tools.tool_source_required = 缺少必需参数。--source/-s 是必需的
 
 # TsFileTool.validateParams — target is required
-log.tools.tool_target_required = Missing required parameters. --target/-t is required
+log.tools.tool_target_required = 缺少必需参数。--target/-t 是必需的
 
 # TsFileTool.validateParams — source does not exist
-log.tools.tool_source_not_exist = %1$s directory or file does not exist.
+log.tools.tool_source_not_exist = %1$s 目录或文件不存在。
 
 # TsFileTool.validateParams — schema file does not exist
-log.tools.tool_schema_not_exist = %1$s schema file does not exist.
+log.tools.tool_schema_not_exist = %1$s schema 文件不存在。
 
 # TsFileTool.validateParams — invalid thread number
-log.tools.tool_invalid_thread_num = Invalid thread number. Thread number must be greater than 0.
+log.tools.tool_invalid_thread_num = 无效的线程数。线程数必须大于 0。
 
 # ArrowSourceReader — error reading Arrow file
-log.tools.arrow_read_error = Error reading Arrow file: %1$s
+log.tools.arrow_read_error = 读取 Arrow 文件出错: %1$s
 
 # ArrowSourceReader — error closing Arrow reader
-log.tools.arrow_close_reader_error = Error closing Arrow reader
+log.tools.arrow_close_reader_error = 关闭 Arrow reader 出错
 
 # ArrowSourceReader — error closing FileInputStream
-log.tools.arrow_close_stream_error = Error closing FileInputStream
+log.tools.arrow_close_stream_error = 关闭 FileInputStream 出错
 
 # ParquetSourceReader — error reading Parquet file
-log.tools.parquet_read_error = Error reading Parquet file: %1$s
+log.tools.parquet_read_error = 读取 Parquet 文件出错: %1$s
 
 # ParquetSourceReader — error closing Parquet reader
-log.tools.parquet_close_reader_error = Error closing Parquet reader
+log.tools.parquet_close_reader_error = 关闭 Parquet reader 出错
 
 # CsvSourceReader — error reading CSV file
-log.tools.csv_read_error = Error reading CSV file: %1$s
+log.tools.csv_read_error = 读取 CSV 文件出错: %1$s
 
 # CsvSourceReader — error closing CSV reader
-log.tools.csv_close_reader_error = Error closing CSV reader
+log.tools.csv_close_reader_error = 关闭 CSV reader 出错

--- a/java/common/src/test/java/org/apache/tsfile/i18n/MessagesTest.java
+++ b/java/common/src/test/java/org/apache/tsfile/i18n/MessagesTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tsfile.i18n;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MessagesTest {
+
+  static {
+    // Pin locale so tests run identically regardless of JVM default. Must be set
+    // before any reference to Messages, since Messages.BUNDLE is initialized at
+    // class load. JUnit loads test classes (and runs their static blocks) before
+    // invoking test methods, so this static block reliably fires first.
+    System.setProperty("tsfile.locale", "en");
+  }
+
+  @Test
+  public void getReturnsRawPattern() {
+    assertEquals("hello %1$s", Messages.get("test.seed"));
+  }
+
+  @Test
+  public void formatSubstitutesArgs() {
+    assertEquals("hello world", Messages.format("test.seed", "world"));
+  }
+}

--- a/java/common/src/test/java/org/apache/tsfile/i18n/MessagesTest.java
+++ b/java/common/src/test/java/org/apache/tsfile/i18n/MessagesTest.java
@@ -20,7 +20,16 @@ package org.apache.tsfile.i18n;
 
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.ResourceBundle;
+import java.util.Set;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class MessagesTest {
 
@@ -40,5 +49,68 @@ public class MessagesTest {
   @Test
   public void formatSubstitutesArgs() {
     assertEquals("hello world", Messages.format("test.seed", "world"));
+  }
+
+  private static final String BUNDLE = "org.apache.tsfile.i18n.messages";
+
+  @Test
+  public void enAndZhKeysMatch() {
+    Set<String> en = keysOf(loadBundle(Locale.ROOT));
+    Set<String> zh = keysOf(loadBundle(Locale.SIMPLIFIED_CHINESE));
+    Set<String> missingInZh = new HashSet<>(en);
+    missingInZh.removeAll(zh);
+    Set<String> extraInZh = new HashSet<>(zh);
+    extraInZh.removeAll(en);
+    assertTrue("keys present in en but missing in zh: " + missingInZh, missingInZh.isEmpty());
+    assertTrue("keys present in zh but not in en: " + extraInZh, extraInZh.isEmpty());
+  }
+
+  @Test
+  public void allEnKeysResolveNonEmpty() {
+    assertAllValuesNonEmpty(loadBundle(Locale.ROOT));
+  }
+
+  @Test
+  public void allZhKeysResolveNonEmpty() {
+    assertAllValuesNonEmpty(loadBundle(Locale.SIMPLIFIED_CHINESE));
+  }
+
+  private static void assertAllValuesNonEmpty(ResourceBundle bundle) {
+    for (String key : Collections.list(bundle.getKeys())) {
+      String value = bundle.getString(key);
+      assertNotNull("null value for key " + key, value);
+      assertFalse("empty value for key " + key, value.trim().isEmpty());
+    }
+  }
+
+  private static ResourceBundle loadBundle(Locale locale) {
+    return ResourceBundle.getBundle(
+        BUNDLE, locale, MessagesTest.class.getClassLoader(), new Utf8TestControl());
+  }
+
+  private static Set<String> keysOf(ResourceBundle bundle) {
+    return new HashSet<>(Collections.list(bundle.getKeys()));
+  }
+
+  private static final class Utf8TestControl extends ResourceBundle.Control {
+    @Override
+    public java.util.ResourceBundle newBundle(
+        String baseName, Locale locale, String format, ClassLoader loader, boolean reload)
+        throws java.io.IOException, IllegalAccessException, InstantiationException {
+      if (!"java.properties".equals(format)) {
+        return super.newBundle(baseName, locale, format, loader, reload);
+      }
+      String bundleName = toBundleName(baseName, locale);
+      String resourceName = toResourceName(bundleName, "properties");
+      try (java.io.InputStream in = loader.getResourceAsStream(resourceName)) {
+        if (in == null) {
+          return null;
+        }
+        try (java.io.Reader reader =
+            new java.io.InputStreamReader(in, java.nio.charset.StandardCharsets.UTF_8)) {
+          return new java.util.PropertyResourceBundle(reader);
+        }
+      }
+    }
   }
 }

--- a/java/tools/src/main/java/org/apache/tsfile/tools/ArrowSourceReader.java
+++ b/java/tools/src/main/java/org/apache/tsfile/tools/ArrowSourceReader.java
@@ -19,6 +19,7 @@
 package org.apache.tsfile.tools;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -90,7 +91,8 @@ public class ArrowSourceReader implements SourceReader {
   @Override
   public ImportSchema inferSchema() {
     if (schema != null) {
-      throw new UnsupportedOperationException("inferSchema() is only available in auto mode");
+      throw new UnsupportedOperationException(
+          Messages.get("error.tools.infer_schema_not_in_auto_mode"));
     }
 
     try {
@@ -133,7 +135,8 @@ public class ArrowSourceReader implements SourceReader {
               tableName, timeColumn, columnNames, types, timePrecision);
       return schema;
     } catch (IOException e) {
-      throw new RuntimeException("Failed to infer schema from: " + sourceFile.getAbsolutePath(), e);
+      throw new RuntimeException(
+          Messages.format("error.tools.infer_schema_failed", sourceFile.getAbsolutePath()), e);
     }
   }
 
@@ -189,7 +192,7 @@ public class ArrowSourceReader implements SourceReader {
 
       return SourceBatch.fromRows(schemaColumnNames, rows);
     } catch (IOException e) {
-      LOGGER.error("Error reading Arrow file: " + sourceFile.getAbsolutePath(), e);
+      LOGGER.error(Messages.format("log.tools.arrow_read_error", sourceFile.getAbsolutePath()), e);
       exhausted = true;
       return null;
     }
@@ -201,7 +204,7 @@ public class ArrowSourceReader implements SourceReader {
       try {
         arrowReader.close();
       } catch (IOException e) {
-        LOGGER.error("Error closing Arrow reader", e);
+        LOGGER.error(Messages.get("log.tools.arrow_close_reader_error"), e);
       }
       arrowReader = null;
     }
@@ -209,7 +212,7 @@ public class ArrowSourceReader implements SourceReader {
       try {
         fileInputStream.close();
       } catch (IOException e) {
-        LOGGER.error("Error closing FileInputStream", e);
+        LOGGER.error(Messages.get("log.tools.arrow_close_stream_error"), e);
       }
       fileInputStream = null;
     }

--- a/java/tools/src/main/java/org/apache/tsfile/tools/AutoSchemaInferer.java
+++ b/java/tools/src/main/java/org/apache/tsfile/tools/AutoSchemaInferer.java
@@ -19,6 +19,7 @@
 package org.apache.tsfile.tools;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -53,12 +54,11 @@ public class AutoSchemaInferer {
       }
     }
     if (matches.isEmpty()) {
-      throw new IllegalArgumentException(
-          "No time column found. Auto mode requires exactly one column named 'time' or 'TIME'.");
+      throw new IllegalArgumentException(Messages.get("error.tools.auto_no_time_column"));
     }
     if (matches.size() > 1) {
       throw new IllegalArgumentException(
-          "Ambiguous time column: found multiple columns matching 'time'/'TIME': " + matches);
+          Messages.format("error.tools.auto_ambiguous_time_column", matches));
     }
     return matches.get(0);
   }

--- a/java/tools/src/main/java/org/apache/tsfile/tools/CsvSourceReader.java
+++ b/java/tools/src/main/java/org/apache/tsfile/tools/CsvSourceReader.java
@@ -19,6 +19,7 @@
 package org.apache.tsfile.tools;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,7 +90,7 @@ public class CsvSourceReader implements SourceReader {
   public ImportSchema inferSchema() {
     if (schema != null) {
       throw new UnsupportedOperationException(
-          "inferSchema() is only available in auto mode (no schema provided)");
+          Messages.get("error.tools.infer_schema_not_in_auto_mode_csv"));
     }
 
     try {
@@ -97,7 +98,8 @@ public class CsvSourceReader implements SourceReader {
 
       String headerLine = reader.readLine();
       if (headerLine == null) {
-        throw new IllegalArgumentException("CSV file is empty: " + sourceFile.getAbsolutePath());
+        throw new IllegalArgumentException(
+            Messages.format("error.tools.csv_file_empty", sourceFile.getAbsolutePath()));
       }
       columnNames = splitLine(headerLine);
       headerConsumed = true;
@@ -138,7 +140,8 @@ public class CsvSourceReader implements SourceReader {
 
       return schema;
     } catch (IOException e) {
-      throw new RuntimeException("Failed to infer schema from: " + sourceFile.getAbsolutePath(), e);
+      throw new RuntimeException(
+          Messages.format("error.tools.infer_schema_failed", sourceFile.getAbsolutePath()), e);
     }
   }
 
@@ -198,7 +201,7 @@ public class CsvSourceReader implements SourceReader {
       return buildBatch(rows);
 
     } catch (IOException e) {
-      LOGGER.error("Error reading CSV file: " + sourceFile.getAbsolutePath(), e);
+      LOGGER.error(Messages.format("log.tools.csv_read_error", sourceFile.getAbsolutePath()), e);
       exhausted = true;
       return null;
     }
@@ -210,7 +213,7 @@ public class CsvSourceReader implements SourceReader {
       try {
         reader.close();
       } catch (IOException e) {
-        LOGGER.error("Error closing CSV reader", e);
+        LOGGER.error(Messages.get("log.tools.csv_close_reader_error"), e);
       }
       reader = null;
     }
@@ -262,12 +265,11 @@ public class CsvSourceReader implements SourceReader {
     int expected = schema.getSourceColumns().size();
     if (columnNames.length != expected) {
       throw new IllegalArgumentException(
-          "Column count mismatch: schema defines "
-              + expected
-              + " columns but CSV header has "
-              + columnNames.length
-              + " columns in "
-              + sourceFile.getAbsolutePath());
+          Messages.format(
+              "error.tools.csv_column_count_mismatch",
+              expected,
+              columnNames.length,
+              sourceFile.getAbsolutePath()));
     }
   }
 

--- a/java/tools/src/main/java/org/apache/tsfile/tools/DateTimeUtils.java
+++ b/java/tools/src/main/java/org/apache/tsfile/tools/DateTimeUtils.java
@@ -18,6 +18,8 @@
  */
 package org.apache.tsfile.tools;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -485,10 +487,7 @@ public class DateTimeUtils {
       String str, ZoneOffset offset, int depth, String timestampPrecision) {
     if (depth >= 2) {
       throw new DateTimeException(
-          String.format(
-              "Failed to convert %s to millisecond, zone offset is %s, "
-                  + "please input like 2011-12-03T10:15:30 or 2011-12-03T10:15:30+01:00",
-              str, offset));
+          Messages.format("error.tools.datetime_convert_failed", str, offset));
     }
     if (str.contains("Z")) {
       return convertDatetimeStrToLong(
@@ -500,10 +499,7 @@ public class DateTimeUtils {
       return convertDatetimeStrToLong(str + offset, offset, depth + 1, timestampPrecision);
     } else if (str.contains("[") || str.contains("]")) {
       throw new DateTimeException(
-          String.format(
-              "%s with [time-region] at end is not supported now, "
-                  + "please input like 2011-12-03T10:15:30 or 2011-12-03T10:15:30+01:00",
-              str));
+          Messages.format("error.tools.datetime_time_region_unsupported", str));
     }
     return getInstantWithPrecision(str, timestampPrecision);
   }

--- a/java/tools/src/main/java/org/apache/tsfile/tools/ImportExecutor.java
+++ b/java/tools/src/main/java/org/apache/tsfile/tools/ImportExecutor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tsfile.tools;
 
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.write.TsFileWriter;
 import org.apache.tsfile.write.record.Tablet;
 
@@ -47,7 +48,7 @@ public class ImportExecutor {
     try {
       Files.createDirectories(Paths.get(outputDir));
     } catch (IOException e) {
-      LOGGER.error("Failed to create output directory: " + outputDir, e);
+      LOGGER.error(Messages.format("log.tools.executor_create_dir_failed", outputDir), e);
       return false;
     }
 
@@ -66,12 +67,13 @@ public class ImportExecutor {
       boolean ok = writeTsFile(batch, outputDir, tsFileName);
       if (!ok) {
         allSuccess = false;
-        LOGGER.error("Failed to write chunk " + chunkIndex + " to " + tsFileName);
+        LOGGER.error(
+            Messages.format("log.tools.executor_write_chunk_failed", chunkIndex, tsFileName));
       }
     }
 
     if (!hasData) {
-      LOGGER.warn("No data read from source: " + sourceBaseName);
+      LOGGER.warn(Messages.format("log.tools.executor_no_data", sourceBaseName));
     }
 
     if (chunkIndex == 1) {
@@ -80,7 +82,8 @@ public class ImportExecutor {
       File single = new File(outputDir, singleName);
       if (indexed.exists() && !single.exists()) {
         if (!indexed.renameTo(single)) {
-          LOGGER.warn("Failed to rename " + indexed.getName() + " to " + singleName);
+          LOGGER.warn(
+              Messages.format("log.tools.executor_rename_failed", indexed.getName(), singleName));
         }
       }
     }
@@ -101,14 +104,16 @@ public class ImportExecutor {
       success = true;
       return true;
     } catch (Exception e) {
-      LOGGER.error("Failed to write file: " + tsFile.getAbsolutePath(), e);
+      LOGGER.error(
+          Messages.format("log.tools.executor_write_file_failed", tsFile.getAbsolutePath()), e);
       return false;
     } finally {
       if (writer != null) {
         try {
           writer.close();
         } catch (IOException e) {
-          LOGGER.error("Failed to close file: " + tsFile.getAbsolutePath(), e);
+          LOGGER.error(
+              Messages.format("log.tools.executor_close_file_failed", tsFile.getAbsolutePath()), e);
         }
       }
       if (!success) {
@@ -123,7 +128,7 @@ public class ImportExecutor {
 
   private static void deleteFile(File file) {
     if (file.exists() && !file.delete()) {
-      LOGGER.warn("Failed to delete: " + file.getAbsolutePath());
+      LOGGER.warn(Messages.format("log.tools.executor_delete_failed", file.getAbsolutePath()));
     }
   }
 }

--- a/java/tools/src/main/java/org/apache/tsfile/tools/ImportSchemaParser.java
+++ b/java/tools/src/main/java/org/apache/tsfile/tools/ImportSchemaParser.java
@@ -19,6 +19,7 @@
 package org.apache.tsfile.tools;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -60,7 +61,8 @@ public class ImportSchemaParser {
         } else if (line.startsWith("has_header=")) {
           String val = extractValue(line);
           if (!"true".equals(val) && !"false".equals(val)) {
-            throw new IllegalArgumentException("has_header must be true or false");
+            throw new IllegalArgumentException(
+                Messages.get("error.tools.import_has_header_invalid"));
           }
           schema.setHasHeader(Boolean.parseBoolean(val));
           section = Section.NONE;
@@ -108,7 +110,8 @@ public class ImportSchemaParser {
     } else if (parts.length == 1) {
       return new ImportSchema.TagColumn(parts[0].trim());
     }
-    throw new IllegalArgumentException("Invalid tag_columns format: " + line);
+    throw new IllegalArgumentException(
+        Messages.format("error.tools.import_tag_columns_invalid", line));
   }
 
   private static ImportSchema.SourceColumn parseSourceColumn(String line) {
@@ -133,7 +136,8 @@ public class ImportSchemaParser {
       }
       return new ImportSchema.SourceColumn(name, TSDataType.STRING);
     }
-    throw new IllegalArgumentException("Invalid source_columns format: " + line);
+    throw new IllegalArgumentException(
+        Messages.format("error.tools.import_source_columns_invalid", line));
   }
 
   private static TSDataType resolveDataType(String typeStr) {
@@ -159,31 +163,34 @@ public class ImportSchemaParser {
       case "TIMESTAMP":
         return TSDataType.TIMESTAMP;
       default:
-        throw new IllegalArgumentException("Unknown data type: " + typeStr);
+        throw new IllegalArgumentException(
+            Messages.format("error.tools.import_unknown_data_type", typeStr));
     }
   }
 
   private static void validate(ImportSchema schema) {
     String tp = schema.getTimePrecision();
     if (!"ms".equals(tp) && !"us".equals(tp) && !"ns".equals(tp) && !"s".equals(tp)) {
-      throw new IllegalArgumentException("time_precision must be ms, us, ns, or s");
+      throw new IllegalArgumentException(
+          Messages.get("error.tools.import_time_precision_unsupported"));
     }
 
     String sep = schema.getSeparator();
     if (!",".equals(sep) && !"\t".equals(sep) && !";".equals(sep)) {
-      throw new IllegalArgumentException("separator must be \",\", tab, or \";\"");
+      throw new IllegalArgumentException(Messages.get("error.tools.import_separator_invalid"));
     }
 
     if (schema.getTableName().isEmpty()) {
-      throw new IllegalArgumentException("table_name is required");
+      throw new IllegalArgumentException(Messages.get("error.tools.import_table_name_required"));
     }
 
     if (schema.getTimeColumnName().isEmpty()) {
-      throw new IllegalArgumentException("time_column is required");
+      throw new IllegalArgumentException(Messages.get("error.tools.import_time_column_required"));
     }
 
     if (schema.getSourceColumns().isEmpty()) {
-      throw new IllegalArgumentException("source_columns is required");
+      throw new IllegalArgumentException(
+          Messages.get("error.tools.import_source_columns_required"));
     }
 
     boolean timeFound = false;
@@ -195,7 +202,7 @@ public class ImportSchemaParser {
     }
     if (!timeFound) {
       throw new IllegalArgumentException(
-          "time_column '" + schema.getTimeColumnName() + "' not found in source_columns");
+          Messages.format("error.tools.import_time_column_not_found", schema.getTimeColumnName()));
     }
 
     Set<String> sourceNames = new HashSet<>();
@@ -207,7 +214,7 @@ public class ImportSchemaParser {
     for (ImportSchema.TagColumn tag : schema.getTagColumns()) {
       if (!tag.isVirtual() && !sourceNames.contains(tag.getName())) {
         throw new IllegalArgumentException(
-            "tag_columns '" + tag.getName() + "' not found in source_columns");
+            Messages.format("error.tools.import_tag_column_not_found", tag.getName()));
       }
     }
   }

--- a/java/tools/src/main/java/org/apache/tsfile/tools/ParquetSourceReader.java
+++ b/java/tools/src/main/java/org/apache/tsfile/tools/ParquetSourceReader.java
@@ -19,6 +19,7 @@
 package org.apache.tsfile.tools;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 
 import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.example.data.Group;
@@ -78,7 +79,8 @@ public class ParquetSourceReader implements SourceReader {
   @Override
   public ImportSchema inferSchema() {
     if (schema != null) {
-      throw new UnsupportedOperationException("inferSchema() is only available in auto mode");
+      throw new UnsupportedOperationException(
+          Messages.get("error.tools.infer_schema_not_in_auto_mode"));
     }
 
     try {
@@ -127,7 +129,8 @@ public class ParquetSourceReader implements SourceReader {
               tableName, timeColumn, columnNames, types, timePrecision);
       return schema;
     } catch (IOException e) {
-      throw new RuntimeException("Failed to infer schema from: " + sourceFile.getAbsolutePath(), e);
+      throw new RuntimeException(
+          Messages.format("error.tools.infer_schema_failed", sourceFile.getAbsolutePath()), e);
     }
   }
 
@@ -184,7 +187,8 @@ public class ParquetSourceReader implements SourceReader {
 
       return SourceBatch.fromRows(schemaColumnNames, rows);
     } catch (IOException e) {
-      LOGGER.error("Error reading Parquet file: " + sourceFile.getAbsolutePath(), e);
+      LOGGER.error(
+          Messages.format("log.tools.parquet_read_error", sourceFile.getAbsolutePath()), e);
       exhausted = true;
       return null;
     }
@@ -196,7 +200,7 @@ public class ParquetSourceReader implements SourceReader {
       try {
         parquetReader.close();
       } catch (IOException e) {
-        LOGGER.error("Error closing Parquet reader", e);
+        LOGGER.error(Messages.get("log.tools.parquet_close_reader_error"), e);
       }
       parquetReader = null;
     }

--- a/java/tools/src/main/java/org/apache/tsfile/tools/SchemaParser.java
+++ b/java/tools/src/main/java/org/apache/tsfile/tools/SchemaParser.java
@@ -18,6 +18,8 @@
  */
 package org.apache.tsfile.tools;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
@@ -160,7 +162,8 @@ public class SchemaParser {
           if (has_header.equals("true") || has_header.equals("false")) {
             schema.hasHeader = Boolean.parseBoolean(has_header);
           } else {
-            throw new IllegalArgumentException("The data format of has_header is incorrect");
+            throw new IllegalArgumentException(
+                Messages.get("error.tools.schema_has_header_invalid"));
           }
         } else if (line.startsWith("separator=")) {
           schema.separator = extractValue(line);
@@ -204,7 +207,7 @@ public class SchemaParser {
     } else if (parts.length == 1) {
       schema.idColumns.add(new IDColumns(parts[0].trim()));
     } else {
-      throw new IllegalArgumentException("The data format of id_columns is incorrect");
+      throw new IllegalArgumentException(Messages.get("error.tools.schema_id_columns_invalid"));
     }
   }
 
@@ -242,7 +245,7 @@ public class SchemaParser {
       }
       schema.csvColumns.add(new Column(columnName));
     } else {
-      throw new IllegalArgumentException("The data format of csv_columns is incorrect");
+      throw new IllegalArgumentException(Messages.get("error.tools.schema_csv_columns_invalid"));
     }
   }
 
@@ -250,32 +253,33 @@ public class SchemaParser {
     if (!schema.timePrecision.equals("us")
         && !schema.timePrecision.equals("ms")
         && !schema.timePrecision.equals("ns")) {
-      throw new IllegalArgumentException("The time_precision parameter only supports ms,us,ns");
+      throw new IllegalArgumentException(
+          Messages.get("error.tools.schema_time_precision_unsupported"));
     }
     if (!schema.separator.equals(",")
         && !schema.separator.equals("tab")
         && !schema.separator.equals(";")) {
-      throw new IllegalArgumentException("separator must be \",\", tab, or \";\"");
+      throw new IllegalArgumentException(Messages.get("error.tools.schema_separator_invalid"));
     }
     if (schema.tableName.isEmpty()) {
-      throw new IllegalArgumentException("table_name is required");
+      throw new IllegalArgumentException(Messages.get("error.tools.schema_table_name_required"));
     }
     if (schema.idColumns.isEmpty()) {
-      throw new IllegalArgumentException("id_columns is required");
+      throw new IllegalArgumentException(Messages.get("error.tools.schema_id_columns_required"));
     }
     if (schema.csvColumns.isEmpty()) {
-      throw new IllegalArgumentException("csv_columns is required");
+      throw new IllegalArgumentException(Messages.get("error.tools.schema_csv_columns_required"));
     }
     if (schema.timeColumn.isEmpty()) {
-      throw new IllegalArgumentException("time_column is required");
+      throw new IllegalArgumentException(Messages.get("error.tools.schema_time_column_required"));
     } else if (schema.timeColumnIndex < 0) {
       throw new IllegalArgumentException(
-          "The value " + schema.timeColumn + " of time_column is not in csv_columns");
+          Messages.format("error.tools.schema_time_column_not_in_csv", schema.timeColumn));
     }
     for (IDColumns idColumn : schema.idColumns) {
       if (idColumn.csvColumnIndex < 0 && !idColumn.isDefault) {
         throw new IllegalArgumentException(
-            "The value " + idColumn.name + " of id_columns is not in csv_columns");
+            Messages.format("error.tools.schema_id_column_not_in_csv", idColumn.name));
       }
     }
   }

--- a/java/tools/src/main/java/org/apache/tsfile/tools/TabletBuilder.java
+++ b/java/tools/src/main/java/org/apache/tsfile/tools/TabletBuilder.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.tools;
 import org.apache.tsfile.enums.ColumnCategory;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.file.metadata.TableSchema;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.write.record.Tablet;
 import org.apache.tsfile.write.schema.IMeasurementSchema;
 import org.apache.tsfile.write.schema.MeasurementSchema;
@@ -160,7 +161,7 @@ public class TabletBuilder {
       }
     }
     throw new IllegalArgumentException(
-        "Time column '" + timeName + "' not found in source columns");
+        Messages.format("error.tools.tablet_time_column_not_found", timeName));
   }
 
   private String[] findSourceColumnNames() {

--- a/java/tools/src/main/java/org/apache/tsfile/tools/TimeConverter.java
+++ b/java/tools/src/main/java/org/apache/tsfile/tools/TimeConverter.java
@@ -18,6 +18,8 @@
  */
 package org.apache.tsfile.tools;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.time.Instant;
 
 public class TimeConverter {
@@ -34,7 +36,7 @@ public class TimeConverter {
 
   public long convert(Object value) {
     if (value == null) {
-      throw new IllegalArgumentException("Time value cannot be null");
+      throw new IllegalArgumentException(Messages.get("error.tools.time_value_null"));
     }
     if (value instanceof Instant) {
       return fromInstant((Instant) value);
@@ -47,7 +49,7 @@ public class TimeConverter {
 
   public long convert(Object value, String sourcePrecision) {
     if (value == null) {
-      throw new IllegalArgumentException("Time value cannot be null");
+      throw new IllegalArgumentException(Messages.get("error.tools.time_value_null"));
     }
     if (value instanceof Instant) {
       return fromInstant((Instant) value);
@@ -128,7 +130,8 @@ public class TimeConverter {
       case "ns":
         return value;
       default:
-        throw new IllegalArgumentException("Unknown precision: " + precision);
+        throw new IllegalArgumentException(
+            Messages.format("error.tools.unknown_precision", precision));
     }
   }
 
@@ -143,7 +146,8 @@ public class TimeConverter {
       case "ns":
         return nanos;
       default:
-        throw new IllegalArgumentException("Unknown precision: " + precision);
+        throw new IllegalArgumentException(
+            Messages.format("error.tools.unknown_precision", precision));
     }
   }
 }

--- a/java/tools/src/main/java/org/apache/tsfile/tools/TsFileTool.java
+++ b/java/tools/src/main/java/org/apache/tsfile/tools/TsFileTool.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.tools;
 
 import org.apache.tsfile.external.commons.io.FilenameUtils;
+import org.apache.tsfile.i18n.Messages;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -72,7 +73,7 @@ public class TsFileTool {
       try {
         importSchema = ImportSchemaParser.parse(schemaPathStr);
       } catch (Exception e) {
-        LOGGER.error("Failed to parse schema file: " + schemaPathStr, e);
+        LOGGER.error(Messages.format("log.tools.tool_parse_schema_failed", schemaPathStr), e);
         System.exit(1);
       }
     }
@@ -87,9 +88,9 @@ public class TsFileTool {
       try {
         executor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
       } catch (InterruptedException e) {
-        LOGGER.error("Failed to await termination", e);
+        LOGGER.error(Messages.get("log.tools.tool_await_termination_failed"), e);
       }
-      LOGGER.info("The " + inputDirectoryStr + " directory or file has completed execution");
+      LOGGER.info(Messages.format("log.tools.tool_execution_completed", inputDirectoryStr));
     }
   }
 
@@ -155,7 +156,9 @@ public class TsFileTool {
               processAutoMode(inputFile, baseName, outputDir, format);
             }
           } catch (Exception e) {
-            LOGGER.error("Failed to process file: " + inputFile.getAbsolutePath(), e);
+            LOGGER.error(
+                Messages.format("log.tools.tool_process_file_failed", inputFile.getAbsolutePath()),
+                e);
             cpFile(inputFile.getAbsolutePath(), failedDirectoryStr);
           }
         });
@@ -167,12 +170,13 @@ public class TsFileTool {
       ImportExecutor importExecutor = new ImportExecutor(importSchema);
       boolean success = importExecutor.execute(reader, outputDir, baseName);
       if (success) {
-        LOGGER.info(baseName + ".tsfile successfully generated");
+        LOGGER.info(Messages.format("log.tools.tool_file_generated", baseName));
       } else {
         cpFile(inputFile.getAbsolutePath(), failedDirectoryStr);
       }
     } catch (Exception e) {
-      LOGGER.error("Failed to process file: " + inputFile.getAbsolutePath(), e);
+      LOGGER.error(
+          Messages.format("log.tools.tool_process_file_failed", inputFile.getAbsolutePath()), e);
       cpFile(inputFile.getAbsolutePath(), failedDirectoryStr);
     }
   }
@@ -184,12 +188,13 @@ public class TsFileTool {
       ImportExecutor importExecutor = new ImportExecutor(autoSchema);
       boolean success = importExecutor.execute(reader, outputDir, baseName);
       if (success) {
-        LOGGER.info(baseName + ".tsfile successfully generated");
+        LOGGER.info(Messages.format("log.tools.tool_file_generated", baseName));
       } else {
         cpFile(inputFile.getAbsolutePath(), failedDirectoryStr);
       }
     } catch (Exception e) {
-      LOGGER.error("Failed to process file: " + inputFile.getAbsolutePath(), e);
+      LOGGER.error(
+          Messages.format("log.tools.tool_process_file_failed", inputFile.getAbsolutePath()), e);
       cpFile(inputFile.getAbsolutePath(), failedDirectoryStr);
     }
   }
@@ -248,7 +253,7 @@ public class TsFileTool {
       Path targetPath = Paths.get(relativeDir, sourcePath.getFileName().toString());
       Files.copy(sourcePath, targetPath, StandardCopyOption.REPLACE_EXISTING);
     } catch (IOException e) {
-      LOGGER.error("Failed to copy file: " + sourceFilePath, e);
+      LOGGER.error(Messages.format("log.tools.tool_copy_file_failed", sourceFilePath), e);
     }
   }
 
@@ -334,7 +339,7 @@ public class TsFileTool {
         failedDirectoryStr = "failed";
       }
     } catch (ParseException e) {
-      LOGGER.error("Error parsing command line options", e);
+      LOGGER.error(Messages.get("log.tools.tool_parse_cli_error"), e);
     }
   }
 
@@ -350,7 +355,7 @@ public class TsFileTool {
           * 1024
           * 1024;
     } else if (blockSizeValue.endsWith("T") || blockSizeValue.endsWith("B")) {
-      throw new IllegalArgumentException("block_size only supports units of K, M, G, or numbers");
+      throw new IllegalArgumentException(Messages.get("error.tools.block_size_unsupported_unit"));
     }
     return Long.parseLong(blockSizeValue);
   }
@@ -370,27 +375,27 @@ public class TsFileTool {
 
   private static boolean validateParams() {
     if (inputDirectoryStr == null || inputDirectoryStr.isEmpty()) {
-      LOGGER.error("Missing required parameters. --source/-s is required");
+      LOGGER.error(Messages.get("log.tools.tool_source_required"));
       return false;
     }
     if (outputDirectoryStr == null || outputDirectoryStr.isEmpty()) {
-      LOGGER.error("Missing required parameters. --target/-t is required");
+      LOGGER.error(Messages.get("log.tools.tool_target_required"));
       return false;
     }
     File sourceDir = new File(inputDirectoryStr);
     if (!sourceDir.exists()) {
-      LOGGER.error(sourceDir + " directory or file does not exist.");
+      LOGGER.error(Messages.format("log.tools.tool_source_not_exist", sourceDir));
       return false;
     }
     if (schemaPathStr != null && !schemaPathStr.isEmpty()) {
       File schemaFile = new File(schemaPathStr);
       if (!schemaFile.exists()) {
-        LOGGER.error(schemaPathStr + " schema file does not exist.");
+        LOGGER.error(Messages.format("log.tools.tool_schema_not_exist", schemaPathStr));
         return false;
       }
     }
     if (THREAD_COUNT <= 0) {
-      LOGGER.error("Invalid thread number. Thread number must be greater than 0.");
+      LOGGER.error(Messages.get("log.tools.tool_invalid_thread_num"));
       return false;
     }
     return true;

--- a/java/tsfile/pom.xml
+++ b/java/tsfile/pom.xml
@@ -212,6 +212,12 @@
                     <skipTests>${tsfile.ut.skip}</skipTests>
                     <reuseForks>false</reuseForks>
                     <runOrder>random</runOrder>
+                    <!-- Pin tsfile.locale=en so tests run against the English (root) message
+                         bundle regardless of the JVM default locale. Must be set at JVM
+                         startup because Messages.BUNDLE is initialized once at class load. -->
+                    <systemPropertyVariables>
+                        <tsfile.locale>en</tsfile.locale>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>
@@ -222,6 +228,9 @@
                     <skipITs>${tsfile.it.skip}</skipITs>
                     <reuseForks>false</reuseForks>
                     <runOrder>random</runOrder>
+                    <systemPropertyVariables>
+                        <tsfile.locale>en</tsfile.locale>
+                    </systemPropertyVariables>
                 </configuration>
                 <executions>
                     <execution>

--- a/java/tsfile/src/main/java/org/apache/tsfile/compress/ICompressor.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/compress/ICompressor.java
@@ -23,6 +23,7 @@ import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.exception.compress.CompressionTypeNotSupportedException;
 import org.apache.tsfile.exception.compress.GZIPCompressOverflowException;
 import org.apache.tsfile.file.metadata.enums.CompressionType;
+import org.apache.tsfile.i18n.Messages;
 
 import com.github.luben.zstd.Zstd;
 import net.jpountz.lz4.LZ4Factory;
@@ -60,7 +61,8 @@ public interface ICompressor extends Serializable {
    */
   static ICompressor getCompressor(CompressionType name) {
     if (name == null) {
-      throw new CompressionTypeNotSupportedException("NULL");
+      throw new CompressionTypeNotSupportedException(
+          Messages.get("error.compress.type_not_supported_null"));
     }
     switch (name) {
       case UNCOMPRESSED:
@@ -76,7 +78,8 @@ public interface ICompressor extends Serializable {
       case LZMA2:
         return new LZMA2Compressor();
       default:
-        throw new CompressionTypeNotSupportedException(name.toString());
+        throw new CompressionTypeNotSupportedException(
+            Messages.format("error.compress.type_not_supported", name));
     }
   }
 
@@ -128,17 +131,17 @@ public interface ICompressor extends Serializable {
 
     @Override
     public byte[] compress(byte[] data, int offset, int length) throws IOException {
-      throw new IOException("No Compressor does not support compression function");
+      throw new IOException(Messages.get("error.compress.no_compressor_not_supported"));
     }
 
     @Override
     public int compress(byte[] data, int offset, int length, byte[] compressed) throws IOException {
-      throw new IOException("No Compressor does not support compression function");
+      throw new IOException(Messages.get("error.compress.no_compressor_not_supported"));
     }
 
     @Override
     public int compress(ByteBuffer data, ByteBuffer compressed) throws IOException {
-      throw new IOException("No Compressor does not support compression function");
+      throw new IOException(Messages.get("error.compress.no_compressor_not_supported"));
     }
 
     @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/compress/IUnCompressor.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/compress/IUnCompressor.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.compress;
 
 import org.apache.tsfile.exception.compress.CompressionTypeNotSupportedException;
 import org.apache.tsfile.file.metadata.enums.CompressionType;
+import org.apache.tsfile.i18n.Messages;
 
 import com.github.luben.zstd.Zstd;
 import net.jpountz.lz4.LZ4SafeDecompressor;
@@ -42,7 +43,8 @@ public interface IUnCompressor {
    */
   static IUnCompressor getUnCompressor(CompressionType name) {
     if (name == null) {
-      throw new CompressionTypeNotSupportedException("NULL");
+      throw new CompressionTypeNotSupportedException(
+          Messages.get("error.compress.type_not_supported_null"));
     }
     switch (name) {
       case UNCOMPRESSED:
@@ -58,7 +60,8 @@ public interface IUnCompressor {
       case LZMA2:
         return new LZMA2UnCompressor();
       default:
-        throw new CompressionTypeNotSupportedException(name.toString());
+        throw new CompressionTypeNotSupportedException(
+            Messages.format("error.compress.type_not_supported", name));
     }
   }
 
@@ -127,7 +130,7 @@ public interface IUnCompressor {
 
     @Override
     public int uncompress(ByteBuffer compressed, ByteBuffer uncompressed) throws IOException {
-      throw new IOException("NoUnCompressor does not support this method.");
+      throw new IOException(Messages.get("error.compress.no_uncompressor_not_supported"));
     }
 
     @Override
@@ -159,8 +162,7 @@ public interface IUnCompressor {
       try {
         return Snappy.uncompress(bytes);
       } catch (IOException e) {
-        logger.error(
-            "tsfile-compression SnappyUnCompressor: errors occurs when uncompress input byte", e);
+        logger.error(Messages.get("log.compress.snappy_uncompress_error"), e);
       }
       return new byte[0];
     }
@@ -180,8 +182,7 @@ public interface IUnCompressor {
       try {
         return Snappy.uncompress(compressed, uncompressed);
       } catch (IOException e) {
-        logger.error(
-            "tsfile-compression SnappyUnCompressor: errors occurs when uncompress input byte", e);
+        logger.error(Messages.get("log.compress.snappy_uncompress_error"), e);
       }
       return 0;
     }
@@ -195,8 +196,6 @@ public interface IUnCompressor {
   class LZ4UnCompressor implements IUnCompressor {
 
     private static final Logger logger = LoggerFactory.getLogger(LZ4UnCompressor.class);
-    private static final String UNCOMPRESS_INPUT_ERROR =
-        "tsfile-compression LZ4UnCompressor: errors occurs when uncompress input byte";
 
     private static final int MAX_COMPRESS_RATIO = 255;
     private static final LZ4SafeDecompressor decompressor =
@@ -206,12 +205,14 @@ public interface IUnCompressor {
 
     @Override
     public int getUncompressedLength(byte[] array, int offset, int length) {
-      throw new UnsupportedOperationException("unsupported get uncompress length");
+      throw new UnsupportedOperationException(
+          Messages.get("error.compress.get_uncompress_length_unsupported"));
     }
 
     @Override
     public int getUncompressedLength(ByteBuffer buffer) {
-      throw new UnsupportedOperationException("unsupported get uncompress length");
+      throw new UnsupportedOperationException(
+          Messages.get("error.compress.get_uncompress_length_unsupported"));
     }
 
     /**
@@ -228,7 +229,7 @@ public interface IUnCompressor {
       try {
         return decompressor.decompress(bytes, MAX_COMPRESS_RATIO * bytes.length);
       } catch (RuntimeException e) {
-        logger.error(UNCOMPRESS_INPUT_ERROR, e);
+        logger.error(Messages.get("log.compress.lz4_uncompress_error"), e);
         throw new IOException(e);
       }
     }
@@ -239,7 +240,7 @@ public interface IUnCompressor {
       try {
         return decompressor.decompress(byteArray, offset, length, output, outOffset);
       } catch (RuntimeException e) {
-        logger.error(UNCOMPRESS_INPUT_ERROR, e);
+        logger.error(Messages.get("log.compress.lz4_uncompress_error"), e);
         throw new IOException(e);
       }
     }
@@ -254,7 +255,7 @@ public interface IUnCompressor {
         decompressor.decompress(compressed, uncompressed);
         return compressed.limit();
       } catch (RuntimeException e) {
-        logger.error(UNCOMPRESS_INPUT_ERROR, e);
+        logger.error(Messages.get("log.compress.lz4_uncompress_error"), e);
         throw new IOException(e);
       }
     }
@@ -269,12 +270,14 @@ public interface IUnCompressor {
 
     @Override
     public int getUncompressedLength(byte[] array, int offset, int length) {
-      throw new UnsupportedOperationException("unsupported get uncompress length");
+      throw new UnsupportedOperationException(
+          Messages.get("error.compress.get_uncompress_length_unsupported"));
     }
 
     @Override
     public int getUncompressedLength(ByteBuffer buffer) {
-      throw new UnsupportedOperationException("unsupported get uncompress length");
+      throw new UnsupportedOperationException(
+          Messages.get("error.compress.get_uncompress_length_unsupported"));
     }
 
     @Override
@@ -358,12 +361,14 @@ public interface IUnCompressor {
 
     @Override
     public int getUncompressedLength(byte[] array, int offset, int length) {
-      throw new UnsupportedOperationException("unsupported get uncompress length");
+      throw new UnsupportedOperationException(
+          Messages.get("error.compress.get_uncompress_length_unsupported"));
     }
 
     @Override
     public int getUncompressedLength(ByteBuffer buffer) {
-      throw new UnsupportedOperationException("unsupported get uncompress length");
+      throw new UnsupportedOperationException(
+          Messages.get("error.compress.get_uncompress_length_unsupported"));
     }
 
     @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/BitmapDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/BitmapDecoder.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.encoding.decoder;
 
 import org.apache.tsfile.exception.encoding.TsFileDecodingException;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.Pair;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
@@ -69,7 +70,7 @@ public class BitmapDecoder extends Decoder {
   public BitmapDecoder() {
     super(TSEncoding.BITMAP);
     this.reset();
-    logger.debug("tsfile-encoding BitmapDecoder: init bitmap decoder");
+    logger.debug(Messages.get("log.encoding.bitmap_decoder_init"));
   }
 
   @Override
@@ -156,9 +157,7 @@ public class BitmapDecoder extends Decoder {
 
       resultList.add(new Pair<>(this.number, tmp));
       logger.debug(
-          "tsfile-encoding BitmapDecoder: number {} in current page, byte length {}",
-          this.number,
-          byteArrayLength);
+          Messages.get("log.encoding.bitmap_decoder_page_data"), this.number, byteArrayLength);
     }
     return resultList;
   }
@@ -186,36 +185,43 @@ public class BitmapDecoder extends Decoder {
    */
   @Override
   public boolean readBoolean(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readBoolean is not supported by BitmapDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.bitmap_decoder_method_not_supported", "readBoolean"));
   }
 
   @Override
   public short readShort(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readShort is not supported by BitmapDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.bitmap_decoder_method_not_supported", "readShort"));
   }
 
   @Override
   public long readLong(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readLong is not supported by BitmapDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.bitmap_decoder_method_not_supported", "readLong"));
   }
 
   @Override
   public float readFloat(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readFloat is not supported by BitmapDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.bitmap_decoder_method_not_supported", "readFloat"));
   }
 
   @Override
   public double readDouble(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readDouble is not supported by BitmapDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.bitmap_decoder_method_not_supported", "readDouble"));
   }
 
   @Override
   public Binary readBinary(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readBinary is not supported by BitmapDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.bitmap_decoder_method_not_supported", "readBinary"));
   }
 
   @Override
   public BigDecimal readBigDecimal(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readBigDecimal is not supported by BitmapDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.bitmap_decoder_method_not_supported", "readBigDecimal"));
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/CamelDecoder.java
@@ -23,6 +23,7 @@ import org.apache.tsfile.common.bitStream.BitInputStream;
 import org.apache.tsfile.common.bitStream.ByteBufferBackedInputStream;
 import org.apache.tsfile.exception.encoding.TsFileDecodingException;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
 import java.io.IOException;
@@ -112,7 +113,7 @@ public class CamelDecoder extends Decoder {
       if (cacheIndex >= cacheSize) {
         if (in == null || in.availableBits() == 0) {
           if (!buffer.hasRemaining()) {
-            throw new TsFileDecodingException("No more data to decode");
+            throw new TsFileDecodingException(Messages.get("error.encoding.camel_no_more_data"));
           }
           // read next chunk
           ByteBuffer slice = buffer.slice();
@@ -128,7 +129,8 @@ public class CamelDecoder extends Decoder {
           // decode current block
           double[] newValues = getValues();
           if (newValues.length == 0) {
-            throw new TsFileDecodingException("Unexpected empty block");
+            throw new TsFileDecodingException(
+                Messages.get("error.encoding.camel_unexpected_empty_block"));
           }
           valueCache = newValues;
           cacheSize = newValues.length;

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/Decoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/Decoder.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.encoding.decoder;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.encoding.TsFileDecodingException;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 
 import java.io.IOException;
@@ -30,7 +31,7 @@ import java.nio.ByteBuffer;
 
 public abstract class Decoder {
 
-  private static final String ERROR_MSG = "Decoder not found: %s , DataType is : %s";
+  private static final String ERROR_MSG_KEY = "error.encoding.decoder_not_found";
 
   private TSEncoding type;
 
@@ -64,7 +65,7 @@ public abstract class Decoder {
           case DOUBLE:
             return new FloatDecoder(TSEncoding.valueOf(encoding.toString()), dataType);
           default:
-            throw new TsFileDecodingException(String.format(ERROR_MSG, encoding, dataType));
+            throw new TsFileDecodingException(Messages.format(ERROR_MSG_KEY, encoding, dataType));
         }
       case TS_2DIFF:
         switch (dataType) {
@@ -79,7 +80,7 @@ public abstract class Decoder {
           case DOUBLE:
             return new FloatDecoder(TSEncoding.valueOf(encoding.toString()), dataType);
           default:
-            throw new TsFileDecodingException(String.format(ERROR_MSG, encoding, dataType));
+            throw new TsFileDecodingException(Messages.format(ERROR_MSG_KEY, encoding, dataType));
         }
       case GORILLA_V1:
         switch (dataType) {
@@ -88,7 +89,7 @@ public abstract class Decoder {
           case DOUBLE:
             return new DoublePrecisionDecoderV1();
           default:
-            throw new TsFileDecodingException(String.format(ERROR_MSG, encoding, dataType));
+            throw new TsFileDecodingException(Messages.format(ERROR_MSG_KEY, encoding, dataType));
         }
       case REGULAR:
         switch (dataType) {
@@ -100,7 +101,7 @@ public abstract class Decoder {
           case TIMESTAMP:
             return new RegularDataDecoder.LongRegularDecoder();
           default:
-            throw new TsFileDecodingException(String.format(ERROR_MSG, encoding, dataType));
+            throw new TsFileDecodingException(Messages.format(ERROR_MSG_KEY, encoding, dataType));
         }
       case GORILLA:
         switch (dataType) {
@@ -116,7 +117,7 @@ public abstract class Decoder {
           case TIMESTAMP:
             return new LongGorillaDecoder();
           default:
-            throw new TsFileDecodingException(String.format(ERROR_MSG, encoding, dataType));
+            throw new TsFileDecodingException(Messages.format(ERROR_MSG_KEY, encoding, dataType));
         }
       case DICTIONARY:
         return new DictionaryDecoder();
@@ -129,7 +130,7 @@ public abstract class Decoder {
           case TIMESTAMP:
             return new LongZigzagDecoder();
           default:
-            throw new TsFileDecodingException(String.format(ERROR_MSG, encoding, dataType));
+            throw new TsFileDecodingException(Messages.format(ERROR_MSG_KEY, encoding, dataType));
         }
       case CHIMP:
         switch (dataType) {
@@ -145,7 +146,7 @@ public abstract class Decoder {
           case TIMESTAMP:
             return new LongChimpDecoder();
           default:
-            throw new TsFileDecodingException(String.format(ERROR_MSG, encoding, dataType));
+            throw new TsFileDecodingException(Messages.format(ERROR_MSG_KEY, encoding, dataType));
         }
       case SPRINTZ:
         switch (dataType) {
@@ -160,7 +161,7 @@ public abstract class Decoder {
           case DOUBLE:
             return new DoubleSprintzDecoder();
           default:
-            throw new TsFileDecodingException(String.format(ERROR_MSG, encoding, dataType));
+            throw new TsFileDecodingException(Messages.format(ERROR_MSG_KEY, encoding, dataType));
         }
       case RLBE:
         switch (dataType) {
@@ -175,50 +176,58 @@ public abstract class Decoder {
           case DOUBLE:
             return new DoubleRLBEDecoder();
           default:
-            throw new TsFileDecodingException(String.format(ERROR_MSG, encoding, dataType));
+            throw new TsFileDecodingException(Messages.format(ERROR_MSG_KEY, encoding, dataType));
         }
       case CAMEL:
         switch (dataType) {
           case DOUBLE:
             return new CamelDecoder();
           default:
-            throw new TsFileDecodingException(String.format(ERROR_MSG, encoding, dataType));
+            throw new TsFileDecodingException(Messages.format(ERROR_MSG_KEY, encoding, dataType));
         }
       default:
-        throw new TsFileDecodingException(String.format(ERROR_MSG, encoding, dataType));
+        throw new TsFileDecodingException(Messages.format(ERROR_MSG_KEY, encoding, dataType));
     }
   }
 
   public int readInt(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readInt is not supported by Decoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.decoder_method_not_supported", "readInt"));
   }
 
   public boolean readBoolean(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readBoolean is not supported by Decoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.decoder_method_not_supported", "readBoolean"));
   }
 
   public short readShort(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readShort is not supported by Decoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.decoder_method_not_supported", "readShort"));
   }
 
   public long readLong(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readLong is not supported by Decoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.decoder_method_not_supported", "readLong"));
   }
 
   public float readFloat(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readFloat is not supported by Decoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.decoder_method_not_supported", "readFloat"));
   }
 
   public double readDouble(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readDouble is not supported by Decoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.decoder_method_not_supported", "readDouble"));
   }
 
   public Binary readBinary(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readBinary is not supported by Decoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.decoder_method_not_supported", "readBinary"));
   }
 
   public BigDecimal readBigDecimal(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readBigDecimal is not supported by Decoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.decoder_method_not_supported", "readBigDecimal"));
   }
 
   public abstract boolean hasNext(ByteBuffer buffer) throws IOException;

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/DictionaryDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/DictionaryDecoder.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.encoding.decoder;
 
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
@@ -52,7 +53,7 @@ public class DictionaryDecoder extends Decoder {
     try {
       return valueDecoder.hasNext(buffer);
     } catch (IOException e) {
-      logger.error("tsfile-decoding DictionaryDecoder: error occurs when decoding", e);
+      logger.error(Messages.get("log.encoding.dictionary_decoder_error"), e);
     }
 
     return false;

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/DoublePrecisionDecoderV1.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/DoublePrecisionDecoderV1.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.encoding.decoder;
 
 import org.apache.tsfile.common.conf.TSFileConfig;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
 import org.slf4j.Logger;
@@ -59,7 +60,7 @@ public class DoublePrecisionDecoderV1 extends GorillaDecoderV1 {
         getNextValue(buffer);
         return tmp;
       } catch (IOException e) {
-        logger.error("DoublePrecisionDecoderV1 cannot read first double number", e);
+        logger.error(Messages.get("log.encoding.double_precision_v1_first_double_error"), e);
       }
     } else {
       try {
@@ -67,7 +68,7 @@ public class DoublePrecisionDecoderV1 extends GorillaDecoderV1 {
         getNextValue(buffer);
         return tmp;
       } catch (IOException e) {
-        logger.error("DoublePrecisionDecoderV1 cannot read following double number", e);
+        logger.error(Messages.get("log.encoding.double_precision_v1_following_double_error"), e);
       }
     }
     return Double.NaN;

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/DoubleSprintzDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/DoubleSprintzDecoder.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.encoding.decoder;
 import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.encoding.bitpacking.LongPacker;
 import org.apache.tsfile.encoding.fire.LongFire;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
 import java.io.IOException;
@@ -116,7 +117,8 @@ public class DoubleSprintzDecoder extends SprintzDecoder {
         firePred.train(convertBuffer[i - 1], convertBuffer[i], err);
       }
     } else {
-      throw new UnsupportedOperationException("Sprintz predictive method {} is not supported.");
+      throw new UnsupportedOperationException(
+          Messages.get("error.encoding.sprintz_unsupported_predict_method"));
     }
   }
 
@@ -126,7 +128,7 @@ public class DoubleSprintzDecoder extends SprintzDecoder {
       try {
         decodeBlock(buffer);
       } catch (IOException e) {
-        logger.error("Error occured when readInt with Sprintz Decoder.", e);
+        logger.error(Messages.get("log.encoding.sprintz_decoder_read_error"), e);
       }
     }
     currentValue = currentBuffer[currentCount++];

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/FloatDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/FloatDecoder.java
@@ -23,6 +23,7 @@ import org.apache.tsfile.encoding.encoder.FloatEncoder;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.encoding.TsFileDecodingException;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.BitMap;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
@@ -57,39 +58,39 @@ public class FloatDecoder extends Decoder {
     if (encodingType == TSEncoding.RLE) {
       if (dataType == TSDataType.FLOAT) {
         decoder = new IntRleDecoder();
-        logger.debug("tsfile-encoding FloatDecoder: init decoder using int-rle and float");
+        logger.debug(Messages.get("log.encoding.float_decoder_init_int_rle"));
       } else if (dataType == TSDataType.DOUBLE) {
         decoder = new LongRleDecoder();
-        logger.debug("tsfile-encoding FloatDecoder: init decoder using long-rle and double");
+        logger.debug(Messages.get("log.encoding.float_decoder_init_long_rle"));
       } else {
         throw new TsFileDecodingException(
-            String.format("data type %s is not supported by FloatDecoder", dataType));
+            Messages.format("error.encoding.float_encoder_unsupported_type", dataType));
       }
     } else if (encodingType == TSEncoding.TS_2DIFF) {
       if (dataType == TSDataType.FLOAT) {
         decoder = new DeltaBinaryDecoder.IntDeltaDecoder();
-        logger.debug("tsfile-encoding FloatDecoder: init decoder using int-delta and float");
+        logger.debug(Messages.get("log.encoding.float_decoder_init_int_delta"));
       } else if (dataType == TSDataType.DOUBLE) {
         decoder = new DeltaBinaryDecoder.LongDeltaDecoder();
-        logger.debug("tsfile-encoding FloatDecoder: init decoder using long-delta and double");
+        logger.debug(Messages.get("log.encoding.float_decoder_init_long_delta"));
       } else {
         throw new TsFileDecodingException(
-            String.format("data type %s is not supported by FloatDecoder", dataType));
+            Messages.format("error.encoding.float_encoder_unsupported_type", dataType));
       }
     } else if (encodingType == TSEncoding.RLBE) {
       if (dataType == TSDataType.FLOAT) {
         decoder = new IntRLBEDecoder();
-        logger.debug("tsfile-encoding FloatDecoder: init decoder using int-rlbe and float");
+        logger.debug(Messages.get("log.encoding.float_decoder_init_int_rlbe"));
       } else if (dataType == TSDataType.DOUBLE) {
         decoder = new LongRLBEDecoder();
-        logger.debug("tsfile-encoding FloatDecoder: init decoder using long-rlbe and double");
+        logger.debug(Messages.get("log.encoding.float_decoder_init_long_rlbe"));
       } else {
         throw new TsFileDecodingException(
-            String.format("data type %s is not supported by FloatDecoder", dataType));
+            Messages.format("error.encoding.float_encoder_unsupported_type", dataType));
       }
     } else {
       throw new TsFileDecodingException(
-          String.format("%s encoding is not supported by FloatDecoder", encodingType));
+          Messages.format("error.encoding.float_decoder_unsupported_encoding", encodingType));
     }
     isMaxPointNumberRead = false;
   }
@@ -167,27 +168,32 @@ public class FloatDecoder extends Decoder {
 
   @Override
   public Binary readBinary(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readBinary is not supported by FloatDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.float_decoder_method_not_supported", "readBinary"));
   }
 
   @Override
   public boolean readBoolean(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readBoolean is not supported by FloatDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.float_decoder_method_not_supported", "readBoolean"));
   }
 
   @Override
   public short readShort(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readShort is not supported by FloatDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.float_decoder_method_not_supported", "readShort"));
   }
 
   @Override
   public int readInt(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readInt is not supported by FloatDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.float_decoder_method_not_supported", "readInt"));
   }
 
   @Override
   public long readLong(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readLong is not supported by FloatDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.float_decoder_method_not_supported", "readLong"));
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/FloatSprintzDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/FloatSprintzDecoder.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.encoding.decoder;
 import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.encoding.bitpacking.IntPacker;
 import org.apache.tsfile.encoding.fire.IntFire;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
 import java.io.IOException;
@@ -117,7 +118,8 @@ public class FloatSprintzDecoder extends SprintzDecoder {
         firePred.train(convertBuffer[i - 1], convertBuffer[i], err);
       }
     } else {
-      throw new UnsupportedOperationException("Sprintz predictive method {} is not supported.");
+      throw new UnsupportedOperationException(
+          Messages.get("error.encoding.sprintz_unsupported_predict_method"));
     }
   }
 
@@ -127,7 +129,7 @@ public class FloatSprintzDecoder extends SprintzDecoder {
       try {
         decodeBlock(buffer);
       } catch (IOException e) {
-        logger.error("Error occured when readInt with Sprintz Decoder.", e);
+        logger.error(Messages.get("log.encoding.sprintz_decoder_read_error"), e);
       }
     }
     currentValue = currentBuffer[currentCount];

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/GorillaDecoderV1.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/GorillaDecoderV1.java
@@ -19,6 +19,7 @@
 package org.apache.tsfile.encoding.decoder;
 
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
 import org.slf4j.Logger;
@@ -70,7 +71,7 @@ public abstract class GorillaDecoderV1 extends Decoder {
       fillBuffer(buffer);
     }
     if (isEmpty()) {
-      throw new IOException("Reading from empty buffer");
+      throw new IOException(Messages.get("error.encoding.gorilla_empty_buffer"));
     }
     numberLeftInBuffer--;
     return ((this.buffer >> numberLeftInBuffer) & 1) == 1;
@@ -86,7 +87,7 @@ public abstract class GorillaDecoderV1 extends Decoder {
       this.buffer = ReadWriteIOUtils.read(buffer);
       numberLeftInBuffer = 8;
     } else {
-      logger.error("Failed to fill a new buffer, because there is no byte to read");
+      logger.error(Messages.get("log.encoding.gorilla_fill_buffer_failed"));
       this.buffer = EOF;
       numberLeftInBuffer = -1;
     }

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/IntRleDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/IntRleDecoder.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.encoding.decoder;
 import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.encoding.bitpacking.IntPacker;
 import org.apache.tsfile.exception.encoding.TsFileDecodingException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
 import org.slf4j.Logger;
@@ -71,12 +72,7 @@ public class IntRleDecoder extends RleDecoder {
       try {
         readNext();
       } catch (IOException e) {
-        logger.error(
-            "tsfile-encoding IntRleDecoder: error occurs when reading all encoding number,"
-                + " length is {}, bit width is {}",
-            length,
-            bitWidth,
-            e);
+        logger.error(Messages.get("log.encoding.int_rle_decoder_read_error"), length, bitWidth, e);
       }
     }
     --currentCount;
@@ -90,7 +86,7 @@ public class IntRleDecoder extends RleDecoder {
         break;
       default:
         throw new TsFileDecodingException(
-            String.format("tsfile-encoding IntRleDecoder: not a valid mode %s", mode));
+            Messages.format("error.encoding.rle_decoder_invalid_mode_int", mode));
     }
 
     if (!hasNextPackage()) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/IntSprintzDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/IntSprintzDecoder.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.encoding.decoder;
 import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.encoding.bitpacking.IntPacker;
 import org.apache.tsfile.encoding.fire.IntFire;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
 import java.io.IOException;
@@ -106,7 +107,8 @@ public class IntSprintzDecoder extends SprintzDecoder {
         firePred.train(currentBuffer[i - 1], currentBuffer[i], err);
       }
     } else {
-      throw new UnsupportedOperationException("Sprintz predictive method {} is not supported.");
+      throw new UnsupportedOperationException(
+          Messages.get("error.encoding.sprintz_unsupported_predict_method"));
     }
   }
 
@@ -116,7 +118,7 @@ public class IntSprintzDecoder extends SprintzDecoder {
       try {
         decodeBlock(buffer);
       } catch (IOException e) {
-        logger.error("Error occured when readInt with Sprintz Decoder.", e);
+        logger.error(Messages.get("log.encoding.sprintz_decoder_read_error"), e);
       }
     }
     currentValue = currentBuffer[currentCount++];

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/IntZigzagDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/IntZigzagDecoder.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.encoding.decoder;
 
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
 import org.slf4j.Logger;
@@ -47,7 +48,7 @@ public class IntZigzagDecoder extends Decoder {
   public IntZigzagDecoder() {
     super(TSEncoding.ZIGZAG);
     this.reset();
-    logger.debug("tsfile-decoding IntZigzagDecoder: int zigzag decoder");
+    logger.debug(Messages.get("log.encoding.int_zigzag_decoder_init"));
   }
 
   /** decoding */

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/LongRleDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/LongRleDecoder.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.encoding.decoder;
 import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.encoding.bitpacking.LongPacker;
 import org.apache.tsfile.exception.encoding.TsFileDecodingException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
 import org.slf4j.Logger;
@@ -66,12 +67,7 @@ public class LongRleDecoder extends RleDecoder {
       try {
         readNext();
       } catch (IOException e) {
-        logger.error(
-            "tsfile-encoding IntRleDecoder: error occurs when reading all encoding number, length "
-                + "is {}, bit width is {}",
-            length,
-            bitWidth,
-            e);
+        logger.error(Messages.get("log.encoding.long_rle_decoder_read_error"), length, bitWidth, e);
       }
     }
     --currentCount;
@@ -85,7 +81,7 @@ public class LongRleDecoder extends RleDecoder {
         break;
       default:
         throw new TsFileDecodingException(
-            String.format("tsfile-encoding LongRleDecoder: not a valid mode %s", mode));
+            Messages.format("error.encoding.rle_decoder_invalid_mode_long", mode));
     }
 
     if (!hasNextPackage()) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/LongSprintzDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/LongSprintzDecoder.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.encoding.decoder;
 import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.encoding.bitpacking.LongPacker;
 import org.apache.tsfile.encoding.fire.LongFire;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
 import java.io.IOException;
@@ -104,7 +105,8 @@ public class LongSprintzDecoder extends SprintzDecoder {
         firePred.train(currentBuffer[i - 1], currentBuffer[i], err);
       }
     } else {
-      throw new UnsupportedOperationException("Sprintz predictive method {} is not supported.");
+      throw new UnsupportedOperationException(
+          Messages.get("error.encoding.sprintz_unsupported_predict_method"));
     }
   }
 
@@ -114,7 +116,7 @@ public class LongSprintzDecoder extends SprintzDecoder {
       try {
         decodeBlock(buffer);
       } catch (IOException e) {
-        logger.error("Error occured when readInt with Sprintz Decoder.", e);
+        logger.error(Messages.get("log.encoding.sprintz_decoder_read_error"), e);
       }
     }
     currentValue = currentBuffer[currentCount++];

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/LongZigzagDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/LongZigzagDecoder.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.encoding.decoder;
 
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
 import org.slf4j.Logger;
@@ -47,7 +48,7 @@ public class LongZigzagDecoder extends Decoder {
   public LongZigzagDecoder() {
     super(TSEncoding.ZIGZAG);
     this.reset();
-    logger.debug("tsfile-encoding LongZigzagDecoder: long zigzag decoder");
+    logger.debug(Messages.get("log.encoding.long_zigzag_decoder_init"));
   }
 
   /** decoding */

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/PlainDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/PlainDecoder.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.encoding.decoder;
 
 import org.apache.tsfile.exception.encoding.TsFileDecodingException;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
@@ -78,7 +79,8 @@ public class PlainDecoder extends Decoder {
 
   @Override
   public BigDecimal readBigDecimal(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readBigDecimal is not supported by PlainDecoder");
+    throw new TsFileDecodingException(
+        Messages.get("error.encoding.plain_decoder_bigdecimal_unsupported"));
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/RleDecoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/RleDecoder.java
@@ -23,6 +23,7 @@ import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.exception.encoding.TsFileDecodingException;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
@@ -109,7 +110,7 @@ public abstract class RleDecoder extends Decoder {
         break;
       default:
         throw new TsFileDecodingException(
-            String.format("tsfile-encoding IntRleDecoder: unknown encoding mode %s", mode));
+            Messages.format("error.encoding.rle_decoder_unknown_mode", mode));
     }
   }
 
@@ -125,9 +126,8 @@ public abstract class RleDecoder extends Decoder {
       bitPackingNum = currentCount;
     } else {
       throw new TsFileDecodingException(
-          String.format(
-              "tsfile-encoding IntRleDecoder: bitPackedGroupCount %d, smaller than 1",
-              bitPackedGroupCount));
+          Messages.format(
+              "error.encoding.rle_decoder_bit_packed_group_count", bitPackedGroupCount));
     }
     readBitPackingBuffer(bitPackedGroupCount, lastBitPackedNum);
   }
@@ -192,42 +192,50 @@ public abstract class RleDecoder extends Decoder {
 
   @Override
   public boolean readBoolean(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readBoolean is not supproted by RleDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.rle_decoder_method_not_supported", "readBoolean"));
   }
 
   @Override
   public short readShort(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readShort is not supproted by RleDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.rle_decoder_method_not_supported", "readShort"));
   }
 
   @Override
   public int readInt(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readInt is not supproted by RleDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.rle_decoder_method_not_supported", "readInt"));
   }
 
   @Override
   public long readLong(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readLong is not supproted by RleDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.rle_decoder_method_not_supported", "readLong"));
   }
 
   @Override
   public float readFloat(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readFloat is not supproted by RleDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.rle_decoder_method_not_supported", "readFloat"));
   }
 
   @Override
   public double readDouble(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readDouble is not supproted by RleDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.rle_decoder_method_not_supported", "readDouble"));
   }
 
   @Override
   public Binary readBinary(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readBinary is not supproted by RleDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.rle_decoder_method_not_supported", "readBinary"));
   }
 
   @Override
   public BigDecimal readBigDecimal(ByteBuffer buffer) {
-    throw new TsFileDecodingException("Method readBigDecimal is not supproted by RleDecoder");
+    throw new TsFileDecodingException(
+        Messages.format("error.encoding.rle_decoder_method_not_supported", "readBigDecimal"));
   }
 
   protected enum Mode {

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/SinglePrecisionDecoderV1.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/decoder/SinglePrecisionDecoderV1.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.encoding.decoder;
 
 import org.apache.tsfile.common.conf.TSFileConfig;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
 import org.slf4j.Logger;
@@ -55,7 +56,7 @@ public class SinglePrecisionDecoderV1 extends GorillaDecoderV1 {
         getNextValue(buffer);
         return tmp;
       } catch (IOException e) {
-        logger.error("SinglePrecisionDecoderV1 cannot read first float number", e);
+        logger.error(Messages.get("log.encoding.single_precision_v1_first_float_error"), e);
       }
     } else {
       try {
@@ -63,7 +64,7 @@ public class SinglePrecisionDecoderV1 extends GorillaDecoderV1 {
         getNextValue(buffer);
         return tmp;
       } catch (IOException e) {
-        logger.error("SinglePrecisionDecoderV1 cannot read following float number", e);
+        logger.error(Messages.get("log.encoding.single_precision_v1_following_float_error"), e);
       }
     }
     return Float.NaN;

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/BitmapEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/BitmapEncoder.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.encoding.encoder;
 
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
 import org.slf4j.Logger;
@@ -59,7 +60,7 @@ public class BitmapEncoder extends Encoder {
   public BitmapEncoder() {
     super(TSEncoding.BITMAP);
     this.values = new ArrayList<>();
-    logger.debug("tsfile-encoding BitmapEncoder: init bitmap encoder");
+    logger.debug(Messages.get("log.encoding.bitmap_encoder_init"));
   }
 
   /**

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/DeltaBinaryEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/DeltaBinaryEncoder.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.encoding.encoder;
 
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.BytesUtils;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
@@ -114,7 +115,7 @@ public abstract class DeltaBinaryEncoder extends Encoder {
     try {
       flushBlockBuffer(out);
     } catch (IOException e) {
-      logger.error("flush data to stream failed!", e);
+      logger.error(Messages.get("log.encoding.flush_data_failed"), e);
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/DictionaryEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/DictionaryEncoder.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.encoding.encoder;
 
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
@@ -78,7 +79,7 @@ public class DictionaryEncoder extends Encoder {
       writeMap(out);
       writeEncodedData(out);
     } catch (IOException e) {
-      logger.error("tsfile-encoding DictionaryEncoder: error occurs when flushing", e);
+      logger.error(Messages.get("log.encoding.dictionary_encoder_flush_error"), e);
     }
     reset();
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/DoubleSprintzEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/DoubleSprintzEncoder.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.encoding.encoder;
 import org.apache.tsfile.encoding.bitpacking.LongPacker;
 import org.apache.tsfile.encoding.fire.LongFire;
 import org.apache.tsfile.exception.encoding.TsFileEncodingException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
 import java.io.ByteArrayOutputStream;
@@ -74,7 +75,7 @@ public class DoubleSprintzEncoder extends SprintzEncoder {
       pred = fire(value, preVlaue);
     } else {
       throw new TsFileEncodingException(
-          "Config: Predict Method {} of SprintzEncoder is not supported.");
+          Messages.get("error.encoding.sprintz_encoder_unsupported_predict_method"));
     }
     if (pred <= 0) {
       pred = -2 * pred;
@@ -155,7 +156,7 @@ public class DoubleSprintzEncoder extends SprintzEncoder {
           flush(out);
         }
       } catch (IOException e) {
-        logger.error("Error occured when encoding INT32 Type value with with Sprintz", e);
+        logger.error(Messages.get("log.encoding.sprintz_double_encode_error"), e);
       }
     }
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/Encoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/Encoder.java
@@ -20,6 +20,7 @@ package org.apache.tsfile.encoding.encoder;
 
 import org.apache.tsfile.exception.encoding.TsFileEncodingException;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 
 import java.io.ByteArrayOutputStream;
@@ -50,35 +51,43 @@ public abstract class Encoder {
   }
 
   public void encode(boolean value, ByteArrayOutputStream out) {
-    throw new TsFileEncodingException("Method encode boolean is not supported by Encoder");
+    throw new TsFileEncodingException(
+        Messages.format("error.encoding.encoder_method_not_supported", "boolean"));
   }
 
   public void encode(short value, ByteArrayOutputStream out) {
-    throw new TsFileEncodingException("Method encode short is not supported by Encoder");
+    throw new TsFileEncodingException(
+        Messages.format("error.encoding.encoder_method_not_supported", "short"));
   }
 
   public void encode(int value, ByteArrayOutputStream out) {
-    throw new TsFileEncodingException("Method encode int is not supported by Encoder");
+    throw new TsFileEncodingException(
+        Messages.format("error.encoding.encoder_method_not_supported", "int"));
   }
 
   public void encode(long value, ByteArrayOutputStream out) {
-    throw new TsFileEncodingException("Method encode long is not supported by Encoder");
+    throw new TsFileEncodingException(
+        Messages.format("error.encoding.encoder_method_not_supported", "long"));
   }
 
   public void encode(float value, ByteArrayOutputStream out) {
-    throw new TsFileEncodingException("Method encode float is not supported by Encoder");
+    throw new TsFileEncodingException(
+        Messages.format("error.encoding.encoder_method_not_supported", "float"));
   }
 
   public void encode(double value, ByteArrayOutputStream out) {
-    throw new TsFileEncodingException("Method encode double is not supported by Encoder");
+    throw new TsFileEncodingException(
+        Messages.format("error.encoding.encoder_method_not_supported", "double"));
   }
 
   public void encode(Binary value, ByteArrayOutputStream out) {
-    throw new TsFileEncodingException("Method encode Binary is not supported by Encoder");
+    throw new TsFileEncodingException(
+        Messages.format("error.encoding.encoder_method_not_supported", "Binary"));
   }
 
   public void encode(BigDecimal value, ByteArrayOutputStream out) {
-    throw new TsFileEncodingException("Method encode BigDecimal is not supported by Encoder");
+    throw new TsFileEncodingException(
+        Messages.format("error.encoding.encoder_method_not_supported", "BigDecimal"));
   }
 
   /**

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/FloatEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/FloatEncoder.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.encoding.encoder;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.encoding.TsFileEncodingException;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.BitMap;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
@@ -70,7 +71,7 @@ public class FloatEncoder extends Encoder {
         encoder = new LongRleEncoder();
       } else {
         throw new TsFileEncodingException(
-            String.format("data type %s is not supported by FloatEncoder", dataType));
+            Messages.format("error.encoding.float_encoder_unsupported_type", dataType));
       }
     } else if (encodingType == TSEncoding.TS_2DIFF) {
       if (dataType == TSDataType.FLOAT) {
@@ -79,7 +80,7 @@ public class FloatEncoder extends Encoder {
         encoder = new DeltaBinaryEncoder.LongDeltaEncoder();
       } else {
         throw new TsFileEncodingException(
-            String.format("data type %s is not supported by FloatEncoder", dataType));
+            Messages.format("error.encoding.float_encoder_unsupported_type", dataType));
       }
     } else if (encodingType == TSEncoding.RLBE) {
       if (dataType == TSDataType.FLOAT) {
@@ -88,11 +89,11 @@ public class FloatEncoder extends Encoder {
         encoder = new LongRLBE();
       } else {
         throw new TsFileEncodingException(
-            String.format("data type %s is not supported by FloatEncoder", dataType));
+            Messages.format("error.encoding.float_encoder_unsupported_type", dataType));
       }
     } else {
       throw new TsFileEncodingException(
-          String.format("%s encoding is not supported by FloatEncoder", encodingType));
+          Messages.format("error.encoding.float_encoder_unsupported_encoding", encodingType));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/FloatSprintzEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/FloatSprintzEncoder.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.encoding.encoder;
 import org.apache.tsfile.encoding.bitpacking.IntPacker;
 import org.apache.tsfile.encoding.fire.IntFire;
 import org.apache.tsfile.exception.encoding.TsFileEncodingException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
 import java.io.ByteArrayOutputStream;
@@ -73,7 +74,7 @@ public class FloatSprintzEncoder extends SprintzEncoder {
       pred = fire(value, preVlaue);
     } else {
       throw new TsFileEncodingException(
-          "Config: Predict Method {} of SprintzEncoder is not supported.");
+          Messages.get("error.encoding.sprintz_encoder_unsupported_predict_method"));
     }
     if (pred <= 0) pred = -2 * pred;
     else pred = 2 * pred - 1; // TODO:overflow
@@ -149,7 +150,7 @@ public class FloatSprintzEncoder extends SprintzEncoder {
           flush(out);
         }
       } catch (IOException e) {
-        logger.error("Error occured when encoding Float Type value with with Sprintz", e);
+        logger.error(Messages.get("log.encoding.sprintz_float_encode_error"), e);
       }
     }
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/IntSprintzEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/IntSprintzEncoder.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.encoding.encoder;
 import org.apache.tsfile.encoding.bitpacking.IntPacker;
 import org.apache.tsfile.encoding.fire.IntFire;
 import org.apache.tsfile.exception.encoding.TsFileEncodingException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
 import java.io.ByteArrayOutputStream;
@@ -69,7 +70,7 @@ public class IntSprintzEncoder extends SprintzEncoder {
       pred = fire(value, preVlaue);
     } else {
       throw new TsFileEncodingException(
-          "Config: Predict Method {} of SprintzEncoder is not supported.");
+          Messages.get("error.encoding.sprintz_encoder_unsupported_predict_method"));
     }
     if (pred <= 0) {
       pred = -2 * pred;
@@ -151,7 +152,7 @@ public class IntSprintzEncoder extends SprintzEncoder {
           flush(out);
         }
       } catch (IOException e) {
-        logger.error("Error occured when encoding INT32 Type value with with Sprintz", e);
+        logger.error(Messages.get("log.encoding.sprintz_int_encode_error"), e);
       }
     }
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/IntZigzagEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/IntZigzagEncoder.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.encoding.encoder;
 
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
 import org.slf4j.Logger;
@@ -43,7 +44,7 @@ public class IntZigzagEncoder extends Encoder {
   public IntZigzagEncoder() {
     super(TSEncoding.ZIGZAG);
     this.values = new ArrayList<>();
-    logger.debug("tsfile-encoding IntZigzagEncoder: int zigzag encoder");
+    logger.debug(Messages.get("log.encoding.int_zigzag_encoder_init"));
   }
 
   /** encoding and bit packing. */

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/LongSprintzEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/LongSprintzEncoder.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.encoding.encoder;
 import org.apache.tsfile.encoding.bitpacking.LongPacker;
 import org.apache.tsfile.encoding.fire.LongFire;
 import org.apache.tsfile.exception.encoding.TsFileEncodingException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
 import java.io.ByteArrayOutputStream;
@@ -70,7 +71,7 @@ public class LongSprintzEncoder extends SprintzEncoder {
       pred = fire(value, preVlaue);
     } else {
       throw new TsFileEncodingException(
-          "Config: Predict Method {} of SprintzEncoder is not supported.");
+          Messages.get("error.encoding.sprintz_encoder_unsupported_predict_method"));
     }
     if (pred <= 0) {
       pred = -2 * pred;
@@ -152,7 +153,7 @@ public class LongSprintzEncoder extends SprintzEncoder {
           flush(out);
         }
       } catch (IOException e) {
-        logger.error("Error occured when encoding INT64 Type value with with Sprintz", e);
+        logger.error(Messages.get("log.encoding.sprintz_long_encode_error"), e);
       }
     }
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/LongZigzagEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/LongZigzagEncoder.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.encoding.encoder;
 
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
 import org.slf4j.Logger;
@@ -43,7 +44,7 @@ public class LongZigzagEncoder extends Encoder {
   public LongZigzagEncoder() {
     super(TSEncoding.ZIGZAG);
     this.values = new ArrayList<>();
-    logger.debug("tsfile-encoding LongZigzagEncoder: long zigzag encoder");
+    logger.debug(Messages.get("log.encoding.long_zigzag_encoder_init"));
   }
 
   /** encoding and bit packing. */

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/PlainEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/PlainEncoder.java
@@ -23,6 +23,7 @@ import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.encoding.TsFileEncodingException;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
@@ -94,15 +95,14 @@ public class PlainEncoder extends Encoder {
       // write value
       out.write(value.getValues());
     } catch (IOException e) {
-      logger.error(
-          "tsfile-encoding PlainEncoder: error occurs when encode Binary value {}", value, e);
+      logger.error(Messages.get("log.encoding.plain_encoder_binary_error"), value, e);
     }
   }
 
   @Override
   public void encode(BigDecimal value, ByteArrayOutputStream out) {
     throw new TsFileEncodingException(
-        "tsfile-encoding PlainEncoder: current version does not support BigDecimal value encoding");
+        Messages.get("error.encoding.plain_encoder_bigdecimal_unsupported"));
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/RegularDataEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/RegularDataEncoder.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.encoding.encoder;
 
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.BytesUtils;
 
 import org.slf4j.Logger;
@@ -103,7 +104,7 @@ public abstract class RegularDataEncoder extends Encoder {
     try {
       flushBlockBuffer(out);
     } catch (IOException e) {
-      LOGGER.error("flush data to stream failed!", e);
+      LOGGER.error(Messages.get("log.encoding.flush_data_failed"), e);
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/RleEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/RleEncoder.java
@@ -23,6 +23,7 @@ import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.exception.encoding.TsFileEncodingException;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
@@ -132,10 +133,7 @@ public abstract class RleEncoder<T extends Comparable<T>> extends Encoder {
         writeRleRun();
       } catch (IOException e) {
         logger.error(
-            "tsfile-encoding RleEncoder : error occurs when writing nums to OutputStram "
-                + "when flushing left nums. "
-                + "numBufferedValues {}, repeatCount {}, bitPackedGroupCount{}, "
-                + "isBitPackRun {}, isBitWidthSaved {}",
+            Messages.get("log.encoding.rle_flush_rle_run_error"),
             numBufferedValues,
             repeatCount,
             bitPackedGroupCount,
@@ -234,12 +232,10 @@ public abstract class RleEncoder<T extends Comparable<T>> extends Encoder {
         repeatCount = TSFileConfig.RLE_MAX_REPEATED_NUM;
         try {
           writeRleRun();
-          logger.debug("tsfile-encoding RleEncoder : write full rle run to stream");
+          logger.debug(Messages.get("log.encoding.rle_write_full_rle_run"));
         } catch (IOException e) {
           logger.error(
-              " error occurs when writing full rle run to OutputStram when repeatCount = {}."
-                  + "numBufferedValues {}, repeatCount {}, bitPackedGroupCount{}, "
-                  + "isBitPackRun {}, isBitWidthSaved {}",
+              Messages.get("log.encoding.rle_full_rle_run_error"),
               TSFileConfig.RLE_MAX_REPEATED_NUM + 1,
               numBufferedValues,
               repeatCount,
@@ -259,10 +255,7 @@ public abstract class RleEncoder<T extends Comparable<T>> extends Encoder {
           writeRleRun();
         } catch (IOException e) {
           logger.error(
-              "tsfile-encoding RleEncoder : error occurs when writing num to OutputStram "
-                  + "when repeatCount > {}."
-                  + "numBufferedValues {}, repeatCount {}, bitPackedGroupCount{}, isBitPackRun {}, "
-                  + "isBitWidthSaved {}",
+              Messages.get("log.encoding.rle_write_num_error"),
               TSFileConfig.RLE_MIN_REPEATED_NUM,
               numBufferedValues,
               repeatCount,

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/TSEncodingBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/TSEncodingBuilder.java
@@ -24,6 +24,7 @@ import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.common.constant.JsonFormatConstant;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.write.UnSupportedDataTypeException;
 
 import org.slf4j.Logger;
@@ -44,7 +45,7 @@ public abstract class TSEncodingBuilder {
 
   private static final Logger logger = LoggerFactory.getLogger(TSEncodingBuilder.class);
   protected final TSFileConfig conf;
-  private static final String ERROR_MSG = "%s doesn't support data type: %s";
+  private static final String ERROR_MSG_KEY = "error.encoding.ts_encoding_builder_unsupported_type";
 
   protected TSEncodingBuilder() {
     this.conf = TSFileDescriptor.getInstance().getConfig();
@@ -81,7 +82,8 @@ public abstract class TSEncodingBuilder {
       case CAMEL:
         return new Camel();
       default:
-        throw new UnsupportedOperationException("Unsupported encoding: " + type);
+        throw new UnsupportedOperationException(
+            Messages.format("error.encoding.ts_encoding_builder_unsupported", type));
     }
   }
 
@@ -128,8 +130,7 @@ public abstract class TSEncodingBuilder {
         if (maxStringLength < 0) {
           maxStringLength = TSFileDescriptor.getInstance().getConfig().getMaxStringLength();
           logger.warn(
-              "cannot set max string length to negative value, replaced with default value:{}",
-              maxStringLength);
+              Messages.get("log.encoding.ts_encoding_max_string_length_negative"), maxStringLength);
         }
       }
     }
@@ -154,7 +155,8 @@ public abstract class TSEncodingBuilder {
         case DOUBLE:
           return new FloatEncoder(TSEncoding.RLE, type, maxPointNumber);
         default:
-          throw new UnSupportedDataTypeException(String.format(ERROR_MSG, TSEncoding.RLE, type));
+          throw new UnSupportedDataTypeException(
+              Messages.format(ERROR_MSG_KEY, TSEncoding.RLE, type));
       }
     }
 
@@ -172,15 +174,13 @@ public abstract class TSEncodingBuilder {
           this.maxPointNumber = Integer.parseInt(props.get(Encoder.MAX_POINT_NUMBER));
         } catch (NumberFormatException e) {
           logger.warn(
-              "The format of max point number {} is not correct."
-                  + " Using default float precision.",
+              Messages.get("log.encoding.ts_encoding_max_point_number_format"),
               props.get(Encoder.MAX_POINT_NUMBER));
         }
         if (maxPointNumber < 0) {
           maxPointNumber = TSFileDescriptor.getInstance().getConfig().getFloatPrecision();
           logger.warn(
-              "cannot set max point number to negative value, replaced with default value:{}",
-              maxPointNumber);
+              Messages.get("log.encoding.ts_encoding_max_point_number_negative"), maxPointNumber);
         }
       }
     }
@@ -210,7 +210,7 @@ public abstract class TSEncodingBuilder {
           return new FloatEncoder(TSEncoding.TS_2DIFF, type, maxPointNumber);
         default:
           throw new UnSupportedDataTypeException(
-              String.format(ERROR_MSG, TSEncoding.TS_2DIFF, type));
+              Messages.format(ERROR_MSG_KEY, TSEncoding.TS_2DIFF, type));
       }
     }
 
@@ -228,15 +228,13 @@ public abstract class TSEncodingBuilder {
           this.maxPointNumber = Integer.parseInt(props.get(Encoder.MAX_POINT_NUMBER));
         } catch (NumberFormatException e) {
           logger.warn(
-              "The format of max point number {} is not correct."
-                  + " Using default float precision.",
+              Messages.get("log.encoding.ts_encoding_max_point_number_format"),
               props.get(Encoder.MAX_POINT_NUMBER));
         }
         if (maxPointNumber < 0) {
           maxPointNumber = TSFileDescriptor.getInstance().getConfig().getFloatPrecision();
           logger.warn(
-              "cannot set max point number to negative value, replaced with default value:{}",
-              maxPointNumber);
+              Messages.get("log.encoding.ts_encoding_max_point_number_negative"), maxPointNumber);
         }
       }
     }
@@ -259,7 +257,7 @@ public abstract class TSEncodingBuilder {
           return new DoublePrecisionEncoderV1();
         default:
           throw new UnSupportedDataTypeException(
-              String.format(ERROR_MSG, TSEncoding.GORILLA_V1, type));
+              Messages.format(ERROR_MSG_KEY, TSEncoding.GORILLA_V1, type));
       }
     }
 
@@ -277,7 +275,8 @@ public abstract class TSEncodingBuilder {
       if (Objects.requireNonNull(type) == TSDataType.DOUBLE) {
         return new CamelEncoder();
       }
-      throw new UnSupportedDataTypeException(String.format(ERROR_MSG, TSEncoding.CAMEL, type));
+      throw new UnSupportedDataTypeException(
+          Messages.format(ERROR_MSG_KEY, TSEncoding.CAMEL, type));
     }
 
     @Override
@@ -300,7 +299,7 @@ public abstract class TSEncodingBuilder {
           return new RegularDataEncoder.LongRegularEncoder();
         default:
           throw new UnSupportedDataTypeException(
-              String.format(ERROR_MSG, TSEncoding.REGULAR, type));
+              Messages.format(ERROR_MSG_KEY, TSEncoding.REGULAR, type));
       }
     }
 
@@ -328,7 +327,7 @@ public abstract class TSEncodingBuilder {
           return new LongGorillaEncoder();
         default:
           throw new UnSupportedDataTypeException(
-              String.format(ERROR_MSG, TSEncoding.GORILLA, type));
+              Messages.format(ERROR_MSG_KEY, TSEncoding.GORILLA, type));
       }
     }
 
@@ -354,7 +353,7 @@ public abstract class TSEncodingBuilder {
           return new DoubleSprintzEncoder();
         default:
           throw new UnSupportedDataTypeException(
-              String.format(ERROR_MSG, TSEncoding.SPRINTZ, type));
+              Messages.format(ERROR_MSG_KEY, TSEncoding.SPRINTZ, type));
       }
     }
 
@@ -380,7 +379,8 @@ public abstract class TSEncodingBuilder {
         case DOUBLE:
           return new DoubleRLBE();
         default:
-          throw new UnSupportedDataTypeException(String.format(ERROR_MSG, TSEncoding.RLBE, type));
+          throw new UnSupportedDataTypeException(
+              Messages.format(ERROR_MSG_KEY, TSEncoding.RLBE, type));
       }
     }
 
@@ -397,7 +397,8 @@ public abstract class TSEncodingBuilder {
       if (type == TSDataType.TEXT || type == TSDataType.STRING) {
         return new DictionaryEncoder();
       }
-      throw new UnSupportedDataTypeException(String.format(ERROR_MSG, TSEncoding.DICTIONARY, type));
+      throw new UnSupportedDataTypeException(
+          Messages.format(ERROR_MSG_KEY, TSEncoding.DICTIONARY, type));
     }
 
     @Override
@@ -418,7 +419,8 @@ public abstract class TSEncodingBuilder {
         case TIMESTAMP:
           return new LongZigzagEncoder();
         default:
-          throw new UnSupportedDataTypeException(String.format(ERROR_MSG, TSEncoding.ZIGZAG, type));
+          throw new UnSupportedDataTypeException(
+              Messages.format(ERROR_MSG_KEY, TSEncoding.ZIGZAG, type));
       }
     }
 
@@ -445,7 +447,8 @@ public abstract class TSEncodingBuilder {
         case TIMESTAMP:
           return new LongChimpEncoder();
         default:
-          throw new UnSupportedDataTypeException(String.format(ERROR_MSG, TSEncoding.CHIMP, type));
+          throw new UnSupportedDataTypeException(
+              Messages.format(ERROR_MSG_KEY, TSEncoding.CHIMP, type));
       }
     }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/encrypt/EncryptUtils.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encrypt/EncryptUtils.java
@@ -269,8 +269,7 @@ public class EncryptUtils {
       try {
         md = MessageDigest.getInstance("SHA-256");
       } catch (NoSuchAlgorithmException e) {
-        throw new EncryptException(
-            "SHA-256 algorithm not found while using SHA-256 to generate data key", e);
+        throw new EncryptException(Messages.get("error.encrypt.sha256_not_found"), e);
       }
       md.update("IoTDB is the best".getBytes());
       md.update(param.getKey());

--- a/java/tsfile/src/main/java/org/apache/tsfile/encrypt/EncryptUtils.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encrypt/EncryptUtils.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.encrypt;
 import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.exception.encrypt.EncryptException;
+import org.apache.tsfile.i18n.Messages;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,7 +88,7 @@ public class EncryptUtils {
     try {
       return deriveKeyInternal(token.getBytes(), salt, ITERATION_COUNT, dkLen);
     } catch (NoSuchAlgorithmException | InvalidKeyException e) {
-      throw new EncryptException("Error deriving key from token", e);
+      throw new EncryptException(Messages.get("error.encrypt.key_derivation_failed"), e);
     }
   }
 
@@ -97,10 +98,10 @@ public class EncryptUtils {
     int hLen = getPRFLength();
 
     if (dkLen < 1) {
-      throw new EncryptException("main key's dkLen must be positive integer: " + dkLen);
+      throw new EncryptException(Messages.format("error.encrypt.dklen_not_positive", dkLen));
     }
     if ((long) dkLen > (long) (Math.pow(2, 32) - 1) * hLen) {
-      throw new EncryptException("main key's dkLen is too long: " + dkLen);
+      throw new EncryptException(Messages.format("error.encrypt.dklen_too_long", dkLen));
     }
 
     int n = (int) Math.ceil((double) dkLen / hLen);
@@ -198,8 +199,7 @@ public class EncryptUtils {
     try {
       md = MessageDigest.getInstance("SHA-256");
     } catch (NoSuchAlgorithmException e) {
-      throw new EncryptException(
-          "SHA-256 algorithm not found while using SHA-256 to generate data key", e);
+      throw new EncryptException(Messages.get("error.encrypt.sha256_not_found"), e);
     }
     md.update("IoTDB is the best".getBytes());
     md.update(conf.getEncryptKey());
@@ -298,11 +298,14 @@ public class EncryptUtils {
       IEncrypt.encryptMap.put(className, constructor);
       return ((IEncrypt) constructor.newInstance(dataEncryptKey));
     } catch (ClassNotFoundException e) {
-      throw new EncryptException("Get encryptor class failed: " + encryptType, e);
+      throw new EncryptException(
+          Messages.format("error.encrypt.encrypt_class_not_found", encryptType), e);
     } catch (NoSuchMethodException e) {
-      throw new EncryptException("Get constructor for encryptor failed: " + encryptType, e);
+      throw new EncryptException(
+          Messages.format("error.encrypt.encrypt_no_constructor", encryptType), e);
     } catch (InvocationTargetException | InstantiationException | IllegalAccessException e) {
-      throw new EncryptException("New encryptor instance failed: " + encryptType, e);
+      throw new EncryptException(
+          Messages.format("error.encrypt.encrypt_instantiation_failed", encryptType), e);
     }
   }
 
@@ -316,8 +319,7 @@ public class EncryptUtils {
       try {
         md = MessageDigest.getInstance("SHA-256");
       } catch (NoSuchAlgorithmException e) {
-        throw new EncryptException(
-            "SHA-256 algorithm not found while using SHA-256 to generate data key", e);
+        throw new EncryptException(Messages.get("error.encrypt.sha256_not_found"), e);
       }
       md.update("IoTDB is the best".getBytes());
       md.update(conf.getEncryptKey());

--- a/java/tsfile/src/main/java/org/apache/tsfile/encrypt/IDecryptor.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encrypt/IDecryptor.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.encrypt;
 
 import org.apache.tsfile.exception.encrypt.EncryptException;
 import org.apache.tsfile.file.metadata.enums.EncryptionType;
+import org.apache.tsfile.i18n.Messages;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,11 +45,14 @@ public interface IDecryptor {
       IEncrypt.encryptMap.put(className, constructor);
       return ((IEncrypt) constructor.newInstance(key)).getDecryptor();
     } catch (ClassNotFoundException e) {
-      throw new EncryptException("Get decryptor class failed, class not found: " + type, e);
+      throw new EncryptException(
+          Messages.format("error.encrypt.decryptor_class_not_found", type), e);
     } catch (NoSuchMethodException e) {
-      throw new EncryptException("Get constructor for decryptor failed: " + type, e);
+      throw new EncryptException(
+          Messages.format("error.encrypt.decryptor_no_constructor", type), e);
     } catch (InvocationTargetException | InstantiationException | IllegalAccessException e) {
-      throw new EncryptException("New decryptor instance failed: " + type, e);
+      throw new EncryptException(
+          Messages.format("error.encrypt.decryptor_instantiation_failed", type), e);
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/encrypt/IEncryptor.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encrypt/IEncryptor.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.encrypt;
 
 import org.apache.tsfile.exception.encrypt.EncryptException;
 import org.apache.tsfile.file.metadata.enums.EncryptionType;
+import org.apache.tsfile.i18n.Messages;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,11 +45,14 @@ public interface IEncryptor {
       IEncrypt.encryptMap.put(className, constructor);
       return ((IEncrypt) constructor.newInstance(key)).getEncryptor();
     } catch (ClassNotFoundException e) {
-      throw new EncryptException("Get encryptor class failed, class not found: " + type, e);
+      throw new EncryptException(
+          Messages.format("error.encrypt.encryptor_class_not_found", type), e);
     } catch (NoSuchMethodException e) {
-      throw new EncryptException("Get constructor for encryptor failed: " + type, e);
+      throw new EncryptException(
+          Messages.format("error.encrypt.encryptor_no_constructor", type), e);
     } catch (InvocationTargetException | InstantiationException | IllegalAccessException e) {
-      throw new EncryptException("New encryptor instance failed: " + type, e);
+      throw new EncryptException(
+          Messages.format("error.encrypt.encryptor_instantiation_failed", type), e);
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/collections4/comparators/ComparatorChain.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/collections4/comparators/ComparatorChain.java
@@ -16,6 +16,8 @@
  */
 package org.apache.tsfile.external.commons.collections4.comparators;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.io.Serializable;
 import java.util.BitSet;
 import java.util.Comparator;
@@ -98,7 +100,7 @@ public class ComparatorChain<E> implements Comparator<E>, Serializable {
   private void checkChainIntegrity() {
     if (comparatorChain.size() == 0) {
       throw new UnsupportedOperationException(
-          "ComparatorChains must contain at least one Comparator");
+          Messages.get("error.external.comparator_chain_empty"));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/collections4/iterators/AbstractEmptyIterator.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/collections4/iterators/AbstractEmptyIterator.java
@@ -16,6 +16,8 @@
  */
 package org.apache.tsfile.external.commons.collections4.iterators;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.util.NoSuchElementException;
 
 /**
@@ -35,7 +37,7 @@ abstract class AbstractEmptyIterator<E> {
   }
 
   public E next() {
-    throw new NoSuchElementException("Iterator contains no elements");
+    throw new NoSuchElementException(Messages.get("error.external.empty_iterator_no_elements"));
   }
 
   public boolean hasPrevious() {
@@ -43,11 +45,11 @@ abstract class AbstractEmptyIterator<E> {
   }
 
   public E previous() {
-    throw new NoSuchElementException("Iterator contains no elements");
+    throw new NoSuchElementException(Messages.get("error.external.empty_iterator_no_elements"));
   }
 
   public void remove() {
-    throw new IllegalStateException("Iterator contains no elements");
+    throw new IllegalStateException(Messages.get("error.external.empty_iterator_no_elements"));
   }
 
   public void reset() {

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/collections4/iterators/AbstractEmptyMapIterator.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/collections4/iterators/AbstractEmptyMapIterator.java
@@ -16,6 +16,8 @@
  */
 package org.apache.tsfile.external.commons.collections4.iterators;
 
+import org.apache.tsfile.i18n.Messages;
+
 /**
  * Provides an implementation of an empty map iterator.
  *
@@ -31,14 +33,14 @@ public abstract class AbstractEmptyMapIterator<K, V> extends AbstractEmptyIterat
   }
 
   public K getKey() {
-    throw new IllegalStateException("Iterator contains no elements");
+    throw new IllegalStateException(Messages.get("error.external.empty_map_iterator_no_elements"));
   }
 
   public V getValue() {
-    throw new IllegalStateException("Iterator contains no elements");
+    throw new IllegalStateException(Messages.get("error.external.empty_map_iterator_no_elements"));
   }
 
   public V setValue(final V value) {
-    throw new IllegalStateException("Iterator contains no elements");
+    throw new IllegalStateException(Messages.get("error.external.empty_map_iterator_no_elements"));
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/collections4/map/AbstractHashedMap.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/collections4/map/AbstractHashedMap.java
@@ -21,6 +21,7 @@ import org.apache.tsfile.external.commons.collections4.KeyValue;
 import org.apache.tsfile.external.commons.collections4.MapIterator;
 import org.apache.tsfile.external.commons.collections4.iterators.EmptyIterator;
 import org.apache.tsfile.external.commons.collections4.iterators.EmptyMapIterator;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -58,15 +59,15 @@ import java.util.Set;
  */
 public class AbstractHashedMap<K, V> extends AbstractMap<K, V> implements IterableMap<K, V> {
 
-  protected static final String NO_NEXT_ENTRY = "No next() entry in the iteration";
-  protected static final String NO_PREVIOUS_ENTRY = "No previous() entry in the iteration";
-  protected static final String REMOVE_INVALID = "remove() can only be called once after next()";
-  protected static final String GETKEY_INVALID =
-      "getKey() can only be called after next() and before remove()";
+  protected static final String NO_NEXT_ENTRY = Messages.get("error.external.map_no_next_entry");
+  protected static final String NO_PREVIOUS_ENTRY =
+      Messages.get("error.external.map_no_previous_entry");
+  protected static final String REMOVE_INVALID = Messages.get("error.external.map_remove_invalid");
+  protected static final String GETKEY_INVALID = Messages.get("error.external.map_getkey_invalid");
   protected static final String GETVALUE_INVALID =
-      "getValue() can only be called after next() and before remove()";
+      Messages.get("error.external.map_getvalue_invalid");
   protected static final String SETVALUE_INVALID =
-      "setValue() can only be called after next() and before remove()";
+      Messages.get("error.external.map_setvalue_invalid");
 
   /** The default capacity to use */
   protected static final int DEFAULT_CAPACITY = 16;
@@ -151,10 +152,12 @@ public class AbstractHashedMap<K, V> extends AbstractMap<K, V> implements Iterab
   protected AbstractHashedMap(int initialCapacity, final float loadFactor) {
     super();
     if (initialCapacity < 0) {
-      throw new IllegalArgumentException("Initial capacity must be a non negative number");
+      throw new IllegalArgumentException(
+          Messages.get("error.external.hashed_map_capacity_negative"));
     }
     if (loadFactor <= 0.0f || Float.isNaN(loadFactor)) {
-      throw new IllegalArgumentException("Load factor must be greater than 0");
+      throw new IllegalArgumentException(
+          Messages.get("error.external.hashed_map_load_factor_invalid"));
     }
     this.loadFactor = loadFactor;
     initialCapacity = calculateNewCapacity(initialCapacity);

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/collections4/map/AbstractLinkedMap.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/collections4/map/AbstractLinkedMap.java
@@ -22,6 +22,7 @@ import org.apache.tsfile.external.commons.collections4.OrderedMapIterator;
 import org.apache.tsfile.external.commons.collections4.ResettableIterator;
 import org.apache.tsfile.external.commons.collections4.iterators.EmptyOrderedIterator;
 import org.apache.tsfile.external.commons.collections4.iterators.EmptyOrderedMapIterator;
+import org.apache.tsfile.i18n.Messages;
 
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
@@ -171,7 +172,7 @@ public abstract class AbstractLinkedMap<K, V> extends AbstractHashedMap<K, V>
   @Override
   public K firstKey() {
     if (size == 0) {
-      throw new NoSuchElementException("Map is empty");
+      throw new NoSuchElementException(Messages.get("error.external.linked_map_empty"));
     }
     return header.after.getKey();
   }
@@ -184,7 +185,7 @@ public abstract class AbstractLinkedMap<K, V> extends AbstractHashedMap<K, V>
   @Override
   public K lastKey() {
     if (size == 0) {
-      throw new NoSuchElementException("Map is empty");
+      throw new NoSuchElementException(Messages.get("error.external.linked_map_empty"));
     }
     return header.before.getKey();
   }
@@ -228,10 +229,12 @@ public abstract class AbstractLinkedMap<K, V> extends AbstractHashedMap<K, V>
    */
   protected LinkEntry<K, V> getEntry(final int index) {
     if (index < 0) {
-      throw new IndexOutOfBoundsException("Index " + index + " is less than zero");
+      throw new IndexOutOfBoundsException(
+          Messages.format("error.external.linked_map_index_negative", index));
     }
     if (index >= size) {
-      throw new IndexOutOfBoundsException("Index " + index + " is invalid for size " + size);
+      throw new IndexOutOfBoundsException(
+          Messages.format("error.external.linked_map_index_invalid", index, size));
     }
     LinkEntry<K, V> entry;
     if (index < size / 2) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/collections4/map/LRUMap.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/collections4/map/LRUMap.java
@@ -17,6 +17,7 @@
 package org.apache.tsfile.external.commons.collections4.map;
 
 import org.apache.tsfile.external.commons.collections4.BoundedMap;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -174,10 +175,10 @@ public class LRUMap<K, V> extends AbstractLinkedMap<K, V>
 
     super(initialSize, loadFactor);
     if (maxSize < 1) {
-      throw new IllegalArgumentException("LRUMap max size must be greater than 0");
+      throw new IllegalArgumentException(Messages.get("error.external.lrumap_max_size_positive"));
     }
     if (initialSize > maxSize) {
-      throw new IllegalArgumentException("LRUMap initial size must not be greather than max size");
+      throw new IllegalArgumentException(Messages.get("error.external.lrumap_initial_exceeds_max"));
     }
     this.maxSize = maxSize;
     this.scanUntilRemovable = scanUntilRemovable;
@@ -263,9 +264,7 @@ public class LRUMap<K, V> extends AbstractLinkedMap<K, V>
       modCount++;
       // remove
       if (entry.before == null) {
-        throw new IllegalStateException(
-            "Entry.before is null."
-                + " This should not occur if your keys are immutable, and you have used synchronization properly.");
+        throw new IllegalStateException(Messages.get("error.external.lrumap_entry_before_null"));
       }
       entry.before.after = entry.after;
       entry.after.before = entry.before;
@@ -275,9 +274,7 @@ public class LRUMap<K, V> extends AbstractLinkedMap<K, V>
       header.before.after = entry;
       header.before = entry;
     } else if (entry == header) {
-      throw new IllegalStateException(
-          "Can't move header to MRU"
-              + " This should not occur if your keys are immutable, and you have used synchronization properly.");
+      throw new IllegalStateException(Messages.get("error.external.lrumap_cannot_move_header"));
     }
   }
 
@@ -326,19 +323,14 @@ public class LRUMap<K, V> extends AbstractLinkedMap<K, V>
         }
         if (reuse == null) {
           throw new IllegalStateException(
-              "Entry.after=null, header.after="
-                  + header.after
-                  + " header.before="
-                  + header.before
-                  + " key="
-                  + key
-                  + " value="
-                  + value
-                  + " size="
-                  + size
-                  + " maxSize="
-                  + maxSize
-                  + " This should not occur if your keys are immutable, and you have used synchronization properly.");
+              Messages.format(
+                  "error.external.lrumap_entry_after_null",
+                  header.after,
+                  header.before,
+                  key,
+                  value,
+                  size,
+                  maxSize));
         }
       } else {
         removeLRUEntry = removeLRU(reuse);
@@ -347,19 +339,14 @@ public class LRUMap<K, V> extends AbstractLinkedMap<K, V>
       if (removeLRUEntry) {
         if (reuse == null) {
           throw new IllegalStateException(
-              "reuse=null, header.after="
-                  + header.after
-                  + " header.before="
-                  + header.before
-                  + " key="
-                  + key
-                  + " value="
-                  + value
-                  + " size="
-                  + size
-                  + " maxSize="
-                  + maxSize
-                  + " This should not occur if your keys are immutable, and you have used synchronization properly.");
+              Messages.format(
+                  "error.external.lrumap_reuse_null",
+                  header.after,
+                  header.before,
+                  key,
+                  value,
+                  size,
+                  maxSize));
         }
         reuseMapping(reuse, hashIndex, hashCode, key, value);
       } else {
@@ -401,19 +388,14 @@ public class LRUMap<K, V> extends AbstractLinkedMap<K, V>
       }
       if (loop == null) {
         throw new IllegalStateException(
-            "Entry.next=null, data[removeIndex]="
-                + data[removeIndex]
-                + " previous="
-                + previous
-                + " key="
-                + key
-                + " value="
-                + value
-                + " size="
-                + size
-                + " maxSize="
-                + maxSize
-                + " This should not occur if your keys are immutable, and you have used synchronization properly.");
+            Messages.format(
+                "error.external.lrumap_loop_null",
+                data[removeIndex],
+                previous,
+                key,
+                value,
+                size,
+                maxSize));
       }
 
       // reuse the entry
@@ -423,19 +405,8 @@ public class LRUMap<K, V> extends AbstractLinkedMap<K, V>
       addEntry(entry, hashIndex);
     } catch (final NullPointerException ex) {
       throw new IllegalStateException(
-          "NPE, entry="
-              + entry
-              + " entryIsHeader="
-              + (entry == header)
-              + " key="
-              + key
-              + " value="
-              + value
-              + " size="
-              + size
-              + " maxSize="
-              + maxSize
-              + " This should not occur if your keys are immutable, and you have used synchronization properly.");
+          Messages.format(
+              "error.external.lrumap_npe", entry, (entry == header), key, value, size, maxSize));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/FileUtils.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/FileUtils.java
@@ -22,6 +22,7 @@ import org.apache.tsfile.external.commons.io.filefilter.IOFileFilter;
 import org.apache.tsfile.external.commons.io.filefilter.SuffixFileFilter;
 import org.apache.tsfile.external.commons.io.function.IOConsumer;
 import org.apache.tsfile.external.commons.io.function.Uncheck;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -77,9 +78,10 @@ public class FileUtils {
     if (!directory.isDirectory()) {
       if (directory.exists()) {
         throw new IllegalArgumentException(
-            "Parameter '" + name + "' is not a directory: '" + directory + "'");
+            Messages.format("error.external.file_not_a_directory", name, directory));
       }
-      throw new FileNotFoundException("Directory '" + directory + "' does not exist.");
+      throw new FileNotFoundException(
+          Messages.format("error.external.file_directory_not_exist", directory));
     }
   }
 
@@ -90,7 +92,7 @@ public class FileUtils {
         fileFilter == null ? directory.listFiles() : directory.listFiles(fileFilter);
     if (files == null) {
       // null if the directory does not denote a directory, or if an I/O error occurs.
-      throw new IOException("Unknown I/O error listing contents of directory: " + directory);
+      throw new IOException(Messages.format("error.external.file_list_io_error", directory));
     }
     return files;
   }
@@ -140,12 +142,12 @@ public class FileUtils {
               PathUtils.EMPTY_LINK_OPTION_ARRAY,
               StandardDeleteOption.OVERRIDE_READ_ONLY);
     } catch (final IOException ex) {
-      throw new IOException("Cannot delete file: " + file, ex);
+      throw new IOException(Messages.format("error.external.file_cannot_delete", file), ex);
     }
     if (deleteCounters.getFileCounter().get() < 1
         && deleteCounters.getDirectoryCounter().get() < 1) {
       // didn't find a file to delete.
-      throw new FileNotFoundException("File does not exist: " + file);
+      throw new FileNotFoundException(Messages.format("error.external.file_not_exist", file));
     }
   }
 
@@ -165,7 +167,7 @@ public class FileUtils {
       if (!srcFile.delete()) {
         deleteQuietly(destFile);
         throw new IOException(
-            "Failed to delete original file '" + srcFile + "' after copy to '" + destFile + "'");
+            Messages.format("error.external.file_move_delete_original", srcFile, destFile));
       }
     }
   }
@@ -175,10 +177,12 @@ public class FileUtils {
     Objects.requireNonNull(file, name);
     if (!file.isFile()) {
       if (file.exists()) {
-        throw new IllegalArgumentException("Parameter '" + name + "' is not a file: " + file);
+        throw new IllegalArgumentException(
+            Messages.format("error.external.file_param_not_a_file", name, file));
       }
       if (!Files.isSymbolicLink(file.toPath())) {
-        throw new FileNotFoundException("Source '" + file + "' does not exist");
+        throw new FileNotFoundException(
+            Messages.format("error.external.file_source_not_exist", file));
       }
     }
   }
@@ -195,7 +199,8 @@ public class FileUtils {
   private static File requireFile(final File file, final String name) {
     Objects.requireNonNull(file, name);
     if (!file.isFile()) {
-      throw new IllegalArgumentException("Parameter '" + name + "' is not a file: " + file);
+      throw new IllegalArgumentException(
+          Messages.format("error.external.file_param_not_a_file", name, file));
     }
     return file;
   }
@@ -203,7 +208,7 @@ public class FileUtils {
   private static void requireAbsent(final File file, final String name) throws FileExistsException {
     if (file.exists()) {
       throw new FileExistsException(
-          String.format("File element in parameter '%s' already exists: '%s'", name, file));
+          Messages.format("error.external.file_already_exists", name, file));
     }
   }
 
@@ -236,7 +241,7 @@ public class FileUtils {
 
     // On Windows, the last modified time is copied by default.
     if (preserveFileDate && !Files.isSymbolicLink(srcPath) && !setTimes(srcFile, destFile)) {
-      throw new IOException("Cannot set the file time.");
+      throw new IOException(Messages.get("error.external.file_cannot_set_time"));
     }
   }
 
@@ -245,9 +250,8 @@ public class FileUtils {
     final String canonicalPath = file1.getCanonicalPath();
     if (canonicalPath.equals(file2.getCanonicalPath())) {
       throw new IllegalArgumentException(
-          String.format(
-              "File canonical paths are equal: '%s' (file1='%s', file2='%s')",
-              canonicalPath, file1, file2));
+          Messages.format(
+              "error.external.file_canonical_paths_equal", canonicalPath, file1, file2));
     }
   }
 
@@ -257,7 +261,8 @@ public class FileUtils {
 
   private static File mkdirs(final File directory) throws IOException {
     if (directory != null && !directory.mkdirs() && !directory.isDirectory()) {
-      throw new IOException("Cannot create directory '" + directory + "'.");
+      throw new IOException(
+          Messages.format("error.external.file_cannot_create_directory", directory));
     }
     return directory;
   }
@@ -460,7 +465,8 @@ public class FileUtils {
     Objects.requireNonNull(source, "source");
     Objects.requireNonNull(destination, "destination");
     if (!source.exists()) {
-      throw new FileNotFoundException("Source '" + source + "' does not exist");
+      throw new FileNotFoundException(
+          Messages.format("error.external.file_source_not_exist", source));
     }
   }
 
@@ -480,11 +486,7 @@ public class FileUtils {
     Objects.requireNonNull(file, fileParamName);
     if (!file.exists()) {
       throw new FileNotFoundException(
-          "File system element for parameter '"
-              + fileParamName
-              + "' does not exist: '"
-              + file
-              + "'");
+          Messages.format("error.external.file_element_not_exist", fileParamName, file));
     }
     return file;
   }
@@ -504,7 +506,7 @@ public class FileUtils {
     Objects.requireNonNull(directory, name);
     if (!directory.isDirectory()) {
       throw new IllegalArgumentException(
-          "Parameter '" + name + "' is not a directory: '" + directory + "'");
+          Messages.format("error.external.file_not_a_directory", name, directory));
     }
     return directory;
   }
@@ -602,13 +604,13 @@ public class FileUtils {
     if (!srcDir.renameTo(destDir)) {
       if (destDir.getCanonicalPath().startsWith(srcDir.getCanonicalPath() + File.separator)) {
         throw new IOException(
-            "Cannot move directory: " + srcDir + " to a subdirectory of itself: " + destDir);
+            Messages.format("error.external.file_move_to_subdirectory", srcDir, destDir));
       }
       copyDirectory(srcDir, destDir);
       deleteDirectory(srcDir);
       if (srcDir.exists()) {
         throw new IOException(
-            "Failed to delete original directory '" + srcDir + "' after copy to '" + destDir + "'");
+            Messages.format("error.external.file_move_delete_directory", srcDir, destDir));
       }
     }
   }
@@ -869,7 +871,7 @@ public class FileUtils {
     Objects.requireNonNull(file, "file");
     if (!file.canWrite()) {
       throw new IllegalArgumentException(
-          "File parameter '" + name + " is not writable: '" + file + "'");
+          Messages.format("error.external.file_not_writable", name, file));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/FilenameUtils.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/FilenameUtils.java
@@ -17,6 +17,8 @@
 
 package org.apache.tsfile.external.commons.io;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.io.File;
 
 public class FilenameUtils {
@@ -113,8 +115,7 @@ public class FilenameUtils {
    */
   private static String requireNonNullChars(final String path) {
     if (path.indexOf(0) >= 0) {
-      throw new IllegalArgumentException(
-          "Null character present in file/path name. There are no known legitimate use cases for such data, but several injection attacks may use it");
+      throw new IllegalArgumentException(Messages.get("error.external.filename_null_char"));
     }
     return path;
   }
@@ -213,7 +214,8 @@ public class FilenameUtils {
       // Special handling for NTFS ADS: Don't accept colon in the fileName.
       final int offset = fileName.indexOf(':', getAdsCriticalOffset(fileName));
       if (offset != -1) {
-        throw new IllegalArgumentException("NTFS ADS separator (':') in file name is forbidden.");
+        throw new IllegalArgumentException(
+            Messages.get("error.external.filename_ntfs_ads_forbidden"));
       }
     }
     final int extensionPos = fileName.lastIndexOf(EXTENSION_SEPARATOR);

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/IOUtils.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/IOUtils.java
@@ -25,6 +25,7 @@ import org.apache.tsfile.external.commons.io.output.ByteArrayOutputStream;
 import org.apache.tsfile.external.commons.io.output.StringBuilderWriter;
 import org.apache.tsfile.external.commons.io.output.ThresholdingOutputStream;
 import org.apache.tsfile.external.commons.io.output.UnsynchronizedByteArrayOutputStream;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
@@ -165,8 +166,8 @@ public class IOUtils {
                 Integer.MAX_VALUE,
                 os -> {
                   throw new IllegalArgumentException(
-                      String.format(
-                          "Cannot read more than %,d into a byte array", Integer.MAX_VALUE));
+                      Messages.format(
+                          "error.external.io_cannot_read_max_bytes", Integer.MAX_VALUE));
                 },
                 os -> ubaOutput)) {
       copy(inputStream, thresholdOutput);
@@ -416,7 +417,8 @@ public class IOUtils {
       throws IOException {
 
     if (size < 0) {
-      throw new IllegalArgumentException("Size must be equal or greater than zero: " + size);
+      throw new IllegalArgumentException(
+          Messages.format("error.external.io_size_non_negative", size));
     }
 
     if (size == 0) {
@@ -432,7 +434,8 @@ public class IOUtils {
     }
 
     if (offset != size) {
-      throw new IOException("Unexpected read size, current: " + offset + ", expected: " + size);
+      throw new IOException(
+          Messages.format("error.external.io_unexpected_read_size", offset, size));
     }
 
     return data;
@@ -482,7 +485,7 @@ public class IOUtils {
         input,
         charset,
         () -> {
-          throw new NullPointerException("input");
+          throw new NullPointerException(Messages.get("error.external.io_null_input"));
         });
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/build/AbstractOrigin.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/build/AbstractOrigin.java
@@ -20,6 +20,7 @@ package org.apache.tsfile.external.commons.io.build;
 import org.apache.tsfile.external.commons.io.IOUtils;
 import org.apache.tsfile.external.commons.io.input.ReaderInputStream;
 import org.apache.tsfile.external.commons.io.output.WriterOutputStream;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -400,9 +401,11 @@ public abstract class AbstractOrigin<T, B extends AbstractOrigin<T, B>>
    */
   public File getFile() {
     throw new UnsupportedOperationException(
-        String.format(
-            "%s#getFile() for %s origin %s",
-            getClass().getSimpleName(), origin.getClass().getSimpleName(), origin));
+        Messages.format(
+            "error.external.abstract_origin_get_file",
+            getClass().getSimpleName(),
+            origin.getClass().getSimpleName(),
+            origin));
   }
 
   /**
@@ -437,9 +440,11 @@ public abstract class AbstractOrigin<T, B extends AbstractOrigin<T, B>>
    */
   public Path getPath() {
     throw new UnsupportedOperationException(
-        String.format(
-            "%s#getPath() for %s origin %s",
-            getClass().getSimpleName(), origin.getClass().getSimpleName(), origin));
+        Messages.format(
+            "error.external.abstract_origin_get_path",
+            getClass().getSimpleName(),
+            origin.getClass().getSimpleName(),
+            origin));
   }
 
   /**

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/build/AbstractOriginSupplier.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/build/AbstractOriginSupplier.java
@@ -26,6 +26,7 @@ import org.apache.tsfile.external.commons.io.build.AbstractOrigin.PathOrigin;
 import org.apache.tsfile.external.commons.io.build.AbstractOrigin.ReaderOrigin;
 import org.apache.tsfile.external.commons.io.build.AbstractOrigin.URIOrigin;
 import org.apache.tsfile.external.commons.io.build.AbstractOrigin.WriterOrigin;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.File;
 import java.io.InputStream;
@@ -168,7 +169,7 @@ public abstract class AbstractOriginSupplier<T, B extends AbstractOriginSupplier
    */
   protected AbstractOrigin<?, ?> checkOrigin() {
     if (origin == null) {
-      throw new IllegalStateException("origin == null");
+      throw new IllegalStateException(Messages.get("error.external.origin_null"));
     }
     return origin;
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/build/AbstractStreamBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/build/AbstractStreamBuilder.java
@@ -20,6 +20,7 @@ package org.apache.tsfile.external.commons.io.build;
 import org.apache.tsfile.external.commons.io.Charsets;
 import org.apache.tsfile.external.commons.io.IOUtils;
 import org.apache.tsfile.external.commons.io.file.PathUtils;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -172,6 +173,7 @@ public abstract class AbstractStreamBuilder<T, B extends AbstractStreamBuilder<T
   }
 
   private int throwIae(final int size, final int max) {
-    throw new IllegalArgumentException(String.format("Request %,d exceeds maximum %,d", size, max));
+    throw new IllegalArgumentException(
+        Messages.format("error.external.stream_builder_request_exceeds_max", size, max));
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/file/PathUtils.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/file/PathUtils.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.external.commons.io.file;
 
 import org.apache.tsfile.external.commons.io.function.IOFunction;
 import org.apache.tsfile.external.commons.io.function.IOSupplier;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -130,9 +131,8 @@ public class PathUtils {
     if (!isPosix(
         parent, linkOptions)) { // Test parent because we may not the permissions to test the file.
       throw new IOException(
-          String.format(
-              "DOS or POSIX file operations not available for '%s', linkOptions %s",
-              path, Arrays.toString(linkOptions)));
+          Messages.format(
+              "error.external.path_file_ops_not_available", path, Arrays.toString(linkOptions)));
     }
     // POSIX
     if (readOnly) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/input/ReaderInputStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/input/ReaderInputStream.java
@@ -21,6 +21,7 @@ import org.apache.tsfile.external.commons.io.IOUtils;
 import org.apache.tsfile.external.commons.io.build.AbstractOrigin;
 import org.apache.tsfile.external.commons.io.build.AbstractStreamBuilder;
 import org.apache.tsfile.external.commons.io.charset.CharsetEncoders;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -149,9 +150,11 @@ public class ReaderInputStream extends InputStream {
     final float minRequired = minBufferSize(charsetEncoder);
     if (bufferSize < minRequired) {
       throw new IllegalArgumentException(
-          String.format(
-              "Buffer size %,d must be at least %s for a CharsetEncoder %s.",
-              bufferSize, minRequired, charsetEncoder.charset().displayName()));
+          Messages.format(
+              "error.external.reader_input_stream_buffer_too_small",
+              bufferSize,
+              minRequired,
+              charsetEncoder.charset().displayName()));
     }
     return bufferSize;
   }
@@ -403,7 +406,8 @@ public class ReaderInputStream extends InputStream {
     Objects.requireNonNull(array, "array");
     if (len < 0 || off < 0 || off + len > array.length) {
       throw new IndexOutOfBoundsException(
-          "Array size=" + array.length + ", offset=" + off + ", length=" + len);
+          Messages.format(
+              "error.external.reader_input_stream_index_out_of_bounds", array.length, off, len));
     }
     int read = 0;
     if (len == 0) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/input/UnsynchronizedByteArrayInputStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/input/UnsynchronizedByteArrayInputStream.java
@@ -18,6 +18,7 @@ package org.apache.tsfile.external.commons.io.input;
 
 import org.apache.tsfile.external.commons.io.build.AbstractOrigin;
 import org.apache.tsfile.external.commons.io.build.AbstractStreamBuilder;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -103,7 +104,7 @@ public class UnsynchronizedByteArrayInputStream extends InputStream {
 
     public Builder setLength(final int length) {
       if (length < 0) {
-        throw new IllegalArgumentException("length cannot be negative");
+        throw new IllegalArgumentException(Messages.get("error.external.ubais_length_negative"));
       }
       this.length = length;
       return this;
@@ -111,7 +112,7 @@ public class UnsynchronizedByteArrayInputStream extends InputStream {
 
     public Builder setOffset(final int offset) {
       if (offset < 0) {
-        throw new IllegalArgumentException("offset cannot be negative");
+        throw new IllegalArgumentException(Messages.get("error.external.ubais_offset_negative"));
       }
       this.offset = offset;
       return this;
@@ -172,7 +173,7 @@ public class UnsynchronizedByteArrayInputStream extends InputStream {
   public UnsynchronizedByteArrayInputStream(final byte[] data, final int offset) {
     Objects.requireNonNull(data, "data");
     if (offset < 0) {
-      throw new IllegalArgumentException("offset cannot be negative");
+      throw new IllegalArgumentException(Messages.get("error.external.ubais_offset_negative"));
     }
     this.data = data;
     this.offset = min(offset, data.length > 0 ? data.length : offset);
@@ -192,10 +193,10 @@ public class UnsynchronizedByteArrayInputStream extends InputStream {
   @Deprecated
   public UnsynchronizedByteArrayInputStream(final byte[] data, final int offset, final int length) {
     if (offset < 0) {
-      throw new IllegalArgumentException("offset cannot be negative");
+      throw new IllegalArgumentException(Messages.get("error.external.ubais_offset_negative"));
     }
     if (length < 0) {
-      throw new IllegalArgumentException("length cannot be negative");
+      throw new IllegalArgumentException(Messages.get("error.external.ubais_length_negative"));
     }
     this.data = Objects.requireNonNull(data, "data");
     this.offset = min(offset, data.length > 0 ? data.length : offset);
@@ -262,7 +263,7 @@ public class UnsynchronizedByteArrayInputStream extends InputStream {
   @Override
   public long skip(final long n) {
     if (n < 0) {
-      throw new IllegalArgumentException("Skipping backward is not supported");
+      throw new IllegalArgumentException(Messages.get("error.external.ubais_skip_backward"));
     }
 
     long actualSkip = eod - offset;

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/output/ByteArrayOutputStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/output/ByteArrayOutputStream.java
@@ -16,6 +16,8 @@
  */
 package org.apache.tsfile.external.commons.io.output;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -44,7 +46,8 @@ public class ByteArrayOutputStream extends AbstractByteArrayOutputStream {
    */
   public ByteArrayOutputStream(final int size) {
     if (size < 0) {
-      throw new IllegalArgumentException("Negative initial size: " + size);
+      throw new IllegalArgumentException(
+          Messages.format("error.external.ubaos_negative_initial_size", size));
     }
     synchronized (this) {
       needNewBuffer(size);

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/output/UnsynchronizedByteArrayOutputStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/output/UnsynchronizedByteArrayOutputStream.java
@@ -20,6 +20,7 @@ import org.apache.tsfile.external.commons.io.build.AbstractOrigin;
 import org.apache.tsfile.external.commons.io.build.AbstractStreamBuilder;
 import org.apache.tsfile.external.commons.io.function.Uncheck;
 import org.apache.tsfile.external.commons.io.input.UnsynchronizedByteArrayInputStream;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -106,7 +107,8 @@ public final class UnsynchronizedByteArrayOutputStream extends AbstractByteArray
   @Deprecated
   public UnsynchronizedByteArrayOutputStream(final int size) {
     if (size < 0) {
-      throw new IllegalArgumentException("Negative initial size: " + size);
+      throw new IllegalArgumentException(
+          Messages.format("error.external.ubaos_negative_initial_size", size));
     }
     needNewBuffer(size);
   }
@@ -147,7 +149,8 @@ public final class UnsynchronizedByteArrayOutputStream extends AbstractByteArray
   @Override
   public void write(final byte[] b, final int off, final int len) {
     if (off < 0 || off > b.length || len < 0 || off + len > b.length || off + len < 0) {
-      throw new IndexOutOfBoundsException(String.format("offset=%,d, length=%,d", off, len));
+      throw new IndexOutOfBoundsException(
+          Messages.format("error.external.ubaos_offset_length_out_of_bounds", off, len));
     }
     if (len == 0) {
       return;

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/output/WriterOutputStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/io/output/WriterOutputStream.java
@@ -20,6 +20,7 @@ import org.apache.tsfile.external.commons.io.Charsets;
 import org.apache.tsfile.external.commons.io.IOUtils;
 import org.apache.tsfile.external.commons.io.build.AbstractStreamBuilder;
 import org.apache.tsfile.external.commons.io.charset.CharsetDecoders;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -206,16 +207,14 @@ public class WriterOutputStream extends OutputStream {
         charsetDecoder2.decode(bb2, cb2, i == len - 1);
       } catch (final IllegalArgumentException e) {
         throw new UnsupportedOperationException(
-            "UTF-16 requested when running on an IBM JDK with broken UTF-16 support. "
-                + "Please find a JDK that supports UTF-16 if you intend to use UF-16 with WriterOutputStream");
+            Messages.get("error.external.writer_output_stream_utf16_ibm"));
       }
       bb2.compact();
     }
     cb2.rewind();
     if (!TEST_STRING_2.equals(cb2.toString())) {
       throw new UnsupportedOperationException(
-          "UTF-16 requested when running on an IBM JDK with broken UTF-16 support. "
-              + "Please find a JDK that supports UTF-16 if you intend to use UF-16 with WriterOutputStream");
+          Messages.get("error.external.writer_output_stream_utf16_ibm"));
     }
   }
 
@@ -426,7 +425,7 @@ public class WriterOutputStream extends OutputStream {
       } else {
         // The decoder is configured to replace malformed input and unmappable characters,
         // so we should not get here.
-        throw new IOException("Unexpected coder result");
+        throw new IOException(Messages.get("error.external.writer_output_stream_unexpected_coder"));
       }
     }
     // Discard the bytes that have been read

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/lang3/ArrayUtils.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/lang3/ArrayUtils.java
@@ -19,6 +19,8 @@
 
 package org.apache.tsfile.external.commons.lang3;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.lang.reflect.Array;
 import java.util.function.Supplier;
 
@@ -122,7 +124,8 @@ public class ArrayUtils {
   private static Object remove(final Object array, final int index) {
     final int length = getLength(array);
     if (index < 0 || index >= length) {
-      throw new IndexOutOfBoundsException("Index: " + index + ", Length: " + length);
+      throw new IndexOutOfBoundsException(
+          Messages.format("error.external.array_index_out_of_bounds", index, length));
     }
     final Object result = Array.newInstance(array.getClass().getComponentType(), length - 1);
     System.arraycopy(array, 0, result, 0, index);
@@ -266,7 +269,9 @@ public class ArrayUtils {
       final Class<?> type2 = array2.getClass().getComponentType();
       if (!type1.isAssignableFrom(type2)) {
         throw new IllegalArgumentException(
-            "Cannot store " + type2.getName() + " in an array of " + type1.getName(), ase);
+            Messages.format(
+                "error.external.array_incompatible_types", type2.getName(), type1.getName()),
+            ase);
       }
       throw ase; // No, so rethrow original
     }

--- a/java/tsfile/src/main/java/org/apache/tsfile/external/commons/lang3/Validate.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/external/commons/lang3/Validate.java
@@ -19,16 +19,17 @@
 
 package org.apache.tsfile.external.commons.lang3;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.util.Objects;
 import java.util.function.Supplier;
 
 public class Validate {
-  private static final String DEFAULT_IS_TRUE_EX_MESSAGE = "The validated expression is false";
   private static final String DEFAULT_IS_NULL_EX_MESSAGE = "The validated object is null";
 
   public static void isTrue(final boolean expression) {
     if (!expression) {
-      throw new IllegalArgumentException(DEFAULT_IS_TRUE_EX_MESSAGE);
+      throw new IllegalArgumentException(Messages.get("error.external.validate_expression_false"));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/MetaMarker.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/MetaMarker.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.file;
 
 import org.apache.tsfile.common.constant.TsFileConstant;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.IOException;
 
@@ -69,6 +70,6 @@ public class MetaMarker {
   private MetaMarker() {}
 
   public static void handleUnexpectedMarker(byte marker) throws IOException {
-    throw new IOException("Unexpected marker " + marker);
+    throw new IOException(Messages.format("error.file.unexpected_marker", marker));
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/AbstractAlignedChunkMetadata.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/AbstractAlignedChunkMetadata.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.file.metadata;
 
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.file.metadata.statistics.Statistics;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.TimeRange;
 import org.apache.tsfile.read.controller.IChunkLoader;
 
@@ -175,13 +176,13 @@ public abstract class AbstractAlignedChunkMetadata implements IChunkMetadata {
   @Override
   public TSDataType getNewType() {
     throw new UnsupportedOperationException(
-        "AlignedChunkMetadata doesn't support setNewType method");
+        Messages.get("error.file.aligned_chunk_metadata_new_type_unsupported"));
   }
 
   @Override
   public void setNewType(TSDataType type) {
     throw new UnsupportedOperationException(
-        "AlignedChunkMetadata doesn't support setNewType method");
+        Messages.get("error.file.aligned_chunk_metadata_new_type_unsupported"));
   }
 
   @Override
@@ -206,7 +207,8 @@ public abstract class AbstractAlignedChunkMetadata implements IChunkMetadata {
 
   @Override
   public int serializeTo(OutputStream outputStream, boolean serializeStatistic) {
-    throw new UnsupportedOperationException("VectorChunkMetadata doesn't support serial method");
+    throw new UnsupportedOperationException(
+        Messages.get("error.file.aligned_chunk_metadata_serialize_unsupported"));
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/ColumnSchemaBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/ColumnSchemaBuilder.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.file.metadata;
 import org.apache.tsfile.annotations.TsFileApi;
 import org.apache.tsfile.enums.ColumnCategory;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 
 public class ColumnSchemaBuilder {
 
@@ -38,7 +39,8 @@ public class ColumnSchemaBuilder {
   @TsFileApi
   public ColumnSchemaBuilder name(String columnName) {
     if (columnName == null || columnName.isEmpty()) {
-      throw new IllegalArgumentException("Column name must be a non empty string");
+      throw new IllegalArgumentException(
+          Messages.get("error.file.column_schema_builder_name_empty"));
     }
     this.columnName = columnName;
     return this;
@@ -73,10 +75,12 @@ public class ColumnSchemaBuilder {
 
   private void validateParameters() {
     if (columnName == null) {
-      throw new IllegalStateException("Column name must be set before building");
+      throw new IllegalStateException(
+          Messages.get("error.file.column_schema_builder_name_not_set"));
     }
     if (columnDataType == null) {
-      throw new IllegalStateException("Column data type must be set before building");
+      throw new IllegalStateException(
+          Messages.get("error.file.column_schema_builder_type_not_set"));
     }
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/IDeviceID.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/IDeviceID.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.file.metadata;
 
 import org.apache.tsfile.common.constant.TsFileConstant;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Accountable;
 
 import org.slf4j.Logger;
@@ -69,13 +70,12 @@ public interface IDeviceID extends Comparable<IDeviceID>, Accountable, Serializa
   Object segment(int i);
 
   default int serializedSize() {
-    LOGGER.debug(
-        "Using default inefficient implementation of serialized size by {}", this.getClass());
+    LOGGER.debug(Messages.get("log.file.device_id_default_serialized_size"), this.getClass());
     try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
       serialize(baos);
       return baos.size();
     } catch (IOException e) {
-      LOGGER.error("Failed to serialize device ID: {}", this, e);
+      LOGGER.error(Messages.get("log.file.device_id_serialize_failed"), this, e);
       return -1;
     }
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/MetadataIndexConstructor.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/MetadataIndexConstructor.java
@@ -23,6 +23,7 @@ import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.file.IMetadataIndexEntry;
 import org.apache.tsfile.file.metadata.enums.MetadataIndexNodeType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.write.writer.TsFileOutput;
 
 import java.io.IOException;
@@ -38,7 +39,7 @@ public class MetadataIndexConstructor {
   private static final TSFileConfig config = TSFileDescriptor.getInstance().getConfig();
 
   private MetadataIndexConstructor() {
-    throw new IllegalStateException("Utility class");
+    throw new IllegalStateException(Messages.get("error.file.utility_class"));
   }
 
   /**

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/StringArrayDeviceID.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/StringArrayDeviceID.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.file.metadata;
 import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.exception.IllegalDeviceIDException;
 import org.apache.tsfile.exception.TsFileRuntimeException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.parser.PathNodesGenerator;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
@@ -102,7 +103,7 @@ public class StringArrayDeviceID implements IDeviceID {
       }
     }
     if (i < 0) {
-      throw new IllegalDeviceIDException("All segments are null");
+      throw new IllegalDeviceIDException(Messages.get("error.file.device_id_all_segments_null"));
     }
     if (i != segments.length - 1) {
       segments = Arrays.copyOf(segments, i + 1);

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/TableSchema.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/TableSchema.java
@@ -24,6 +24,7 @@ import org.apache.tsfile.common.constant.TsFileConstant;
 import org.apache.tsfile.compatibility.DeserializeConfig;
 import org.apache.tsfile.enums.ColumnCategory;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 import org.apache.tsfile.write.schema.IMeasurementSchema;
@@ -100,8 +101,7 @@ public class TableSchema {
       columnPosIndex.put(measurementName, i);
     }
     if (measurementSchemas.size() != columnPosIndex.size()) {
-      throw new IllegalArgumentException(
-          "Each column name in the table should be unique(case insensitive).");
+      throw new IllegalArgumentException(Messages.get("error.file.table_schema_duplicate_column"));
     }
     this.columnCategories = columnCategories;
     this.updatable = false;
@@ -116,8 +116,7 @@ public class TableSchema {
     this.measurementSchemas = columnSchemas;
     this.columnPosIndex = columnPosIndex;
     if (measurementSchemas.size() != columnPosIndex.size()) {
-      throw new IllegalArgumentException(
-          "Each column name in the table should be unique(case insensitive).");
+      throw new IllegalArgumentException(Messages.get("error.file.table_schema_duplicate_column"));
     }
     this.columnCategories = columnCategories;
     this.updatable = false;
@@ -137,8 +136,7 @@ public class TableSchema {
       columnPosIndex.put(columnName, i);
     }
     if (columnNameList.size() != columnPosIndex.size()) {
-      throw new IllegalArgumentException(
-          "Each column name in the table should be unique(case insensitive).");
+      throw new IllegalArgumentException(Messages.get("error.file.table_schema_duplicate_column"));
     }
     this.columnCategories = categoryList;
     this.updatable = false;
@@ -158,8 +156,7 @@ public class TableSchema {
       this.columnPosIndex.put(columnName, i);
     }
     if (columnSchemaList.size() != columnPosIndex.size()) {
-      throw new IllegalArgumentException(
-          "Each column name in the table should be unique(case insensitive).");
+      throw new IllegalArgumentException(Messages.get("error.file.table_schema_duplicate_column"));
     }
     this.updatable = false;
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/TsFileMetadata.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/TsFileMetadata.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.file.metadata;
 import org.apache.tsfile.compatibility.DeserializeConfig;
 import org.apache.tsfile.encrypt.EncryptUtils;
 import org.apache.tsfile.exception.encrypt.EncryptException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.BloomFilter;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
@@ -132,13 +133,16 @@ public class TsFileMetadata {
         propertiesMap.put("encryptKey", "");
       } else if (propertiesMap.get("encryptLevel").equals("1")) {
         if (!propertiesMap.containsKey("encryptType")) {
-          throw new EncryptException("TsfileMetadata lack of encryptType while encryptLevel is 1");
+          throw new EncryptException(
+              Messages.format("error.file.tsfile_metadata_no_encrypt_type", 1));
         }
         if (!propertiesMap.containsKey("encryptKey")) {
-          throw new EncryptException("TsfileMetadata lack of encryptKey while encryptLevel is 1");
+          throw new EncryptException(
+              Messages.format("error.file.tsfile_metadata_no_encrypt_key", 1));
         }
         if (propertiesMap.get("encryptKey") == null || propertiesMap.get("encryptKey").isEmpty()) {
-          throw new EncryptException("TsfileMetadata null encryptKey while encryptLevel is 1");
+          throw new EncryptException(
+              Messages.format("error.file.tsfile_metadata_null_encrypt_key", 1));
         }
         String str = propertiesMap.get("encryptKey");
         fileMetaData.encryptLevel = 1;
@@ -146,13 +150,16 @@ public class TsFileMetadata {
         fileMetaData.encryptType = propertiesMap.get("encryptType");
       } else if (propertiesMap.get("encryptLevel").equals("2")) {
         if (!propertiesMap.containsKey("encryptType")) {
-          throw new EncryptException("TsfileMetadata lack of encryptType while encryptLevel is 2");
+          throw new EncryptException(
+              Messages.format("error.file.tsfile_metadata_no_encrypt_type", 2));
         }
         if (!propertiesMap.containsKey("encryptKey")) {
-          throw new EncryptException("TsfileMetadata lack of encryptKey while encryptLevel is 2");
+          throw new EncryptException(
+              Messages.format("error.file.tsfile_metadata_no_encrypt_key", 2));
         }
         if (propertiesMap.get("encryptKey") == null || propertiesMap.get("encryptKey").isEmpty()) {
-          throw new EncryptException("TsfileMetadata null encryptKey while encryptLevel is 2");
+          throw new EncryptException(
+              Messages.format("error.file.tsfile_metadata_null_encrypt_key", 2));
         }
         fileMetaData.encryptLevel = 2;
         String str = propertiesMap.get("encryptKey");
@@ -160,7 +167,9 @@ public class TsFileMetadata {
         fileMetaData.encryptType = propertiesMap.get("encryptType");
       } else {
         throw new EncryptException(
-            "Unsupported encryptLevel: " + propertiesMap.get("encryptLevel"));
+            Messages.format(
+                "error.file.tsfile_metadata_unsupported_encrypt_level",
+                propertiesMap.get("encryptLevel")));
       }
       fileMetaData.tsFileProperties = propertiesMap;
     }

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/enums/CompressionType.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/enums/CompressionType.java
@@ -19,6 +19,8 @@
 
 package org.apache.tsfile.file.metadata.enums;
 
+import org.apache.tsfile.i18n.Messages;
+
 public enum CompressionType {
   /** Do not comprocess. */
   UNCOMPRESSED("", (byte) 0),
@@ -69,7 +71,8 @@ public enum CompressionType {
       case 9:
         return CompressionType.LZMA2;
       default:
-        throw new IllegalArgumentException("Invalid input: " + compressor);
+        throw new IllegalArgumentException(
+            Messages.format("error.common.invalid_input", compressor));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/enums/MetadataIndexNodeType.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/enums/MetadataIndexNodeType.java
@@ -19,6 +19,8 @@
 
 package org.apache.tsfile.file.metadata.enums;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -68,7 +70,7 @@ public enum MetadataIndexNodeType {
       case 3:
         return MetadataIndexNodeType.LEAF_MEASUREMENT;
       default:
-        throw new IllegalArgumentException("Invalid input: " + i);
+        throw new IllegalArgumentException(Messages.format("error.common.invalid_input", i));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/enums/TSEncoding.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/enums/TSEncoding.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.file.metadata.enums;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 
 import java.util.EnumMap;
 import java.util.HashSet;
@@ -145,7 +146,7 @@ public enum TSEncoding {
       case 14:
         return TSEncoding.CAMEL;
       default:
-        throw new IllegalArgumentException("Invalid input: " + encoding);
+        throw new IllegalArgumentException(Messages.format("error.common.invalid_input", encoding));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/BinaryStatistics.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/BinaryStatistics.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.file.metadata.statistics;
 import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.filter.StatisticsClassException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
@@ -94,13 +95,13 @@ public class BinaryStatistics extends Statistics<Binary> {
   @Override
   public Binary getMinValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.TEXT, "min"));
+        Messages.format("error.file.stats_unsupported", TSDataType.TEXT, "min"));
   }
 
   @Override
   public Binary getMaxValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.TEXT, "max"));
+        Messages.format("error.file.stats_unsupported", TSDataType.TEXT, "max"));
   }
 
   @Override
@@ -116,13 +117,13 @@ public class BinaryStatistics extends Statistics<Binary> {
   @Override
   public double getSumDoubleValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.TEXT, "double sum"));
+        Messages.format("error.file.stats_unsupported", TSDataType.TEXT, "double sum"));
   }
 
   @Override
   public long getSumLongValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.TEXT, "long sum"));
+        Messages.format("error.file.stats_unsupported", TSDataType.TEXT, "long sum"));
   }
 
   @SuppressWarnings("rawtypes")

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/BlobStatistics.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/BlobStatistics.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.file.metadata.statistics;
 
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.filter.StatisticsClassException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.RamUsageEstimator;
 
@@ -76,38 +77,38 @@ public class BlobStatistics extends Statistics<Binary> {
   @Override
   public Binary getMinValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.BLOB, "min"));
+        Messages.format("error.file.stats_unsupported", TSDataType.BLOB, "min"));
   }
 
   @Override
   public Binary getMaxValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.BLOB, "max"));
+        Messages.format("error.file.stats_unsupported", TSDataType.BLOB, "max"));
   }
 
   @Override
   public Binary getFirstValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.BLOB, "first"));
+        Messages.format("error.file.stats_unsupported", TSDataType.BLOB, "first"));
   }
 
   @Override
   public Binary getLastValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.BLOB, "last"));
+        Messages.format("error.file.stats_unsupported", TSDataType.BLOB, "last"));
   }
 
   @Override
   public double getSumDoubleValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.BLOB, "sum"));
+        Messages.format("error.file.stats_unsupported", TSDataType.BLOB, "sum"));
   }
 
   @Override
   public long getSumLongValue() {
 
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.BLOB, "sum"));
+        Messages.format("error.file.stats_unsupported", TSDataType.BLOB, "sum"));
   }
 
   @SuppressWarnings("rawtypes")

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/BooleanStatistics.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/BooleanStatistics.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.file.metadata.statistics;
 
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.filter.StatisticsClassException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
@@ -106,13 +107,13 @@ public class BooleanStatistics extends Statistics<Boolean> {
   @Override
   public Boolean getMinValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.BOOLEAN, "min"));
+        Messages.format("error.file.stats_unsupported", TSDataType.BOOLEAN, "min"));
   }
 
   @Override
   public Boolean getMaxValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.BOOLEAN, "max"));
+        Messages.format("error.file.stats_unsupported", TSDataType.BOOLEAN, "max"));
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/DoubleStatistics.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/DoubleStatistics.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.file.metadata.statistics;
 
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.filter.StatisticsClassException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
@@ -166,7 +167,7 @@ public class DoubleStatistics extends Statistics<Double> {
   @Override
   public long getSumLongValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.DOUBLE, "long sum"));
+        Messages.format("error.file.stats_unsupported", TSDataType.DOUBLE, "long sum"));
   }
 
   @SuppressWarnings("rawtypes")

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/FloatStatistics.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/FloatStatistics.java
@@ -20,6 +20,7 @@ package org.apache.tsfile.file.metadata.statistics;
 
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.filter.StatisticsClassException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
@@ -157,7 +158,7 @@ public class FloatStatistics extends Statistics<Float> {
   @Override
   public long getSumLongValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.FLOAT, "long sum"));
+        Messages.format("error.file.stats_unsupported", TSDataType.FLOAT, "long sum"));
   }
 
   @SuppressWarnings("rawtypes")

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/LongStatistics.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/LongStatistics.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.file.metadata.statistics;
 
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.filter.StatisticsClassException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
@@ -93,7 +94,7 @@ public class LongStatistics extends Statistics<Long> {
   @Override
   public long getSumLongValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.INT64, "long sum"));
+        Messages.format("error.file.stats_unsupported", TSDataType.INT64, "long sum"));
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/ObjectStatistics.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/ObjectStatistics.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.file.metadata.statistics;
 
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.filter.StatisticsClassException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.RamUsageEstimator;
 
@@ -76,38 +77,38 @@ public class ObjectStatistics extends Statistics<Binary> {
   @Override
   public Binary getMinValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.OBJECT, "min"));
+        Messages.format("error.file.stats_unsupported", TSDataType.OBJECT, "min"));
   }
 
   @Override
   public Binary getMaxValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.OBJECT, "max"));
+        Messages.format("error.file.stats_unsupported", TSDataType.OBJECT, "max"));
   }
 
   @Override
   public Binary getFirstValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.OBJECT, "first"));
+        Messages.format("error.file.stats_unsupported", TSDataType.OBJECT, "first"));
   }
 
   @Override
   public Binary getLastValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.OBJECT, "last"));
+        Messages.format("error.file.stats_unsupported", TSDataType.OBJECT, "last"));
   }
 
   @Override
   public double getSumDoubleValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.OBJECT, "sum"));
+        Messages.format("error.file.stats_unsupported", TSDataType.OBJECT, "sum"));
   }
 
   @Override
   public long getSumLongValue() {
 
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.OBJECT, "sum"));
+        Messages.format("error.file.stats_unsupported", TSDataType.OBJECT, "sum"));
   }
 
   @SuppressWarnings("rawtypes")

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/Statistics.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/Statistics.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.file.metadata.statistics;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.filter.StatisticsClassException;
 import org.apache.tsfile.exception.write.UnknownColumnTypeException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.filter.basic.Filter;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.Pair;
@@ -255,7 +256,7 @@ public abstract class Statistics<T extends Serializable> {
     } else {
       Class<?> thisClass = this.getClass();
       Class<?> statsClass = stats.getClass();
-      LOG.warn("Statistics classes mismatched,no merge: {} v.s. {}", thisClass, statsClass);
+      LOG.warn(Messages.get("log.file.stats_classes_mismatched"), thisClass, statsClass);
 
       throw new StatisticsClassException(thisClass, statsClass);
     }

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/StringStatistics.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/StringStatistics.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.file.metadata.statistics;
 import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.filter.StatisticsClassException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
@@ -134,13 +135,13 @@ public class StringStatistics extends Statistics<Binary> {
   @Override
   public double getSumDoubleValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.STRING, "double sum"));
+        Messages.format("error.file.stats_unsupported", TSDataType.STRING, "double sum"));
   }
 
   @Override
   public long getSumLongValue() {
     throw new StatisticsClassException(
-        String.format(STATS_UNSUPPORTED_MSG, TSDataType.STRING, "long sum"));
+        Messages.format("error.file.stats_unsupported", TSDataType.STRING, "long sum"));
   }
 
   @SuppressWarnings("rawtypes")

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/TimeStatistics.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/statistics/TimeStatistics.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.file.metadata.statistics;
 
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.filter.StatisticsClassException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.RamUsageEstimator;
 
 import java.io.IOException;
@@ -96,27 +97,32 @@ public class TimeStatistics extends Statistics<Long> {
 
   @Override
   public double getSumDoubleValue() {
-    throw new StatisticsClassException(String.format(STATS_UNSUPPORTED_MSG, TIME, "double sum"));
+    throw new StatisticsClassException(
+        Messages.format("error.file.stats_unsupported", TIME, "double sum"));
   }
 
   @Override
   public long getSumLongValue() {
-    throw new StatisticsClassException(String.format(STATS_UNSUPPORTED_MSG, TIME, "long sum"));
+    throw new StatisticsClassException(
+        Messages.format("error.file.stats_unsupported", TIME, "long sum"));
   }
 
   @Override
   void updateStats(long value) {
-    throw new StatisticsClassException(String.format(STATS_UNSUPPORTED_MSG, TIME, UPDATE_STATS));
+    throw new StatisticsClassException(
+        Messages.format("error.file.stats_unsupported", TIME, UPDATE_STATS));
   }
 
   @Override
   void updateStats(long[] values, int batchSize) {
-    throw new StatisticsClassException(String.format(STATS_UNSUPPORTED_MSG, TIME, UPDATE_STATS));
+    throw new StatisticsClassException(
+        Messages.format("error.file.stats_unsupported", TIME, UPDATE_STATS));
   }
 
   @Override
   public void updateStats(long minValue, long maxValue) {
-    throw new StatisticsClassException(String.format(STATS_UNSUPPORTED_MSG, TIME, UPDATE_STATS));
+    throw new StatisticsClassException(
+        Messages.format("error.file.stats_unsupported", TIME, UPDATE_STATS));
   }
 
   @SuppressWarnings("rawtypes")

--- a/java/tsfile/src/main/java/org/apache/tsfile/fileSystem/fileInputFactory/HDFSInputFactory.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/fileSystem/fileInputFactory/HDFSInputFactory.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.fileSystem.fileInputFactory;
 
 import org.apache.tsfile.common.conf.TSFileDescriptor;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.reader.TsFileInput;
 
 import org.slf4j.Logger;
@@ -40,9 +41,7 @@ public class HDFSInputFactory implements FileInputFactory {
           Class.forName(TSFileDescriptor.getInstance().getConfig().getHdfsTsFileInput());
       constructor = clazz.getConstructor(String.class);
     } catch (ClassNotFoundException | NoSuchMethodException e) {
-      logger.error(
-          "Failed to get HDFSInput in Hadoop file system. Please check your dependency of Hadoop module.",
-          e);
+      logger.error(Messages.get("log.fs.hdfs_input_factory_init_error"), e);
     }
   }
 
@@ -51,11 +50,7 @@ public class HDFSInputFactory implements FileInputFactory {
     try {
       return (TsFileInput) constructor.newInstance(filePath);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      throw new IOException(
-          String.format(
-              "Failed to get TsFile input of file: %s. Please check your dependency of Hadoop module.",
-              filePath),
-          e);
+      throw new IOException(Messages.format("error.fs.hdfs_input_factory_get_error", filePath), e);
     }
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/fileSystem/fileInputFactory/OSFileInputFactory.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/fileSystem/fileInputFactory/OSFileInputFactory.java
@@ -19,6 +19,7 @@
 package org.apache.tsfile.fileSystem.fileInputFactory;
 
 import org.apache.tsfile.common.conf.TSFileDescriptor;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.reader.TsFileInput;
 
 import org.slf4j.Logger;
@@ -38,9 +39,7 @@ public class OSFileInputFactory implements FileInputFactory {
           Class.forName(TSFileDescriptor.getInstance().getConfig().getObjectStorageTsFileInput());
       constructor = clazz.getConstructor(String.class);
     } catch (ClassNotFoundException | NoSuchMethodException e) {
-      logger.error(
-          "Failed to get OSInput in object storage. Please check your dependency of object storage module.",
-          e);
+      logger.error(Messages.get("log.fs.os_input_factory_init_error"), e);
     }
   }
 
@@ -49,11 +48,7 @@ public class OSFileInputFactory implements FileInputFactory {
     try {
       return (TsFileInput) constructor.newInstance(filePath);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      throw new IOException(
-          String.format(
-              "Failed to get TsFile input of file: %s. Please check your dependency of object storage module.",
-              filePath),
-          e);
+      throw new IOException(Messages.format("error.fs.os_input_factory_get_error", filePath), e);
     }
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/fileSystem/fileOutputFactory/HDFSOutputFactory.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/fileSystem/fileOutputFactory/HDFSOutputFactory.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.fileSystem.fileOutputFactory;
 
 import org.apache.tsfile.common.conf.TSFileDescriptor;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.write.writer.TsFileOutput;
 
 import org.slf4j.Logger;
@@ -39,9 +40,7 @@ public class HDFSOutputFactory implements FileOutputFactory {
           Class.forName(TSFileDescriptor.getInstance().getConfig().getHdfsTsFileOutput());
       constructor = clazz.getConstructor(String.class, boolean.class);
     } catch (ClassNotFoundException | NoSuchMethodException e) {
-      logger.error(
-          "Failed to get HDFSInput in Hadoop file system. Please check your dependency of Hadoop module.",
-          e);
+      logger.error(Messages.get("log.fs.hdfs_output_factory_init_error"), e);
     }
   }
 
@@ -50,10 +49,7 @@ public class HDFSOutputFactory implements FileOutputFactory {
     try {
       return (TsFileOutput) constructor.newInstance(filePath, !append);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to get TsFile output of file: {}. Please check your dependency of Hadoop module.",
-          filePath,
-          e);
+      logger.error(Messages.get("log.fs.hdfs_output_factory_get_error"), filePath, e);
       return null;
     }
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/fileSystem/fileOutputFactory/LocalFSOutputFactory.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/fileSystem/fileOutputFactory/LocalFSOutputFactory.java
@@ -19,6 +19,7 @@
 
 package org.apache.tsfile.fileSystem.fileOutputFactory;
 
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.write.writer.LocalTsFileOutput;
 import org.apache.tsfile.write.writer.TsFileOutput;
 
@@ -43,7 +44,7 @@ public class LocalFSOutputFactory implements FileOutputFactory {
       }
       return new LocalTsFileOutput(new FileOutputStream(file, append));
     } catch (IOException e) {
-      logger.error("Failed to get TsFile output of file: {}, ", filePath, e);
+      logger.error(Messages.get("log.fs.local_output_factory_get_error"), filePath, e);
       return null;
     }
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/fileSystem/fileOutputFactory/OSFileOutputFactory.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/fileSystem/fileOutputFactory/OSFileOutputFactory.java
@@ -19,6 +19,7 @@
 package org.apache.tsfile.fileSystem.fileOutputFactory;
 
 import org.apache.tsfile.common.conf.TSFileDescriptor;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.write.writer.TsFileOutput;
 
 import org.slf4j.Logger;
@@ -37,9 +38,7 @@ public class OSFileOutputFactory implements FileOutputFactory {
           Class.forName(TSFileDescriptor.getInstance().getConfig().getObjectStorageTsFileOutput());
       constructor = clazz.getConstructor(String.class, boolean.class);
     } catch (ClassNotFoundException | NoSuchMethodException e) {
-      logger.error(
-          "Failed to get OSInput in object storage. Please check your dependency of object storage module.",
-          e);
+      logger.error(Messages.get("log.fs.os_output_factory_init_error"), e);
     }
   }
 
@@ -48,10 +47,7 @@ public class OSFileOutputFactory implements FileOutputFactory {
     try {
       return (TsFileOutput) constructor.newInstance(filePath, !append);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to get TsFile output of file: {}. Please check your dependency of object storage module.",
-          filePath,
-          e);
+      logger.error(Messages.get("log.fs.os_output_factory_get_error"), filePath, e);
       return null;
     }
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/fileSystem/fsFactory/HDFSFactory.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/fileSystem/fsFactory/HDFSFactory.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.fileSystem.fsFactory;
 
 import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.fileSystem.FSType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.FSUtils;
 
 import org.slf4j.Logger;
@@ -73,8 +74,7 @@ public class HDFSFactory implements FSFactory {
       copyFromLocal = clazz.getMethod("copyFromLocal", File.class);
       copyTo = clazz.getMethod("copyTo", File.class);
     } catch (ClassNotFoundException | NoSuchMethodException e) {
-      logger.error(
-          "Failed to get Hadoop file system. Please check your dependency of Hadoop module.", e);
+      logger.error(Messages.get("log.fs.hdfs_factory_init_error"), e);
     }
   }
 
@@ -87,8 +87,7 @@ public class HDFSFactory implements FSFactory {
       }
       return res;
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to get file: {}. Please check your dependency of Hadoop module.", pathname, e);
+      logger.error(Messages.get("log.fs.hdfs_factory_get_file_with_parent_error"), pathname, e);
       return null;
     }
   }
@@ -98,8 +97,7 @@ public class HDFSFactory implements FSFactory {
     try {
       return (File) constructorWithPathname.newInstance(pathname);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to get file: {}. Please check your dependency of Hadoop module.", pathname, e);
+      logger.error(Messages.get("log.fs.hdfs_factory_get_file_error"), pathname, e);
       return null;
     }
   }
@@ -110,9 +108,7 @@ public class HDFSFactory implements FSFactory {
       return (File) constructorWithParentStringAndChild.newInstance(parent, child);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
       logger.error(
-          "Failed to get file: {}. Please check your dependency of Hadoop module.",
-          parent + File.separator + child,
-          e);
+          Messages.get("log.fs.hdfs_factory_get_file2_error"), parent + File.separator + child, e);
       return null;
     }
   }
@@ -123,7 +119,7 @@ public class HDFSFactory implements FSFactory {
       return (File) constructorWithParentFileAndChild.newInstance(parent, child);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
       logger.error(
-          "Failed to get file: {}. Please check your dependency of Hadoop module.",
+          Messages.get("log.fs.hdfs_factory_get_file3_error"),
           parent.getAbsolutePath() + File.separator + child,
           e);
       return null;
@@ -135,8 +131,7 @@ public class HDFSFactory implements FSFactory {
     try {
       return (File) constructorWithUri.newInstance(uri);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to get file: {}. Please check your dependency of Hadoop module.", uri, e);
+      logger.error(Messages.get("log.fs.hdfs_factory_get_file_uri_error"), uri, e);
       return null;
     }
   }
@@ -147,10 +142,7 @@ public class HDFSFactory implements FSFactory {
       return (BufferedReader)
           getBufferedReader.invoke(constructorWithPathname.newInstance(filePath), filePath);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to get buffered reader for {}. Please check your dependency of Hadoop module.",
-          filePath,
-          e);
+      logger.error(Messages.get("log.fs.hdfs_factory_get_reader_error"), filePath, e);
       return null;
     }
   }
@@ -161,10 +153,7 @@ public class HDFSFactory implements FSFactory {
       return (BufferedWriter)
           getBufferedWriter.invoke(constructorWithPathname.newInstance(filePath), filePath, append);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to get buffered writer for {}. Please check your dependency of Hadoop module.",
-          filePath,
-          e);
+      logger.error(Messages.get("log.fs.hdfs_factory_get_writer_error"), filePath, e);
       return null;
     }
   }
@@ -175,10 +164,7 @@ public class HDFSFactory implements FSFactory {
       return (BufferedInputStream)
           getBufferedInputStream.invoke(constructorWithPathname.newInstance(filePath), filePath);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to get buffered input stream for {}. Please check your dependency of Hadoop module.",
-          filePath,
-          e);
+      logger.error(Messages.get("log.fs.hdfs_factory_get_input_stream_error"), filePath, e);
       return null;
     }
   }
@@ -189,10 +175,7 @@ public class HDFSFactory implements FSFactory {
       return (BufferedOutputStream)
           getBufferedOutputStream.invoke(constructorWithPathname.newInstance(filePath), filePath);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to get buffered output stream for {}. Please check your dependency of Hadoop module.",
-          filePath,
-          e);
+      logger.error(Messages.get("log.fs.hdfs_factory_get_output_stream_error"), filePath, e);
       return null;
     }
   }
@@ -232,11 +215,7 @@ public class HDFSFactory implements FSFactory {
           listFilesBySuffix.invoke(
               constructorWithPathname.newInstance(fileFolder), fileFolder, suffix);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to list files in {} with SUFFIX {}. Please check your dependency of Hadoop module.",
-          fileFolder,
-          suffix,
-          e);
+      logger.error(Messages.get("log.fs.hdfs_factory_list_suffix_error"), fileFolder, suffix, e);
       return null;
     }
   }
@@ -248,11 +227,7 @@ public class HDFSFactory implements FSFactory {
           listFilesByPrefix.invoke(
               constructorWithPathname.newInstance(fileFolder), fileFolder, prefix);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to list files in {} with PREFIX {}. Please check your dependency of Hadoop module.",
-          fileFolder,
-          prefix,
-          e);
+      logger.error(Messages.get("log.fs.hdfs_factory_list_prefix_error"), fileFolder, prefix, e);
       return null;
     }
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/fileSystem/fsFactory/HybridFSFactory.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/fileSystem/fsFactory/HybridFSFactory.java
@@ -20,6 +20,7 @@ package org.apache.tsfile.fileSystem.fsFactory;
 
 import org.apache.tsfile.fileSystem.FSPath;
 import org.apache.tsfile.fileSystem.FSType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.FSUtils;
 
 import org.slf4j.Logger;
@@ -120,7 +121,7 @@ public class HybridFSFactory implements FSFactory {
       getFSFactory(destType).moveFile(srcFile, destFile);
     } else {
       throw new IOException(
-          String.format("Doesn't support move file from %s to %s.", srcType, destType));
+          Messages.format("error.fs.hybrid_factory_move_unsupported", srcType, destType));
     }
   }
 
@@ -135,7 +136,7 @@ public class HybridFSFactory implements FSFactory {
       getFSFactory(FSType.HDFS).copyFile(srcFile, destFile);
     } else {
       throw new IOException(
-          String.format("Doesn't support move file from %s to %s.", srcType, destType));
+          Messages.format("error.fs.hybrid_factory_copy_unsupported", srcType, destType));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/fileSystem/fsFactory/LocalFSFactory.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/fileSystem/fsFactory/LocalFSFactory.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.fileSystem.fsFactory;
 
 import org.apache.tsfile.external.commons.io.FileUtils;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.NoSyncBufferedInputStream;
 import org.apache.tsfile.utils.NoSyncBufferedOutputStream;
 
@@ -78,7 +79,7 @@ public class LocalFSFactory implements FSFactory {
     try {
       return new BufferedReader(new FileReader(filePath));
     } catch (IOException e) {
-      logger.error("Failed to get buffered reader for {}. ", filePath, e);
+      logger.error(Messages.get("log.fs.local_factory_get_reader_error"), filePath, e);
       return null;
     }
   }
@@ -88,7 +89,7 @@ public class LocalFSFactory implements FSFactory {
     try {
       return new BufferedWriter(new FileWriter(filePath, append));
     } catch (IOException e) {
-      logger.error("Failed to get buffered writer for {}. ", filePath, e);
+      logger.error(Messages.get("log.fs.local_factory_get_writer_error"), filePath, e);
       return null;
     }
   }
@@ -98,7 +99,7 @@ public class LocalFSFactory implements FSFactory {
     try {
       return new NoSyncBufferedInputStream(new FileInputStream(filePath));
     } catch (IOException e) {
-      logger.error("Failed to get buffered input stream for {}. ", filePath, e);
+      logger.error(Messages.get("log.fs.local_factory_get_input_stream_error"), filePath, e);
       return null;
     }
   }
@@ -108,7 +109,7 @@ public class LocalFSFactory implements FSFactory {
     try {
       return new NoSyncBufferedOutputStream(new FileOutputStream(filePath));
     } catch (IOException e) {
-      logger.error("Failed to get buffered output stream for {}. ", filePath, e);
+      logger.error(Messages.get("log.fs.local_factory_get_output_stream_error"), filePath, e);
       return null;
     }
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/fileSystem/fsFactory/OSFSFactory.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/fileSystem/fsFactory/OSFSFactory.java
@@ -20,6 +20,7 @@ package org.apache.tsfile.fileSystem.fsFactory;
 
 import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.fileSystem.FSType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.FSUtils;
 
 import org.slf4j.Logger;
@@ -73,9 +74,7 @@ public class OSFSFactory implements FSFactory {
       copyTo = clazz.getMethod("copyTo", File.class);
       deleteObjectsByPrefix = clazz.getMethod("deleteObjectsByPrefix");
     } catch (ClassNotFoundException | NoSuchMethodException e) {
-      logger.error(
-          "Failed to get object storage. Please check your dependency of object storage module.",
-          e);
+      logger.error(Messages.get("log.fs.os_factory_init_error"), e);
     }
   }
 
@@ -84,10 +83,7 @@ public class OSFSFactory implements FSFactory {
     try {
       return (File) constructorWithPathname.newInstance(pathname);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to get file: {}. Please check your dependency of object storage module.",
-          pathname,
-          e);
+      logger.error(Messages.get("log.fs.os_factory_get_file_with_parent_error"), pathname, e);
       return null;
     }
   }
@@ -97,8 +93,7 @@ public class OSFSFactory implements FSFactory {
     try {
       return (File) constructorWithPathname.newInstance(pathname);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to get file: {}. Please check your dependency of Hadoop module.", pathname, e);
+      logger.error(Messages.get("log.fs.os_factory_get_file_error"), pathname, e);
       return null;
     }
   }
@@ -109,9 +104,7 @@ public class OSFSFactory implements FSFactory {
       return (File) constructorWithParentStringAndChild.newInstance(parent, child);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
       logger.error(
-          "Failed to get file: {}. Please check your dependency of Hadoop module.",
-          parent + File.separator + child,
-          e);
+          Messages.get("log.fs.os_factory_get_file2_error"), parent + File.separator + child, e);
       return null;
     }
   }
@@ -122,7 +115,7 @@ public class OSFSFactory implements FSFactory {
       return (File) constructorWithParentFileAndChild.newInstance(parent, child);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
       logger.error(
-          "Failed to get file: {}. Please check your dependency of Hadoop module.",
+          Messages.get("log.fs.os_factory_get_file3_error"),
           parent.getAbsolutePath() + File.separator + child,
           e);
       return null;
@@ -134,8 +127,7 @@ public class OSFSFactory implements FSFactory {
     try {
       return (File) constructorWithUri.newInstance(uri);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to get file: {}. Please check your dependency of object storage module.", uri, e);
+      logger.error(Messages.get("log.fs.os_factory_get_file_uri_error"), uri, e);
       return null;
     }
   }
@@ -146,10 +138,7 @@ public class OSFSFactory implements FSFactory {
       return (BufferedReader)
           getBufferedReader.invoke(constructorWithPathname.newInstance(filePath));
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to get buffered reader for {}. Please check your dependency of object storage module.",
-          filePath,
-          e);
+      logger.error(Messages.get("log.fs.os_factory_get_reader_error"), filePath, e);
       return null;
     }
   }
@@ -160,10 +149,7 @@ public class OSFSFactory implements FSFactory {
       return (BufferedWriter)
           getBufferedWriter.invoke(constructorWithPathname.newInstance(filePath), append);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to get buffered writer for {}. Please check your dependency of object storage module.",
-          filePath,
-          e);
+      logger.error(Messages.get("log.fs.os_factory_get_writer_error"), filePath, e);
       return null;
     }
   }
@@ -174,10 +160,7 @@ public class OSFSFactory implements FSFactory {
       return (BufferedInputStream)
           getBufferedInputStream.invoke(constructorWithPathname.newInstance(filePath));
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to get buffered input stream for {}. Please check your dependency of object storage module.",
-          filePath,
-          e);
+      logger.error(Messages.get("log.fs.os_factory_get_input_stream_error"), filePath, e);
       return null;
     }
   }
@@ -188,10 +171,7 @@ public class OSFSFactory implements FSFactory {
       return (BufferedOutputStream)
           getBufferedOutputStream.invoke(constructorWithPathname.newInstance(filePath));
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to get buffered output stream for {}. Please check your dependency of object storage module.",
-          filePath,
-          e);
+      logger.error(Messages.get("log.fs.os_factory_get_output_stream_error"), filePath, e);
       return null;
     }
   }
@@ -215,8 +195,8 @@ public class OSFSFactory implements FSFactory {
         copyTo.invoke(srcFile, destFile);
       } else {
         throw new IOException(
-            String.format(
-                "Doesn't support copy file from %s to %s.", srcType, FSType.OBJECT_STORAGE));
+            Messages.format(
+                "error.fs.os_factory_copy_unsupported", srcType, FSType.OBJECT_STORAGE));
       }
     } catch (InvocationTargetException | IllegalAccessException e) {
       throw new IOException(e);
@@ -230,11 +210,7 @@ public class OSFSFactory implements FSFactory {
           listFilesBySuffix.invoke(
               constructorWithPathname.newInstance(fileFolder), fileFolder, suffix);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to list files in {} with SUFFIX {}. Please check your dependency of object storage module.",
-          fileFolder,
-          suffix,
-          e);
+      logger.error(Messages.get("log.fs.os_factory_list_suffix_error"), fileFolder, suffix, e);
       return null;
     }
   }
@@ -246,11 +222,7 @@ public class OSFSFactory implements FSFactory {
           listFilesByPrefix.invoke(
               constructorWithPathname.newInstance(fileFolder), fileFolder, prefix);
     } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-      logger.error(
-          "Failed to list files in {} with PREFIX {}. Please check your dependency of object storage module.",
-          fileFolder,
-          prefix,
-          e);
+      logger.error(Messages.get("log.fs.os_factory_list_prefix_error"), fileFolder, prefix, e);
       return null;
     }
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/LazyTsFileDeviceIterator.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/LazyTsFileDeviceIterator.java
@@ -25,6 +25,7 @@ import org.apache.tsfile.file.metadata.DeviceMetadataIndexEntry;
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.file.metadata.MetadataIndexNode;
 import org.apache.tsfile.file.metadata.enums.MetadataIndexNodeType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Pair;
 
 import org.slf4j.Logger;
@@ -139,14 +140,14 @@ public class LazyTsFileDeviceIterator {
 
   public IDeviceID getCurrentDeviceID() {
     if (currentDeviceAndMeasurementNodeOffsetPair == null) {
-      throw new IllegalStateException("next() must be called before accessing current device");
+      throw new IllegalStateException(Messages.get("error.read.device_iterator_no_current"));
     }
     return currentDeviceAndMeasurementNodeOffsetPair.getLeft();
   }
 
   public long[] getCurrentDeviceMeasurementNodeOffset() {
     if (currentDeviceAndMeasurementNodeOffsetPair == null) {
-      throw new IllegalStateException("next() must be called before accessing current device");
+      throw new IllegalStateException(Messages.get("error.read.device_iterator_no_current"));
     }
     return this.currentDeviceAndMeasurementNodeOffsetPair.getRight();
   }
@@ -157,7 +158,7 @@ public class LazyTsFileDeviceIterator {
 
   public MetadataIndexNode getFirstMeasurementNodeOfCurrentDevice() throws IOException {
     if (currentDeviceAndMeasurementNodeOffsetPair == null) {
-      throw new IllegalStateException("next() must be called before accessing current device");
+      throw new IllegalStateException(Messages.get("error.read.device_iterator_no_current"));
     }
     if (this.firstMeasurementNodeOfCurrentDevice != null) {
       return this.firstMeasurementNodeOfCurrentDevice;
@@ -212,7 +213,7 @@ public class LazyTsFileDeviceIterator {
   protected void getDevicesOfLeafNode(
       MetadataIndexNode deviceLeafNode, Queue<Pair<IDeviceID, long[]>> measurementNodeOffsetQueue) {
     if (!deviceLeafNode.getNodeType().equals(MetadataIndexNodeType.LEAF_DEVICE)) {
-      throw new IllegalStateException("the first param should be device leaf node.");
+      throw new IllegalStateException(Messages.get("error.read.device_leaf_node_required"));
     }
     List<IMetadataIndexEntry> childrenEntries = deviceLeafNode.getChildren();
     for (int i = 0; i < childrenEntries.size(); i++) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/TsFileDeviceIterator.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/TsFileDeviceIterator.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.read;
 import org.apache.tsfile.exception.TsFileRuntimeException;
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.file.metadata.MetadataIndexNode;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Pair;
 
 import java.io.IOException;
@@ -62,8 +63,7 @@ public class TsFileDeviceIterator implements Iterator<Pair<IDeviceID, Boolean>> 
       // get the first measurement node of this device, to know if the device is aligned
       return new Pair<>(deviceId, lazyTsFileDeviceIterator.isCurrentDeviceAligned());
     } catch (IOException e) {
-      throw new TsFileRuntimeException(
-          "Error occurred while reading a time series metadata block.");
+      throw new TsFileRuntimeException(Messages.get("error.read.metadata_block_read_error"));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/TsFileRestorableReader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/TsFileRestorableReader.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.read;
 import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.encrypt.EncryptParameter;
 import org.apache.tsfile.fileSystem.FSFactoryProducer;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.write.TsFileWriter;
 import org.apache.tsfile.write.writer.RestorableTsFileIOWriter;
 
@@ -81,7 +82,7 @@ public class TsFileRestorableReader extends TsFileSequenceReader {
     // Check if file is damaged
     if (!isComplete()) {
       // Try to close it
-      logger.info("File {} has no correct tail magic, try to repair...", file);
+      logger.info(Messages.get("log.read.file_repair"), file);
       try (RestorableTsFileIOWriter rWriter =
               new RestorableTsFileIOWriter(
                   FSFactoryProducer.getFSFactory().getFile(file), getFirstEncryptParam());

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/TsFileSequenceReader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/TsFileSequenceReader.java
@@ -62,6 +62,7 @@ import org.apache.tsfile.file.metadata.enums.MetadataIndexNodeType;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.tsfile.file.metadata.statistics.Statistics;
 import org.apache.tsfile.fileSystem.FSFactoryProducer;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.BatchData;
 import org.apache.tsfile.read.common.Chunk;
 import org.apache.tsfile.read.common.Path;
@@ -116,7 +117,7 @@ public class TsFileSequenceReader implements AutoCloseable {
   private static final Logger resourceLogger = LoggerFactory.getLogger("FileMonitor");
   protected static final TSFileConfig config = TSFileDescriptor.getInstance().getConfig();
   private static final String METADATA_INDEX_NODE_DESERIALIZE_ERROR =
-      "Something error happened while deserializing MetadataIndexNode of file {}";
+      Messages.get("log.read.sequence_reader_metadata_index_node_error");
   private static final int MAX_READ_BUFFER_SIZE = 4 * 1024 * 1024;
   protected String file;
   protected TsFileInput tsFileInput;
@@ -218,7 +219,7 @@ public class TsFileSequenceReader implements AutoCloseable {
             break;
 
           default:
-            throw new IOException("Unexpected marker " + marker);
+            throw new IOException(Messages.format("error.read.unexpected_marker", marker));
         }
       }
 
@@ -572,7 +573,7 @@ public class TsFileSequenceReader implements AutoCloseable {
     } catch (StopReadTsFileByInterruptException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Something error happened while reading file metadata of file {}", file, e);
+      logger.error(Messages.get("log.read.sequence_reader_file_metadata_error"), file, e);
       throw e;
     }
     return tsFileMetaData;
@@ -740,7 +741,8 @@ public class TsFileSequenceReader implements AutoCloseable {
       if (ignoreNotExistDevice) {
         return null;
       }
-      throw new IOException("Device {" + device + "} is not in tsFileMetaData of " + file);
+      throw new IOException(
+          Messages.format("error.read.device_not_in_metadata_file", device, file));
     }
     ByteBuffer buffer =
         readData(metadataIndexPair.left.getOffset(), metadataIndexPair.right, ioSizeConsumer);
@@ -769,8 +771,7 @@ public class TsFileSequenceReader implements AutoCloseable {
         try {
           timeseriesMetadataList.add(TimeseriesMetadata.deserializeFrom(buffer, true));
         } catch (Exception e) {
-          logger.error(
-              "Something error happened while deserializing TimeseriesMetadata of file {}", file);
+          logger.error(Messages.get("log.read.sequence_reader_tsm_deserialize_error"), file);
           throw e;
         }
       }
@@ -785,8 +786,7 @@ public class TsFileSequenceReader implements AutoCloseable {
         try {
           timeseriesMetadataList.add(TimeseriesMetadata.deserializeFrom(tsFileInput, true));
         } catch (Exception e1) {
-          logger.error(
-              "Something error happened while deserializing TimeseriesMetadata of file {}", file);
+          logger.error(Messages.get("log.read.sequence_reader_tsm_deserialize_error"), file);
           throw e1;
         }
       }
@@ -810,7 +810,7 @@ public class TsFileSequenceReader implements AutoCloseable {
         return null;
       }
       throw new IOException(
-          "Device {" + path.getDeviceString() + "} is not in tsFileMetaData of " + file);
+          Messages.format("error.read.device_not_in_metadata_file", path.getDeviceString(), file));
     }
     ByteBuffer buffer = readData(metadataIndexPair.left.getOffset(), metadataIndexPair.right);
     MetadataIndexNode metadataIndexNode;
@@ -838,8 +838,7 @@ public class TsFileSequenceReader implements AutoCloseable {
       try {
         timeseriesMetadataList.add(TimeseriesMetadata.deserializeFrom(buffer, true));
       } catch (Exception e) {
-        logger.error(
-            "Something error happened while deserializing TimeseriesMetadata of file {}", file);
+        logger.error(Messages.get("log.read.sequence_reader_tsm_deserialize_error"), file);
         throw e;
       }
     }
@@ -879,7 +878,8 @@ public class TsFileSequenceReader implements AutoCloseable {
       if (ignoreNotExistDevice) {
         return Collections.emptyList();
       }
-      throw new IOException("Device {" + device + "} is not in tsFileMetaData of " + file);
+      throw new IOException(
+          Messages.format("error.read.device_not_in_metadata_file", device, file));
     }
     List<TimeseriesMetadata> timeseriesMetadataList = new ArrayList<>();
 
@@ -891,8 +891,7 @@ public class TsFileSequenceReader implements AutoCloseable {
         try {
           timeseriesMetadata = TimeseriesMetadata.deserializeFrom(buffer, true);
         } catch (Exception e) {
-          logger.error(
-              "Something error happened while deserializing TimeseriesMetadata of file {}", file);
+          logger.error(Messages.get("log.read.sequence_reader_tsm_deserialize_error"), file);
           throw e;
         }
         if (allSensors.contains(timeseriesMetadata.getMeasurementId())) {
@@ -914,8 +913,7 @@ public class TsFileSequenceReader implements AutoCloseable {
           } catch (StopReadTsFileByInterruptException e) {
             throw e;
           } catch (Exception e1) {
-            logger.error(
-                "Something error happened while deserializing TimeseriesMetadata of file {}", file);
+            logger.error(Messages.get("log.read.sequence_reader_tsm_deserialize_error"), file);
             throw e1;
           }
           if (allSensors.contains(timeseriesMetadata.getMeasurementId())) {
@@ -1033,8 +1031,7 @@ public class TsFileSequenceReader implements AutoCloseable {
       try {
         timeseriesMetadataList.add(TimeseriesMetadata.deserializeFrom(buffer, true));
       } catch (Exception e) {
-        logger.error(
-            "Something error happened while deserializing TimeseriesMetadata of file {}", file);
+        logger.error(Messages.get("log.read.sequence_reader_tsm_deserialize_error"), file);
         throw e;
       }
     }
@@ -1317,8 +1314,7 @@ public class TsFileSequenceReader implements AutoCloseable {
           }
           return paths;
         } catch (IOException e) {
-          throw new TsFileRuntimeException(
-              "Error occurred while reading a time series metadata block.");
+          throw new TsFileRuntimeException(Messages.get("error.read.metadata_block_read_error"));
         }
       }
     };
@@ -1362,7 +1358,7 @@ public class TsFileSequenceReader implements AutoCloseable {
     } catch (StopReadTsFileByInterruptException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Something error happened while getting all paths of file {}", file);
+      logger.error(Messages.get("log.read.sequence_reader_paths_error"), file);
       throw e;
     }
   }
@@ -1625,7 +1621,7 @@ public class TsFileSequenceReader implements AutoCloseable {
     } catch (StopReadTsFileByInterruptException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Something error happened while generating MetadataIndex of file {}", file);
+      logger.error(Messages.get("log.read.sequence_reader_metadata_index_error"), file);
       throw e;
     }
   }
@@ -1703,7 +1699,7 @@ public class TsFileSequenceReader implements AutoCloseable {
     } catch (StopReadTsFileByInterruptException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Something error happened while generating MetadataIndex of file {}", file);
+      logger.error(Messages.get("log.read.sequence_reader_metadata_index_error"), file);
       throw e;
     }
   }
@@ -1843,7 +1839,7 @@ public class TsFileSequenceReader implements AutoCloseable {
     } catch (StopReadTsFileByInterruptException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Something error happened while deserializing MetadataIndex of file {}", file);
+      logger.error(Messages.get("log.read.sequence_reader_deserialize_metadata_error"), file);
       throw e;
     }
   }
@@ -1886,7 +1882,7 @@ public class TsFileSequenceReader implements AutoCloseable {
     } catch (StopReadTsFileByInterruptException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Something error happened while deserializing MetadataIndex of file {}", file);
+      logger.error(Messages.get("log.read.sequence_reader_deserialize_metadata_error"), file);
       throw e;
     }
   }
@@ -1920,13 +1916,13 @@ public class TsFileSequenceReader implements AutoCloseable {
   public void readPlanIndex() throws IOException {
     ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
     if (ReadWriteIOUtils.readAsPossible(tsFileInput, buffer) == 0) {
-      throw new IOException("reach the end of the file.");
+      throw new IOException(Messages.get("error.read.reach_end_of_file"));
     }
     buffer.flip();
     minPlanIndex = buffer.getLong();
     buffer.clear();
     if (ReadWriteIOUtils.readAsPossible(tsFileInput, buffer) == 0) {
-      throw new IOException("reach the end of the file.");
+      throw new IOException(Messages.get("error.read.reach_end_of_file"));
     }
     buffer.flip();
     maxPlanIndex = buffer.getLong();
@@ -1945,7 +1941,8 @@ public class TsFileSequenceReader implements AutoCloseable {
     } catch (StopReadTsFileByInterruptException e) {
       throw e;
     } catch (Throwable t) {
-      logger.warn("Exception {} happened while reading chunk header of {}", t.getMessage(), file);
+      logger.warn(
+          Messages.get("log.read.sequence_reader_chunk_header_error"), t.getMessage(), file);
       throw t;
     }
   }
@@ -1963,7 +1960,8 @@ public class TsFileSequenceReader implements AutoCloseable {
     } catch (StopReadTsFileByInterruptException e) {
       throw e;
     } catch (Throwable t) {
-      logger.warn("Exception {} happened while reading chunk header of {}", t.getMessage(), file);
+      logger.warn(
+          Messages.get("log.read.sequence_reader_chunk_header_error"), t.getMessage(), file);
       throw t;
     }
   }
@@ -1994,7 +1992,7 @@ public class TsFileSequenceReader implements AutoCloseable {
     } catch (StopReadTsFileByInterruptException e) {
       throw e;
     } catch (Throwable t) {
-      logger.warn("Exception {} happened while reading chunk of {}", t.getMessage(), file);
+      logger.warn(Messages.get("log.read.sequence_reader_chunk_error"), t.getMessage(), file);
       throw t;
     }
   }
@@ -2020,7 +2018,7 @@ public class TsFileSequenceReader implements AutoCloseable {
     } catch (StopReadTsFileByInterruptException e) {
       throw e;
     } catch (Throwable t) {
-      logger.warn("Exception {} happened while reading chunk of {}", t.getMessage(), file);
+      logger.warn(Messages.get("log.read.sequence_reader_chunk_error"), t.getMessage(), file);
       throw t;
     }
   }
@@ -2046,7 +2044,7 @@ public class TsFileSequenceReader implements AutoCloseable {
     } catch (StopReadTsFileByInterruptException e) {
       throw e;
     } catch (Throwable t) {
-      logger.warn("Exception {} happened while reading chunk of {}", t.getMessage(), file);
+      logger.warn(Messages.get("log.read.sequence_reader_chunk_error"), t.getMessage(), file);
       throw t;
     }
   }
@@ -2117,7 +2115,7 @@ public class TsFileSequenceReader implements AutoCloseable {
     } catch (StopReadTsFileByInterruptException e) {
       throw e;
     } catch (Throwable t) {
-      logger.warn("Exception {} happened while reading page header of {}", t.getMessage(), file);
+      logger.warn(Messages.get("log.read.sequence_reader_page_header_error"), t.getMessage(), file);
       throw t;
     }
   }
@@ -2174,11 +2172,8 @@ public class TsFileSequenceReader implements AutoCloseable {
           0);
     } catch (Exception e) {
       throw new IOException(
-          "Uncompress error! uncompress size: "
-              + uncompressedSize
-              + "compressed size: "
-              + buffer.remaining()
-              + e.getMessage(),
+          Messages.format(
+              "error.read.uncompress_error", uncompressedSize, buffer.remaining(), e.getMessage()),
           e);
     }
 
@@ -2192,7 +2187,7 @@ public class TsFileSequenceReader implements AutoCloseable {
   public byte readMarker() throws IOException {
     markerBuffer.clear();
     if (ReadWriteIOUtils.readAsPossible(tsFileInput, markerBuffer) == 0) {
-      throw new IOException("reach the end of the file.");
+      throw new IOException(Messages.get("error.read.reach_end_of_file"));
     }
     markerBuffer.flip();
     return markerBuffer.get();
@@ -2258,17 +2253,15 @@ public class TsFileSequenceReader implements AutoCloseable {
       buffer.limit(bufferLimit);
       if (position < 0) {
         if (ReadWriteIOUtils.readAsPossible(tsFileInput, buffer) != allocateSize) {
-          throw new IOException("reach the end of the data");
+          throw new IOException(Messages.get("error.read.reach_end_of_data"));
         }
       } else {
         long actualReadSize =
             ReadWriteIOUtils.readAsPossible(tsFileInput, buffer, position, allocateSize);
         if (actualReadSize != allocateSize) {
           throw new IOException(
-              String.format(
-                  "reach the end of the data. Size of data that want to read: %s,"
-                      + "actual read size: %s, position: %s",
-                  allocateSize, actualReadSize, position));
+              Messages.format(
+                  "error.read.reach_end_of_data_detail", allocateSize, actualReadSize, position));
         }
         position += allocateSize;
       }
@@ -2307,7 +2300,7 @@ public class TsFileSequenceReader implements AutoCloseable {
     } catch (StopReadTsFileByInterruptException e) {
       throw e;
     } catch (Throwable t) {
-      logger.warn("Exception {} happened while reading data of {}", t.getMessage(), file);
+      logger.warn(Messages.get("log.read.sequence_reader_data_error"), t.getMessage(), file);
       throw t;
     }
   }
@@ -2494,7 +2487,8 @@ public class TsFileSequenceReader implements AutoCloseable {
                           chunkStatistics.update(timeStamp, value.getBinary());
                           break;
                         default:
-                          throw new IOException("Unexpected type " + dataType);
+                          throw new IOException(
+                              Messages.format("error.read.unexpected_type", dataType));
                       }
                     }
                   }
@@ -2534,7 +2528,8 @@ public class TsFileSequenceReader implements AutoCloseable {
                         chunkStatistics.update(batchData.currentTime(), batchData.getBinary());
                         break;
                       default:
-                        throw new IOException("Unexpected type " + dataType);
+                        throw new IOException(
+                            Messages.format("error.read.unexpected_type", dataType));
                     }
                     batchData.next();
                   }
@@ -2598,7 +2593,7 @@ public class TsFileSequenceReader implements AutoCloseable {
             break;
           default:
             // the disk file is corrupted, using this file may be dangerous
-            throw new IOException("Unexpected marker " + marker);
+            throw new IOException(Messages.format("error.read.unexpected_marker", marker));
         }
       }
       // now we read the tail of the data section, so we are sure that the last
@@ -2620,7 +2615,7 @@ public class TsFileSequenceReader implements AutoCloseable {
       }
     } catch (Exception e) {
       logger.warn(
-          "TsFile {} self-check cannot proceed at position {} " + "recovered, because : {}",
+          Messages.get("log.read.sequence_reader_self_check_warn"),
           file,
           this.position(),
           e.getMessage());
@@ -2653,7 +2648,7 @@ public class TsFileSequenceReader implements AutoCloseable {
       return TsFileCheckStatus.FILE_NOT_FOUND;
     }
     long fileSize = checkFile.length();
-    logger.info("file length: " + fileSize);
+    logger.info(Messages.get("log.read.sequence_reader_file_length"), fileSize);
 
     int headerLength = TSFileConfig.MAGIC_STRING.getBytes().length + Byte.BYTES;
     if (fileSize < headerLength) {
@@ -2674,7 +2669,7 @@ public class TsFileSequenceReader implements AutoCloseable {
     } catch (StopReadTsFileByInterruptException e) {
       throw e;
     } catch (IOException e) {
-      logger.error("Error occurred while fast checking TsFile.");
+      logger.error(Messages.get("log.read.sequence_reader_fast_check_error"));
       throw e;
     }
     for (Map.Entry<Long, Pair<Path, TimeseriesMetadata>> entry : timeseriesMetadataMap.entrySet()) {
@@ -2689,19 +2684,20 @@ public class TsFileSequenceReader implements AutoCloseable {
         } catch (StopReadTsFileByInterruptException e) {
           throw e;
         } catch (IOException e) {
-          logger.error("Error occurred while checking the statistics of chunk and its pages");
+          logger.error(Messages.get("log.read.sequence_reader_stats_check_error"));
           throw e;
         }
         if (tscheckStatus == TsFileCheckStatus.FILE_EXISTS_MISTAKES) {
           throw new TsFileStatisticsMistakesException(
-              "Chunk" + message + chunkMetadata.getOffsetOfChunkHeader());
+              Messages.format(
+                  "error.read.stats_mistakes_chunk", chunkMetadata.getOffsetOfChunkHeader()));
         }
         chunkMetadatasSta.mergeStatistics(chunkMetadata.getStatistics());
       }
       if (!timeseriesMetadataSta.equals(chunkMetadatasSta)) {
         long timeseriesMetadataPos = entry.getKey();
         throw new TsFileStatisticsMistakesException(
-            "TimeseriesMetadata" + message + timeseriesMetadataPos);
+            Messages.format("error.read.stats_mistakes_tsm", timeseriesMetadataPos));
       }
     }
     return TsFileCheckStatus.COMPLETE_FILE;
@@ -2765,7 +2761,7 @@ public class TsFileSequenceReader implements AutoCloseable {
             chunkStatistics.update(batchData.currentTime(), batchData.getBinary());
             break;
           default:
-            throw new IOException("Unexpected type " + dataType);
+            throw new IOException(Messages.format("error.read.unexpected_type", dataType));
         }
         batchData.next();
       }
@@ -2857,7 +2853,7 @@ public class TsFileSequenceReader implements AutoCloseable {
     Pair<IMetadataIndexEntry, Long> metadataIndexPair =
         getMetadataAndEndOffsetOfDeviceNode(deviceMetadataIndexNode, device, true);
     if (metadataIndexPair == null) {
-      throw new IOException("Device {" + device + "} is not in tsFileMetaData");
+      throw new IOException(Messages.format("error.read.device_not_in_metadata", device));
     }
     ByteBuffer buffer = readData(metadataIndexPair.left.getOffset(), metadataIndexPair.right);
     MetadataIndexNode metadataIndexNode;
@@ -2886,7 +2882,7 @@ public class TsFileSequenceReader implements AutoCloseable {
       throws IOException {
     TimeseriesMetadata firstTimeseriesMetadata = getTimeColumnMetadata(metadataIndexNode, null);
     if (firstTimeseriesMetadata == null) {
-      throw new IOException("Timeseries of device {" + device + "} are not aligned");
+      throw new IOException(Messages.format("error.read.timeseries_not_aligned", device));
     }
 
     Map<IDeviceID, List<TimeseriesMetadata>> timeseriesMetadataMap = new TreeMap<>();
@@ -2920,9 +2916,11 @@ public class TsFileSequenceReader implements AutoCloseable {
 
     if (timeseriesMetadataMap.values().size() != 1) {
       throw new IOException(
-          String.format(
-              "Error when reading timeseriesMetadata of device %s in file %s: should only one timeseriesMetadataList in one device, actual: %d",
-              device, file, timeseriesMetadataMap.values().size()));
+          Messages.format(
+              "error.read.aligned_chunk_metadata_one_device",
+              device,
+              file,
+              timeseriesMetadataMap.values().size()));
     }
 
     List<TimeseriesMetadata> timeseriesMetadataList =
@@ -3207,8 +3205,7 @@ public class TsFileSequenceReader implements AutoCloseable {
           }
           return measurementChunkMetadataList;
         } catch (IOException e) {
-          throw new TsFileRuntimeException(
-              "Error occurred while reading a time series metadata block.");
+          throw new TsFileRuntimeException(Messages.get("error.read.metadata_block_read_error"));
         }
       }
     };
@@ -3237,8 +3234,7 @@ public class TsFileSequenceReader implements AutoCloseable {
     } catch (StopReadTsFileByInterruptException e) {
       throw e;
     } catch (Exception e) {
-      logger.error(
-          "Error occurred while collecting offset ranges of measurement nodes of file {}", file);
+      logger.error(Messages.get("log.read.sequence_reader_collect_offset_error"), file);
       throw e;
     }
   }
@@ -3298,7 +3294,7 @@ public class TsFileSequenceReader implements AutoCloseable {
       try {
         loadNextValue();
       } catch (IOException e) {
-        logger.warn("Cannot read timeseries metadata from {},", file, e);
+        logger.warn(Messages.get("log.read.sequence_reader_tsm_warn"), file, e);
         return false;
       }
       return nextValue != null;

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/TsFileSequenceReaderTimeseriesMetadataIterator.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/TsFileSequenceReaderTimeseriesMetadataIterator.java
@@ -27,6 +27,7 @@ import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.file.metadata.MetadataIndexNode;
 import org.apache.tsfile.file.metadata.TimeseriesMetadata;
 import org.apache.tsfile.file.metadata.enums.MetadataIndexNodeType;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -113,11 +114,8 @@ public class TsFileSequenceReaderTimeseriesMetadataIterator
               .addAll(deserializeTimeseriesMetadataUsingTsFileInput(currentEndOffset));
         } catch (IOException e) {
           throw new TsFileSequenceReaderTimeseriesMetadataIteratorException(
-              String.format(
-                  "TsFileSequenceReaderTimeseriesMetadataIterator: deserializeTimeseriesMetadataUsingTsFileInput failed, "
-                      + "currentEndOffset: %d, "
-                      + e.getMessage(),
-                  currentEndOffset));
+              Messages.format(
+                  "error.read.tsm_iterator_tsfinput_failed", currentEndOffset, e.getMessage()));
         }
       }
 
@@ -133,11 +131,8 @@ public class TsFileSequenceReaderTimeseriesMetadataIterator
         deserializeMetadataIndexEntry(indexEntryInfo, timeseriesMetadataMap);
       } catch (IOException e) {
         throw new TsFileSequenceReaderTimeseriesMetadataIteratorException(
-            String.format(
-                "TsFileSequenceReaderTimeseriesMetadataIterator: deserializeMetadataIndexEntry failed, "
-                    + "MetadataIndexEntryInfo: %s, "
-                    + e.getMessage(),
-                indexEntryInfo));
+            Messages.format(
+                "error.read.tsm_iterator_index_entry_failed", indexEntryInfo, e.getMessage()));
       }
     }
 
@@ -176,7 +171,7 @@ public class TsFileSequenceReaderTimeseriesMetadataIterator
       throws IOException {
     if (currentBuffer != null && currentBuffer.hasRemaining()) {
       throw new TsFileSequenceReaderTimeseriesMetadataIteratorException(
-          "currentBuffer still has some data left before deserializeLeafMeasurement");
+          Messages.get("error.read.tsm_iterator_buffer_not_empty"));
     }
     if (endOffset - metadataIndexEntry.getOffset() < Integer.MAX_VALUE) {
       currentBuffer = reader.readData(metadataIndexEntry.getOffset(), endOffset);

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/BatchData.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/BatchData.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.read.common;
 
 import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.TimeValuePair;
 import org.apache.tsfile.read.reader.IPointReader;
 import org.apache.tsfile.utils.Binary;
@@ -763,14 +764,16 @@ public class BatchData {
                   outputStream.writeInt(value.getInt());
                   break;
                 default:
-                  throw new IllegalArgumentException("Unknown data type for BatchData:" + dataType);
+                  throw new IllegalArgumentException(
+                      Messages.format("error.read.batch_data_unknown_type", dataType));
               }
             }
           }
         }
         break;
       default:
-        throw new IllegalArgumentException("Unknown data type for BatchData:" + dataType);
+        throw new IllegalArgumentException(
+            Messages.format("error.read.batch_data_unknown_type", dataType));
     }
   }
 
@@ -826,7 +829,8 @@ public class BatchData {
         case 2:
           return new DescReadWriteBatchData(dataType);
         default:
-          throw new IllegalArgumentException("Invalid input: " + type);
+          throw new IllegalArgumentException(
+              Messages.format("error.read.batch_data_invalid_input", type));
       }
     }
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/BatchDataFactory.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/BatchDataFactory.java
@@ -20,11 +20,12 @@
 package org.apache.tsfile.read.common;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 
 public class BatchDataFactory {
 
   private BatchDataFactory() {
-    throw new IllegalStateException("Factory class");
+    throw new IllegalStateException(Messages.get("error.read.factory_class"));
   }
 
   public static BatchData createBatchData(

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/Chunk.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/Chunk.java
@@ -27,6 +27,7 @@ import org.apache.tsfile.file.MetaMarker;
 import org.apache.tsfile.file.header.ChunkHeader;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.tsfile.file.metadata.statistics.Statistics;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.TimeValuePair;
 import org.apache.tsfile.read.reader.IPageReader;
 import org.apache.tsfile.read.reader.IPointReader;
@@ -299,7 +300,7 @@ public class Chunk {
                 convertedValue == null);
             break;
           default:
-            throw new IOException("Unsupported data type: " + newType);
+            throw new IOException(Messages.format("error.read.chunk_unsupported_type", newType));
         }
       }
       chunkWriter.sealCurrentPage();
@@ -343,7 +344,7 @@ public class Chunk {
             newType.castFromSingleValue(chunkHeader.getDataType(), point.getValue().getValue());
         long timestamp = point.getTimestamp();
         if (convertedValue == null) {
-          throw new IOException("NonAlignedChunk contains null, timestamp: " + timestamp);
+          throw new IOException(Messages.format("error.read.chunk_non_aligned_null", timestamp));
         }
         switch (newType) {
           case BOOLEAN:
@@ -370,7 +371,7 @@ public class Chunk {
             chunkWriter.write(timestamp, (Binary) convertedValue);
             break;
           default:
-            throw new IOException("Unsupported data type: " + newType);
+            throw new IOException(Messages.format("error.read.chunk_unsupported_type", newType));
         }
       }
       chunkWriter.sealCurrentPage();

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/Field.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/Field.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.read.common;
 
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.NullFieldException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.BytesUtils;
 import org.apache.tsfile.utils.DateUtils;
@@ -147,7 +148,8 @@ public class Field {
     if (dataType == null) {
       throw new NullFieldException();
     } else if (dataType == TSDataType.OBJECT) {
-      throw new UnsupportedOperationException("OBJECT Type only support getStringValue");
+      throw new UnsupportedOperationException(
+          Messages.get("error.read.field_object_type_no_binary"));
     }
     return binaryV;
   }
@@ -292,7 +294,8 @@ public class Field {
         field.setBinaryV(value.getBinary());
         break;
       default:
-        throw new UnSupportedDataTypeException("UnSupported" + value.getDataType());
+        throw new UnSupportedDataTypeException(
+            Messages.format("error.common.unsupported_data_type", value.getDataType()));
     }
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/Path.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/Path.java
@@ -26,6 +26,7 @@ import org.apache.tsfile.external.commons.lang3.Validate;
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.file.metadata.IDeviceID.Deserializer;
 import org.apache.tsfile.file.metadata.IDeviceID.Factory;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.parser.PathNodesGenerator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 
@@ -164,7 +165,7 @@ public class Path implements Serializable, Comparable<Path> {
   }
 
   public String getFullPathWithAlias() {
-    throw new IllegalArgumentException("doesn't alias in TSFile Path");
+    throw new IllegalArgumentException(Messages.get("error.read.path_no_alias"));
   }
 
   public void setMeasurement(String measurement) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/SignalBatchData.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/SignalBatchData.java
@@ -19,6 +19,8 @@
 
 package org.apache.tsfile.read.common;
 
+import org.apache.tsfile.i18n.Messages;
+
 /** It is an empty signal to notify the caller that there is no more batch data after it. */
 public class SignalBatchData extends BatchData {
 
@@ -39,6 +41,7 @@ public class SignalBatchData extends BatchData {
 
   @Override
   public boolean hasCurrent() {
-    throw new UnsupportedOperationException("hasCurrent is not supported for SignalBatchData");
+    throw new UnsupportedOperationException(
+        Messages.get("error.read.signal_batch_data_no_has_current"));
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/TimeRange.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/TimeRange.java
@@ -19,6 +19,7 @@
 
 package org.apache.tsfile.read.common;
 
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.expression.IExpression;
 import org.apache.tsfile.read.expression.impl.BinaryExpression;
 import org.apache.tsfile.read.expression.impl.GlobalTimeExpression;
@@ -56,7 +57,7 @@ public class TimeRange implements Comparable<TimeRange> {
   @Override
   public int compareTo(TimeRange r) {
     if (r == null) {
-      throw new NullPointerException("The input cannot be null!");
+      throw new NullPointerException(Messages.get("error.read.timerange_null_input"));
     }
     if (this.min > r.min) {
       return 1;
@@ -75,14 +76,14 @@ public class TimeRange implements Comparable<TimeRange> {
 
   public void setMin(long min) {
     if (min < 0 || min > this.max) {
-      throw new IllegalArgumentException("Invalid input!");
+      throw new IllegalArgumentException(Messages.get("error.read.timerange_invalid_input"));
     }
     this.min = min;
   }
 
   public void setMax(long max) {
     if (max < 0 || max < this.min) {
-      throw new IllegalArgumentException("Invalid input!");
+      throw new IllegalArgumentException(Messages.get("error.read.timerange_invalid_input"));
     }
     this.max = max;
   }
@@ -128,7 +129,8 @@ public class TimeRange implements Comparable<TimeRange> {
    */
   public void set(long min, long max) {
     if (min > max) {
-      throw new IllegalArgumentException("min:" + min + " should not be larger than max: " + max);
+      throw new IllegalArgumentException(
+          Messages.format("error.read.timerange_min_gt_max", min, max));
     }
     this.min = min;
     this.max = max;

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/TsBlock.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/TsBlock.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.read.common.block;
 
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.file.metadata.TableSchema;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.TimeValuePair;
 import org.apache.tsfile.read.common.IBatchDataIterator;
 import org.apache.tsfile.read.common.block.column.ColumnFactory;
@@ -36,7 +37,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -144,9 +144,8 @@ public class TsBlock {
   public TsBlock getRegion(int positionOffset, int length) {
     if (positionOffset < 0 || length < 0 || positionOffset + length > positionCount) {
       throw new IndexOutOfBoundsException(
-          format(
-              "Invalid position %s and length %s in page with %s positions",
-              positionOffset, length, positionCount));
+          Messages.format(
+              "error.read.tsblock_invalid_region", positionOffset, length, positionCount));
     }
     int channelCount = getValueColumnCount();
     Column[] slicedColumns = new Column[channelCount];
@@ -183,7 +182,7 @@ public class TsBlock {
    */
   public TsBlock subTsBlock(int fromIndex) {
     if (fromIndex > positionCount) {
-      throw new IllegalArgumentException("FromIndex of subTsBlock cannot over positionCount.");
+      throw new IllegalArgumentException(Messages.get("error.read.tsblock_from_index_over"));
     }
     Column subTimeColumn = timeColumn.subColumn(fromIndex);
     Column[] subValueColumns = new Column[valueColumns.length];
@@ -544,7 +543,7 @@ public class TsBlock {
   private static int determinePositionCount(Column... columns) {
     requireNonNull(columns, "columns is null");
     if (columns.length == 0) {
-      throw new IllegalArgumentException("columns is empty");
+      throw new IllegalArgumentException(Messages.get("error.read.tsblock_columns_empty"));
     }
 
     return columns[0].getPositionCount();
@@ -599,7 +598,8 @@ public class TsBlock {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              "Unknown datatype: " + valueColumns[i].getDataType());
+              Messages.format(
+                  "error.read.tsblock_unknown_datatype", valueColumns[i].getDataType()));
       }
     }
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/TsBlockBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/TsBlockBuilder.java
@@ -25,6 +25,7 @@ import org.apache.tsfile.block.column.ColumnBuilder;
 import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.block.column.BinaryColumnBuilder;
 import org.apache.tsfile.read.common.block.column.BooleanColumnBuilder;
 import org.apache.tsfile.read.common.block.column.DoubleColumnBuilder;
@@ -37,7 +38,6 @@ import org.apache.tsfile.utils.Binary;
 
 import java.util.List;
 
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.apache.tsfile.utils.Preconditions.checkArgument;
 
@@ -149,7 +149,8 @@ public class TsBlockBuilder {
                   tsBlockBuilderStatus.createColumnBuilderStatus(), initialExpectedEntries);
           break;
         default:
-          throw new IllegalArgumentException("Unknown data type: " + types.get(i));
+          throw new IllegalArgumentException(
+              Messages.format("error.read.tsblock_builder_unknown_type", types.get(i)));
       }
     }
   }
@@ -228,7 +229,8 @@ public class TsBlockBuilder {
                   tsBlockBuilderStatus.createColumnBuilderStatus(), initialExpectedEntries);
           break;
         default:
-          throw new IllegalArgumentException("Unknown data type: " + types.get(i));
+          throw new IllegalArgumentException(
+              Messages.format("error.read.tsblock_builder_unknown_type", types.get(i)));
       }
     }
   }
@@ -330,9 +332,10 @@ public class TsBlockBuilder {
   public TsBlock build(Column timeColumn) {
     if (timeColumn.getPositionCount() != declaredPositions) {
       throw new IllegalStateException(
-          format(
-              "Declared positions (%s) does not match time column's number of entries (%s)",
-              declaredPositions, timeColumn.getPositionCount()));
+          Messages.format(
+              "error.read.tsblock_builder_time_mismatch",
+              declaredPositions,
+              timeColumn.getPositionCount()));
     }
 
     Column[] columns = new Column[valueColumnBuilders.length];
@@ -340,9 +343,11 @@ public class TsBlockBuilder {
       columns[i] = valueColumnBuilders[i].build();
       if (columns[i].getPositionCount() != declaredPositions) {
         throw new IllegalStateException(
-            format(
-                "Declared positions (%s) does not match column %s's number of entries (%s)",
-                declaredPositions, i, columns[i].getPositionCount()));
+            Messages.format(
+                "error.read.tsblock_builder_col_mismatch",
+                declaredPositions,
+                i,
+                columns[i].getPositionCount()));
       }
     }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryArrayColumnEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryArrayColumnEncoder.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.read.common.block.column;
 
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 
 import java.io.DataOutputStream;
@@ -46,7 +47,8 @@ public class BinaryArrayColumnEncoder implements ColumnEncoder {
     //    +---------------+-------+
 
     if (!TSDataType.TEXT.equals(dataType)) {
-      throw new IllegalArgumentException("Invalid data type: " + dataType);
+      throw new IllegalArgumentException(
+          Messages.format("error.read.col_encoder_invalid_type", dataType));
     }
 
     boolean[] nullIndicators = ColumnEncoder.deserializeNullIndicators(input, positionCount);
@@ -87,7 +89,8 @@ public class BinaryArrayColumnEncoder implements ColumnEncoder {
         }
       }
     } else {
-      throw new IllegalArgumentException("Invalid data type: " + dataType);
+      throw new IllegalArgumentException(
+          Messages.format("error.read.col_encoder_invalid_type", dataType));
     }
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumn.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.read.common.block.column;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnEncoding;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
@@ -61,21 +62,21 @@ public class BinaryColumn implements Column {
 
   BinaryColumn(int arrayOffset, int positionCount, boolean[] valueIsNull, Binary[] values) {
     if (arrayOffset < 0) {
-      throw new IllegalArgumentException("arrayOffset is negative");
+      throw new IllegalArgumentException(Messages.get("error.read.col_array_offset_negative"));
     }
     this.arrayOffset = arrayOffset;
     if (positionCount < 0) {
-      throw new IllegalArgumentException("positionCount is negative");
+      throw new IllegalArgumentException(Messages.get("error.read.col_position_count_negative"));
     }
     this.positionCount = positionCount;
 
     if (values.length - arrayOffset < positionCount) {
-      throw new IllegalArgumentException("values length is less than positionCount");
+      throw new IllegalArgumentException(Messages.get("error.read.col_values_length_lt_position"));
     }
     this.values = values;
 
     if (valueIsNull != null && valueIsNull.length - arrayOffset < positionCount) {
-      throw new IllegalArgumentException("isNull length is less than positionCount");
+      throw new IllegalArgumentException(Messages.get("error.read.col_isnull_length_lt_position"));
     }
     this.valueIsNull = valueIsNull;
 
@@ -91,21 +92,21 @@ public class BinaryColumn implements Column {
       Binary[] values,
       long retainedSizeInBytes) {
     if (arrayOffset < 0) {
-      throw new IllegalArgumentException("arrayOffset is negative");
+      throw new IllegalArgumentException(Messages.get("error.read.col_array_offset_negative"));
     }
     this.arrayOffset = arrayOffset;
     if (positionCount < 0) {
-      throw new IllegalArgumentException("positionCount is negative");
+      throw new IllegalArgumentException(Messages.get("error.read.col_position_count_negative"));
     }
     this.positionCount = positionCount;
 
     if (values.length - arrayOffset < positionCount) {
-      throw new IllegalArgumentException("values length is less than positionCount");
+      throw new IllegalArgumentException(Messages.get("error.read.col_values_length_lt_position"));
     }
     this.values = values;
 
     if (valueIsNull != null && valueIsNull.length - arrayOffset < positionCount) {
-      throw new IllegalArgumentException("isNull length is less than positionCount");
+      throw new IllegalArgumentException(Messages.get("error.read.col_isnull_length_lt_position"));
     }
     this.valueIsNull = valueIsNull;
     this.retainedSizeInBytes = retainedSizeInBytes;
@@ -201,7 +202,7 @@ public class BinaryColumn implements Column {
   @Override
   public Column subColumn(int fromIndex) {
     if (fromIndex > positionCount) {
-      throw new IllegalArgumentException("fromIndex is not valid");
+      throw new IllegalArgumentException(Messages.get("error.read.col_from_index_invalid"));
     }
     return new BinaryColumn(
         arrayOffset + fromIndex, positionCount - fromIndex, valueIsNull, values);
@@ -210,7 +211,7 @@ public class BinaryColumn implements Column {
   @Override
   public Column subColumnCopy(int fromIndex) {
     if (fromIndex > positionCount) {
-      throw new IllegalArgumentException("fromIndex is not valid");
+      throw new IllegalArgumentException(Messages.get("error.read.col_from_index_invalid"));
     }
 
     int from = arrayOffset + fromIndex;

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumnBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BinaryColumnBuilder.java
@@ -23,6 +23,7 @@ import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnBuilder;
 import org.apache.tsfile.block.column.ColumnBuilderStatus;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
@@ -93,7 +94,7 @@ public class BinaryColumnBuilder implements ColumnBuilder {
       writeBinary((Binary) value);
       return this;
     }
-    throw new UnSupportedDataTypeException("BinaryColumn only support Binary data type");
+    throw new UnSupportedDataTypeException(Messages.get("error.read.col_builder_binary_type"));
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BooleanColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BooleanColumn.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.read.common.block.column;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnEncoding;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
@@ -58,21 +59,21 @@ public class BooleanColumn implements Column {
 
   BooleanColumn(int arrayOffset, int positionCount, boolean[] valueIsNull, boolean[] values) {
     if (arrayOffset < 0) {
-      throw new IllegalArgumentException("arrayOffset is negative");
+      throw new IllegalArgumentException(Messages.get("error.read.col_array_offset_negative"));
     }
     this.arrayOffset = arrayOffset;
     if (positionCount < 0) {
-      throw new IllegalArgumentException("positionCount is negative");
+      throw new IllegalArgumentException(Messages.get("error.read.col_position_count_negative"));
     }
     this.positionCount = positionCount;
 
     if (values.length - arrayOffset < positionCount) {
-      throw new IllegalArgumentException("values length is less than positionCount");
+      throw new IllegalArgumentException(Messages.get("error.read.col_values_length_lt_position"));
     }
     this.values = values;
 
     if (valueIsNull != null && valueIsNull.length - arrayOffset < positionCount) {
-      throw new IllegalArgumentException("isNull length is less than positionCount");
+      throw new IllegalArgumentException(Messages.get("error.read.col_isnull_length_lt_position"));
     }
     this.valueIsNull = valueIsNull;
 
@@ -181,7 +182,7 @@ public class BooleanColumn implements Column {
   @Override
   public Column subColumn(int fromIndex) {
     if (fromIndex > positionCount) {
-      throw new IllegalArgumentException("fromIndex is not valid");
+      throw new IllegalArgumentException(Messages.get("error.read.col_from_index_invalid"));
     }
     return new BooleanColumn(
         arrayOffset + fromIndex, positionCount - fromIndex, valueIsNull, values);
@@ -190,7 +191,7 @@ public class BooleanColumn implements Column {
   @Override
   public Column subColumnCopy(int fromIndex) {
     if (fromIndex > positionCount) {
-      throw new IllegalArgumentException("fromIndex is not valid");
+      throw new IllegalArgumentException(Messages.get("error.read.col_from_index_invalid"));
     }
 
     int from = arrayOffset + fromIndex;

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BooleanColumnBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/BooleanColumnBuilder.java
@@ -23,6 +23,7 @@ import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnBuilder;
 import org.apache.tsfile.block.column.ColumnBuilderStatus;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
 import org.apache.tsfile.write.UnSupportedDataTypeException;
@@ -89,7 +90,7 @@ public class BooleanColumnBuilder implements ColumnBuilder {
       writeBoolean((Boolean) value);
       return this;
     }
-    throw new UnSupportedDataTypeException("BooleanColumn only support Boolean data type");
+    throw new UnSupportedDataTypeException(Messages.get("error.read.col_builder_boolean_type"));
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/ByteArrayColumnEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/ByteArrayColumnEncoder.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.read.common.block.column;
 
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -39,7 +40,8 @@ public class ByteArrayColumnEncoder implements ColumnEncoder {
     //    +---------------+-----------------+-------------+
 
     if (!TSDataType.BOOLEAN.equals(dataType)) {
-      throw new IllegalArgumentException("Invalid data type: " + dataType);
+      throw new IllegalArgumentException(
+          Messages.format("error.read.col_encoder_invalid_type", dataType));
     }
 
     boolean[] nullIndicators = ColumnEncoder.deserializeNullIndicators(input, positionCount);
@@ -57,7 +59,8 @@ public class ByteArrayColumnEncoder implements ColumnEncoder {
     if (TSDataType.BOOLEAN.equals(dataType)) {
       ColumnEncoder.serializeBooleanArray(output, column, Column::getBoolean);
     } else {
-      throw new IllegalArgumentException("Invalid data type: " + dataType);
+      throw new IllegalArgumentException(
+          Messages.format("error.read.col_encoder_invalid_type", dataType));
     }
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/ColumnEncoderFactory.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/ColumnEncoderFactory.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.read.common.block.column;
 
 import org.apache.tsfile.block.column.ColumnEncoding;
+import org.apache.tsfile.i18n.Messages;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -44,7 +45,8 @@ public class ColumnEncoderFactory {
   public static ColumnEncoder get(ColumnEncoding columnEncoding) {
     ColumnEncoder res = encodingToEncoder.get(columnEncoding);
     if (res == null) {
-      throw new IllegalArgumentException("Unsupported column encoding: " + columnEncoding);
+      throw new IllegalArgumentException(
+          Messages.format("error.read.col_encoder_unsupported", columnEncoding));
     }
     return res;
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/ColumnFactory.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/ColumnFactory.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.read.common.block.column;
 
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 
 public class ColumnFactory {
   public static Column create(TSDataType dataType, int initialCapacity) {
@@ -44,7 +45,8 @@ public class ColumnFactory {
       case BOOLEAN:
         return new BooleanColumn(initialCapacity);
       default:
-        throw new IllegalArgumentException("Unsupported data type: " + dataType);
+        throw new IllegalArgumentException(
+            Messages.format("error.read.column_factory_unsupported_type", dataType));
     }
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/ColumnUtil.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/ColumnUtil.java
@@ -20,11 +20,11 @@
 package org.apache.tsfile.read.common.block.column;
 
 import org.apache.tsfile.block.column.Column;
+import org.apache.tsfile.i18n.Messages;
 
 import java.util.Arrays;
 
 import static java.lang.Math.ceil;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class ColumnUtil {
@@ -41,34 +41,31 @@ public class ColumnUtil {
     requireNonNull(array, "array is null");
     if (offset < 0 || length < 0 || offset + length > array.length) {
       throw new IndexOutOfBoundsException(
-          format(
-              "Invalid offset %s and length %s in array with %s elements",
-              offset, length, array.length));
+          Messages.format(
+              "error.read.col_util_invalid_offset_length", offset, length, array.length));
     }
   }
 
   static void checkValidRegion(int positionCount, int positionOffset, int length) {
     if (positionOffset < 0 || length < 0 || positionOffset + length > positionCount) {
       throw new IndexOutOfBoundsException(
-          format(
-              "Invalid position %s and length %s in block with %s positions",
-              positionOffset, length, positionCount));
+          Messages.format(
+              "error.read.col_util_invalid_pos_length", positionOffset, length, positionCount));
     }
   }
 
   static void checkValidPositions(boolean[] positions, int positionCount) {
     if (positions.length != positionCount) {
       throw new IllegalArgumentException(
-          format(
-              "Invalid positions array size %d, actual position count is %d",
-              positions.length, positionCount));
+          Messages.format(
+              "error.read.col_util_invalid_positions_size", positions.length, positionCount));
     }
   }
 
   static void checkValidPosition(int position, int positionCount) {
     if (position < 0 || position >= positionCount) {
       throw new IllegalArgumentException(
-          format("Invalid position %s in block with %s positions", position, positionCount));
+          Messages.format("error.read.col_util_invalid_position", position, positionCount));
     }
   }
 
@@ -93,7 +90,8 @@ public class ColumnUtil {
     } else if (newSize > MAX_ARRAY_SIZE) {
       newSize = MAX_ARRAY_SIZE;
       if (newSize == currentSize) {
-        throw new IllegalArgumentException(format("Cannot grow array beyond '%s'", MAX_ARRAY_SIZE));
+        throw new IllegalArgumentException(
+            Messages.format("error.read.col_util_cannot_grow", MAX_ARRAY_SIZE));
       }
     }
     return (int) newSize;

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/DictionaryColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/DictionaryColumn.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.read.common.block.column;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnEncoding;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
@@ -118,12 +119,12 @@ public final class DictionaryColumn implements Column {
     requireNonNull(ids, "ids is null");
 
     if (positionCount < 0) {
-      throw new IllegalArgumentException("positionCount is negative");
+      throw new IllegalArgumentException(Messages.get("error.read.col_position_count_negative"));
     }
 
     this.idsOffset = idsOffset;
     if (ids.length - idsOffset < positionCount) {
-      throw new IllegalArgumentException("ids length is less than positionCount");
+      throw new IllegalArgumentException(Messages.get("error.read.col_ids_length_lt_position"));
     }
 
     this.positionCount = positionCount;
@@ -139,8 +140,7 @@ public final class DictionaryColumn implements Column {
     }
 
     if (isSequentialIds && !dictionaryIsCompacted) {
-      throw new IllegalArgumentException(
-          "sequential ids flag is only valid for compacted dictionary");
+      throw new IllegalArgumentException(Messages.get("error.read.dict_col_sequential_ids"));
     }
     this.isSequentialIds = isSequentialIds;
   }
@@ -503,7 +503,7 @@ public final class DictionaryColumn implements Column {
     for (int i = 0; i < positionCount; i++) {
       int newId = remapIndex[getId(i)];
       if (newId == -1) {
-        throw new IllegalStateException("reference to a non-existent key");
+        throw new IllegalStateException(Messages.get("error.read.dict_col_nonexistent_key"));
       }
       newIds[i] = newId;
     }
@@ -569,7 +569,7 @@ public final class DictionaryColumn implements Column {
       if (!firstDictionaryColumn
           .getDictionarySourceId()
           .equals(dictionaryColumn.getDictionarySourceId())) {
-        throw new IllegalArgumentException("dictionarySourceIds must be the same");
+        throw new IllegalArgumentException(Messages.get("error.read.dict_col_source_ids_mismatch"));
       }
 
       try {
@@ -594,7 +594,7 @@ public final class DictionaryColumn implements Column {
     for (int i = 0; i < positionCount; i++) {
       int newId = remapIndex[dictionaryColumn.getId(i)];
       if (newId == -1) {
-        throw new IllegalStateException("reference to a non-existent key");
+        throw new IllegalStateException(Messages.get("error.read.dict_col_nonexistent_key"));
       }
       newIds[i] = newId;
     }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/DoubleColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/DoubleColumn.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.read.common.block.column;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnEncoding;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
@@ -59,21 +60,21 @@ public class DoubleColumn implements Column {
 
   DoubleColumn(int arrayOffset, int positionCount, boolean[] valueIsNull, double[] values) {
     if (arrayOffset < 0) {
-      throw new IllegalArgumentException("arrayOffset is negative");
+      throw new IllegalArgumentException(Messages.get("error.read.col_array_offset_negative"));
     }
     this.arrayOffset = arrayOffset;
     if (positionCount < 0) {
-      throw new IllegalArgumentException("positionCount is negative");
+      throw new IllegalArgumentException(Messages.get("error.read.col_position_count_negative"));
     }
     this.positionCount = positionCount;
 
     if (values.length - arrayOffset < positionCount) {
-      throw new IllegalArgumentException("values length is less than positionCount");
+      throw new IllegalArgumentException(Messages.get("error.read.col_values_length_lt_position"));
     }
     this.values = values;
 
     if (valueIsNull != null && valueIsNull.length - arrayOffset < positionCount) {
-      throw new IllegalArgumentException("isNull length is less than positionCount");
+      throw new IllegalArgumentException(Messages.get("error.read.col_isnull_length_lt_position"));
     }
     this.valueIsNull = valueIsNull;
 
@@ -182,7 +183,7 @@ public class DoubleColumn implements Column {
   @Override
   public Column subColumn(int fromIndex) {
     if (fromIndex > positionCount) {
-      throw new IllegalArgumentException("fromIndex is not valid");
+      throw new IllegalArgumentException(Messages.get("error.read.col_from_index_invalid"));
     }
     return new DoubleColumn(
         arrayOffset + fromIndex, positionCount - fromIndex, valueIsNull, values);
@@ -191,7 +192,7 @@ public class DoubleColumn implements Column {
   @Override
   public Column subColumnCopy(int fromIndex) {
     if (fromIndex > positionCount) {
-      throw new IllegalArgumentException("fromIndex is not valid");
+      throw new IllegalArgumentException(Messages.get("error.read.col_from_index_invalid"));
     }
 
     int from = arrayOffset + fromIndex;

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/DoubleColumnBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/DoubleColumnBuilder.java
@@ -23,6 +23,7 @@ import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnBuilder;
 import org.apache.tsfile.block.column.ColumnBuilderStatus;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
 import org.apache.tsfile.write.UnSupportedDataTypeException;
@@ -104,7 +105,7 @@ public class DoubleColumnBuilder implements ColumnBuilder {
       writeDouble((Double) value);
       return this;
     }
-    throw new UnSupportedDataTypeException("DoubleColumn only support Double data type");
+    throw new UnSupportedDataTypeException(Messages.get("error.read.col_builder_double_type"));
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/FloatColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/FloatColumn.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.read.common.block.column;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnEncoding;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
@@ -60,21 +61,21 @@ public class FloatColumn implements Column {
 
   FloatColumn(int arrayOffset, int positionCount, boolean[] valueIsNull, float[] values) {
     if (arrayOffset < 0) {
-      throw new IllegalArgumentException("arrayOffset is negative");
+      throw new IllegalArgumentException(Messages.get("error.read.col_array_offset_negative"));
     }
     this.arrayOffset = arrayOffset;
     if (positionCount < 0) {
-      throw new IllegalArgumentException("positionCount is negative");
+      throw new IllegalArgumentException(Messages.get("error.read.col_position_count_negative"));
     }
     this.positionCount = positionCount;
 
     if (values.length - arrayOffset < positionCount) {
-      throw new IllegalArgumentException("values length is less than positionCount");
+      throw new IllegalArgumentException(Messages.get("error.read.col_values_length_lt_position"));
     }
     this.values = values;
 
     if (valueIsNull != null && valueIsNull.length - arrayOffset < positionCount) {
-      throw new IllegalArgumentException("isNull length is less than positionCount");
+      throw new IllegalArgumentException(Messages.get("error.read.col_isnull_length_lt_position"));
     }
     this.valueIsNull = valueIsNull;
 
@@ -197,7 +198,7 @@ public class FloatColumn implements Column {
   @Override
   public Column subColumn(int fromIndex) {
     if (fromIndex > positionCount) {
-      throw new IllegalArgumentException("fromIndex is not valid");
+      throw new IllegalArgumentException(Messages.get("error.read.col_from_index_invalid"));
     }
     return new FloatColumn(arrayOffset + fromIndex, positionCount - fromIndex, valueIsNull, values);
   }
@@ -205,7 +206,7 @@ public class FloatColumn implements Column {
   @Override
   public Column subColumnCopy(int fromIndex) {
     if (fromIndex > positionCount) {
-      throw new IllegalArgumentException("fromIndex is not valid");
+      throw new IllegalArgumentException(Messages.get("error.read.col_from_index_invalid"));
     }
 
     int from = arrayOffset + fromIndex;

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/FloatColumnBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/FloatColumnBuilder.java
@@ -23,6 +23,7 @@ import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnBuilder;
 import org.apache.tsfile.block.column.ColumnBuilderStatus;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
 import org.apache.tsfile.write.UnSupportedDataTypeException;
@@ -99,7 +100,7 @@ public class FloatColumnBuilder implements ColumnBuilder {
       writeFloat((Float) value);
       return this;
     }
-    throw new UnSupportedDataTypeException("FloatColumn only support Float data type");
+    throw new UnSupportedDataTypeException(Messages.get("error.read.col_builder_float_type"));
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/Int32ArrayColumnEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/Int32ArrayColumnEncoder.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.read.common.block.column;
 
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -71,7 +72,8 @@ public class Int32ArrayColumnEncoder implements ColumnEncoder {
         }
         return new FloatColumn(0, positionCount, nullIndicators, floatValues);
       default:
-        throw new IllegalArgumentException("Invalid data type: " + dataType);
+        throw new IllegalArgumentException(
+            Messages.format("error.read.col_encoder_invalid_type", dataType));
     }
   }
 
@@ -111,7 +113,8 @@ public class Int32ArrayColumnEncoder implements ColumnEncoder {
         }
         break;
       default:
-        throw new IllegalArgumentException("Invalid data type: " + dataType);
+        throw new IllegalArgumentException(
+            Messages.format("error.read.col_encoder_invalid_type", dataType));
     }
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/Int64ArrayColumnEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/Int64ArrayColumnEncoder.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.read.common.block.column;
 
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -70,7 +71,8 @@ public class Int64ArrayColumnEncoder implements ColumnEncoder {
         }
         return new DoubleColumn(0, positionCount, nullIndicators, doubleValues);
       default:
-        throw new IllegalArgumentException("Invalid data type: " + dataType);
+        throw new IllegalArgumentException(
+            Messages.format("error.read.col_encoder_invalid_type", dataType));
     }
   }
 
@@ -98,7 +100,8 @@ public class Int64ArrayColumnEncoder implements ColumnEncoder {
         }
         break;
       default:
-        throw new IllegalArgumentException("Invalid data type: " + dataType);
+        throw new IllegalArgumentException(
+            Messages.format("error.read.col_encoder_invalid_type", dataType));
     }
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/IntColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/IntColumn.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.read.common.block.column;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnEncoding;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
@@ -73,21 +74,21 @@ public class IntColumn implements Column {
 
   IntColumn(int arrayOffset, int positionCount, boolean[] valueIsNull, int[] values) {
     if (arrayOffset < 0) {
-      throw new IllegalArgumentException("arrayOffset is negative");
+      throw new IllegalArgumentException(Messages.get("error.read.col_array_offset_negative"));
     }
     this.arrayOffset = arrayOffset;
     if (positionCount < 0) {
-      throw new IllegalArgumentException("positionCount is negative");
+      throw new IllegalArgumentException(Messages.get("error.read.col_position_count_negative"));
     }
     this.positionCount = positionCount;
 
     if (values.length - arrayOffset < positionCount) {
-      throw new IllegalArgumentException("values length is less than positionCount");
+      throw new IllegalArgumentException(Messages.get("error.read.col_values_length_lt_position"));
     }
     this.values = values;
 
     if (valueIsNull != null && valueIsNull.length - arrayOffset < positionCount) {
-      throw new IllegalArgumentException("isNull length is less than positionCount");
+      throw new IllegalArgumentException(Messages.get("error.read.col_isnull_length_lt_position"));
     }
     this.valueIsNull = valueIsNull;
 
@@ -252,7 +253,7 @@ public class IntColumn implements Column {
   @Override
   public Column subColumn(int fromIndex) {
     if (fromIndex > positionCount) {
-      throw new IllegalArgumentException("fromIndex is not valid");
+      throw new IllegalArgumentException(Messages.get("error.read.col_from_index_invalid"));
     }
     return new IntColumn(
         arrayOffset + fromIndex, positionCount - fromIndex, valueIsNull, values, dataType);
@@ -261,7 +262,7 @@ public class IntColumn implements Column {
   @Override
   public Column subColumnCopy(int fromIndex) {
     if (fromIndex > positionCount) {
-      throw new IllegalArgumentException("fromIndex is not valid");
+      throw new IllegalArgumentException(Messages.get("error.read.col_from_index_invalid"));
     }
 
     int from = arrayOffset + fromIndex;

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/IntColumnBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/IntColumnBuilder.java
@@ -23,6 +23,7 @@ import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnBuilder;
 import org.apache.tsfile.block.column.ColumnBuilderStatus;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.DateUtils;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
@@ -102,7 +103,7 @@ public class IntColumnBuilder implements ColumnBuilder {
       writeInt(DateUtils.parseDateExpressionToInt((LocalDate) value));
       return this;
     }
-    throw new UnSupportedDataTypeException("IntegerColumn only support Integer data type");
+    throw new UnSupportedDataTypeException(Messages.get("error.read.col_builder_int_type"));
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/LongColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/LongColumn.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.read.common.block.column;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnEncoding;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
@@ -60,21 +61,21 @@ public class LongColumn implements Column {
 
   LongColumn(int arrayOffset, int positionCount, boolean[] valueIsNull, long[] values) {
     if (arrayOffset < 0) {
-      throw new IllegalArgumentException("arrayOffset is negative");
+      throw new IllegalArgumentException(Messages.get("error.read.col_array_offset_negative"));
     }
     this.arrayOffset = arrayOffset;
     if (positionCount < 0) {
-      throw new IllegalArgumentException("positionCount is negative");
+      throw new IllegalArgumentException(Messages.get("error.read.col_position_count_negative"));
     }
     this.positionCount = positionCount;
 
     if (values.length - arrayOffset < positionCount) {
-      throw new IllegalArgumentException("values length is less than positionCount");
+      throw new IllegalArgumentException(Messages.get("error.read.col_values_length_lt_position"));
     }
     this.values = values;
 
     if (valueIsNull != null && valueIsNull.length - arrayOffset < positionCount) {
-      throw new IllegalArgumentException("isNull length is less than positionCount");
+      throw new IllegalArgumentException(Messages.get("error.read.col_isnull_length_lt_position"));
     }
     this.valueIsNull = valueIsNull;
 
@@ -197,7 +198,7 @@ public class LongColumn implements Column {
   @Override
   public Column subColumn(int fromIndex) {
     if (fromIndex > positionCount) {
-      throw new IllegalArgumentException("fromIndex is not valid");
+      throw new IllegalArgumentException(Messages.get("error.read.col_from_index_invalid"));
     }
     return new LongColumn(arrayOffset + fromIndex, positionCount - fromIndex, valueIsNull, values);
   }
@@ -205,7 +206,7 @@ public class LongColumn implements Column {
   @Override
   public Column subColumnCopy(int fromIndex) {
     if (fromIndex > positionCount) {
-      throw new IllegalArgumentException("fromIndex is not valid");
+      throw new IllegalArgumentException(Messages.get("error.read.col_from_index_invalid"));
     }
 
     int from = arrayOffset + fromIndex;

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/LongColumnBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/LongColumnBuilder.java
@@ -23,6 +23,7 @@ import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnBuilder;
 import org.apache.tsfile.block.column.ColumnBuilderStatus;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
 import org.apache.tsfile.write.UnSupportedDataTypeException;
@@ -94,7 +95,7 @@ public class LongColumnBuilder implements ColumnBuilder {
       writeLong((Long) value);
       return this;
     }
-    throw new UnSupportedDataTypeException("LongColumn only support Long data type");
+    throw new UnSupportedDataTypeException(Messages.get("error.read.col_builder_long_type"));
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/NullColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/NullColumn.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.read.common.block.column;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnEncoding;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.RamUsageEstimator;
 
 import static java.util.Objects.requireNonNull;
@@ -44,7 +45,7 @@ public class NullColumn implements Column {
 
   public NullColumn(int positionCount) {
     if (positionCount < 0) {
-      throw new IllegalArgumentException("positionCount is negative");
+      throw new IllegalArgumentException(Messages.get("error.read.col_position_count_negative"));
     }
     this.positionCount = positionCount;
     retainedSizeInBytes = INSTANCE_SIZE;
@@ -104,7 +105,7 @@ public class NullColumn implements Column {
   @Override
   public Column subColumn(int fromIndex) {
     if (fromIndex > positionCount) {
-      throw new IllegalArgumentException("fromIndex is not valid");
+      throw new IllegalArgumentException(Messages.get("error.read.col_from_index_invalid"));
     }
     return new NullColumn(positionCount - fromIndex);
   }
@@ -157,7 +158,8 @@ public class NullColumn implements Column {
       case OBJECT:
         return new RunLengthEncodedColumn(BinaryColumnBuilder.NULL_VALUE_BLOCK, positionCount);
       default:
-        throw new IllegalArgumentException("Unknown data type: " + dataType);
+        throw new IllegalArgumentException(
+            Messages.format("error.read.null_col_unknown_type", dataType));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/RunLengthColumnEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/RunLengthColumnEncoder.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.read.common.block.column;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnEncoding;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -46,7 +47,7 @@ public class RunLengthColumnEncoder implements ColumnEncoder {
   public void writeColumn(DataOutputStream output, Column column) throws IOException {
     Column innerColumn = ((RunLengthEncodedColumn) column).getValue();
     if (innerColumn instanceof RunLengthEncodedColumn) {
-      throw new IOException("Unable to encode a nested RLE column.");
+      throw new IOException(Messages.get("error.read.rle_encoder_nested"));
     }
 
     innerColumn.getEncoding().serializeTo(output);

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/RunLengthEncodedColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/RunLengthEncodedColumn.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.read.common.block.column;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnEncoding;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.TsPrimitiveType;
@@ -45,9 +46,7 @@ public class RunLengthEncodedColumn implements Column {
     requireNonNull(value, "value is null");
     if (value.getPositionCount() != 1) {
       throw new IllegalArgumentException(
-          String.format(
-              "Expected value to contain a single position but has %s positions",
-              value.getPositionCount()));
+          Messages.format("error.read.rle_col_expected_single", value.getPositionCount()));
     }
 
     if (value instanceof RunLengthEncodedColumn) {
@@ -57,7 +56,7 @@ public class RunLengthEncodedColumn implements Column {
     }
 
     if (positionCount < 0) {
-      throw new IllegalArgumentException("positionCount is negative");
+      throw new IllegalArgumentException(Messages.get("error.read.col_position_count_negative"));
     }
 
     this.positionCount = positionCount;
@@ -214,7 +213,7 @@ public class RunLengthEncodedColumn implements Column {
   @Override
   public Column subColumn(int fromIndex) {
     if (fromIndex > positionCount) {
-      throw new IllegalArgumentException("fromIndex is not valid");
+      throw new IllegalArgumentException(Messages.get("error.read.col_from_index_invalid"));
     }
     return new RunLengthEncodedColumn(value, positionCount - fromIndex);
   }
@@ -222,7 +221,7 @@ public class RunLengthEncodedColumn implements Column {
   @Override
   public Column subColumnCopy(int fromIndex) {
     if (fromIndex > positionCount) {
-      throw new IllegalArgumentException("fromIndex is not valid");
+      throw new IllegalArgumentException(Messages.get("error.read.col_from_index_invalid"));
     }
     Column valueCopy = value.subColumnCopy(0);
     return new RunLengthEncodedColumn(valueCopy, positionCount - fromIndex);
@@ -266,7 +265,8 @@ public class RunLengthEncodedColumn implements Column {
   @Override
   public void setNull(int start, int end) {
     throw new UnsupportedOperationException(
-        String.format(
-            "set null of %s is not supported !", RunLengthEncodedColumn.class.getSimpleName()));
+        Messages.format(
+            "error.read.rle_col_set_null_unsupported",
+            RunLengthEncodedColumn.class.getSimpleName()));
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TimeColumn.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TimeColumn.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.read.common.block.column;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnEncoding;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.RamUsageEstimator;
 
 import java.util.Arrays;
@@ -53,16 +54,16 @@ public class TimeColumn implements Column {
 
   TimeColumn(int arrayOffset, int positionCount, long[] values) {
     if (arrayOffset < 0) {
-      throw new IllegalArgumentException("arrayOffset is negative");
+      throw new IllegalArgumentException(Messages.get("error.read.col_array_offset_negative"));
     }
     this.arrayOffset = arrayOffset;
     if (positionCount < 0) {
-      throw new IllegalArgumentException("positionCount is negative");
+      throw new IllegalArgumentException(Messages.get("error.read.col_position_count_negative"));
     }
     this.positionCount = positionCount;
 
     if (values.length - arrayOffset < positionCount) {
-      throw new IllegalArgumentException("values length is less than positionCount");
+      throw new IllegalArgumentException(Messages.get("error.read.col_values_length_lt_position"));
     }
     this.values = values;
 
@@ -100,7 +101,8 @@ public class TimeColumn implements Column {
 
   @Override
   public boolean[] isNull() {
-    throw new UnsupportedOperationException("isNull is not supported for TimeColumn");
+    throw new UnsupportedOperationException(
+        Messages.get("error.read.time_column_isnull_unsupported"));
   }
 
   @Override
@@ -138,7 +140,7 @@ public class TimeColumn implements Column {
   @Override
   public Column subColumn(int fromIndex) {
     if (fromIndex > positionCount) {
-      throw new IllegalArgumentException("fromIndex is not valid");
+      throw new IllegalArgumentException(Messages.get("error.read.col_from_index_invalid"));
     }
     return new TimeColumn(arrayOffset + fromIndex, positionCount - fromIndex, values);
   }
@@ -146,7 +148,7 @@ public class TimeColumn implements Column {
   @Override
   public Column subColumnCopy(int fromIndex) {
     if (fromIndex > positionCount) {
-      throw new IllegalArgumentException("fromIndex is not valid");
+      throw new IllegalArgumentException(Messages.get("error.read.col_from_index_invalid"));
     }
 
     int from = arrayOffset + fromIndex;

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TimeColumnBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TimeColumnBuilder.java
@@ -23,6 +23,7 @@ import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnBuilder;
 import org.apache.tsfile.block.column.ColumnBuilderStatus;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.write.UnSupportedDataTypeException;
 
@@ -81,7 +82,7 @@ public class TimeColumnBuilder implements ColumnBuilder {
       writeLong((Long) value);
       return this;
     }
-    throw new UnSupportedDataTypeException("LongColumn only support Long data type");
+    throw new UnSupportedDataTypeException(Messages.get("error.read.col_builder_long_type"));
   }
 
   @Override
@@ -150,7 +151,8 @@ public class TimeColumnBuilder implements ColumnBuilder {
 
   private void checkReadablePosition(int position) {
     if (position < 0 || position >= getPositionCount()) {
-      throw new IllegalArgumentException("position is not valid");
+      throw new IllegalArgumentException(
+          Messages.get("error.read.time_col_builder_position_invalid"));
     }
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TsBlockSerde.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/block/column/TsBlockSerde.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.read.common.block.column;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.block.column.ColumnEncoding;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.block.TsBlock;
 
 import java.io.ByteArrayOutputStream;
@@ -92,7 +93,7 @@ public class TsBlockSerde {
   public ByteBuffer serialize(TsBlock tsBlock) throws IOException {
     if (tsBlock.getSizeInBytes() > Integer.MAX_VALUE) {
       throw new IllegalStateException(
-          "TsBlock should not be that large: " + tsBlock.getSizeInBytes());
+          Messages.format("error.read.tsblock_too_large", tsBlock.getSizeInBytes()));
     }
     ByteArrayOutputStream byteArrayOutputStream =
         new ByteArrayOutputStream((int) tsBlock.getSizeInBytes());

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/parser/PathParseError.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/parser/PathParseError.java
@@ -19,6 +19,8 @@
 
 package org.apache.tsfile.read.common.parser;
 
+import org.apache.tsfile.i18n.Messages;
+
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.RecognitionException;
@@ -58,6 +60,7 @@ public class PathParseError extends BaseErrorListener {
         }
       }
     }
-    throw new ParseCancellationException("line " + line + ":" + charPositionInLine + " " + msg);
+    throw new ParseCancellationException(
+        Messages.format("error.read.path_parse_error", line, charPositionInLine, msg));
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/common/type/TypeFactory.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/common/type/TypeFactory.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.read.common.type;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 
 public class TypeFactory {
 
@@ -53,7 +54,7 @@ public class TypeFactory {
         return ObjectType.getInstance();
       default:
         throw new UnsupportedOperationException(
-            String.format("Invalid TSDataType for TypeFactory: %s", tsDataType));
+            Messages.format("error.read.typefactory_invalid_tsdata_type", tsDataType));
     }
   }
 
@@ -83,7 +84,7 @@ public class TypeFactory {
         return StringType.getInstance();
       default:
         throw new UnsupportedOperationException(
-            String.format("Invalid TypeEnum for TypeFactory: %s", typeEnum));
+            Messages.format("error.read.typefactory_invalid_type_enum", typeEnum));
     }
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/controller/DeviceMetaIterator.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/controller/DeviceMetaIterator.java
@@ -23,6 +23,7 @@ import org.apache.tsfile.file.metadata.DeviceMetadataIndexEntry;
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.file.metadata.MetadataIndexNode;
 import org.apache.tsfile.file.metadata.enums.MetadataIndexNodeType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.TsFileSequenceReader;
 import org.apache.tsfile.read.filter.basic.Filter;
 import org.apache.tsfile.utils.Pair;
@@ -62,7 +63,7 @@ public class DeviceMetaIterator implements Iterator<Pair<IDeviceID, MetadataInde
     try {
       loadResults();
     } catch (IOException e) {
-      LOGGER.error("Failed to load device meta data", e);
+      LOGGER.error(Messages.get("log.read.device_meta_iterator_error"), e);
       return false;
     }
 
@@ -120,7 +121,8 @@ public class DeviceMetaIterator implements Iterator<Pair<IDeviceID, MetadataInde
           loadInternalNode(currentNode);
           break;
         default:
-          throw new IOException("A non-device node detected: " + currentNode);
+          throw new IOException(
+              Messages.format("error.read.non_device_node_detected", currentNode));
       }
     }
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/controller/MetadataQuerierByFileImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/controller/MetadataQuerierByFileImpl.java
@@ -30,6 +30,7 @@ import org.apache.tsfile.file.metadata.MetadataIndexNode;
 import org.apache.tsfile.file.metadata.TableSchema;
 import org.apache.tsfile.file.metadata.TimeseriesMetadata;
 import org.apache.tsfile.file.metadata.TsFileMetadata;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.TsFileSequenceReader;
 import org.apache.tsfile.read.TsFileSequenceReader.LocateStatus;
 import org.apache.tsfile.read.common.Path;
@@ -209,8 +210,7 @@ public class MetadataQuerierByFileImpl implements IMetadataQuerier {
   public List<TimeRange> convertSpace2TimePartition(
       List<Path> paths, long spacePartitionStartPos, long spacePartitionEndPos) throws IOException {
     if (spacePartitionStartPos > spacePartitionEndPos) {
-      throw new IllegalArgumentException(
-          "'spacePartitionStartPos' should not be larger than 'spacePartitionEndPos'.");
+      throw new IllegalArgumentException(Messages.get("error.read.metadata_querier_illegal_arg"));
     }
 
     // (1) get timeRangesInCandidates and timeRangesBeforeCandidates by iterating

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/expression/util/ExpressionOptimizer.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/expression/util/ExpressionOptimizer.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.read.expression.util;
 
 import org.apache.tsfile.exception.filter.QueryFilterOptimizationException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.Path;
 import org.apache.tsfile.read.expression.ExpressionType;
 import org.apache.tsfile.read.expression.IBinaryExpression;
@@ -80,7 +81,8 @@ public class ExpressionOptimizer {
           } else if (relation == ExpressionType.OR) {
             midRet = BinaryExpression.or(regularLeft, regularRight);
           } else {
-            throw new UnsupportedOperationException("unsupported IExpression type: " + relation);
+            throw new UnsupportedOperationException(
+                Messages.format("error.read.expression_unsupported_binary_type", relation));
           }
           if (midRet.getLeft().getType() == ExpressionType.GLOBAL_TIME
               || midRet.getRight().getType() == ExpressionType.GLOBAL_TIME) {
@@ -89,12 +91,13 @@ public class ExpressionOptimizer {
             return midRet;
           }
         } catch (StackOverflowError stackOverflowError) {
-          throw new QueryFilterOptimizationException("StackOverflowError is encountered.");
+          throw new QueryFilterOptimizationException(
+              Messages.get("error.read.expression_stack_overflow"));
         }
       }
     }
     throw new UnsupportedOperationException(
-        "unknown IExpression type: " + expression.getClass().getName());
+        Messages.format("error.read.expression_unknown_type", expression.getClass().getName()));
   }
 
   private IExpression handleOneGlobalTimeFilter(
@@ -116,7 +119,8 @@ public class ExpressionOptimizer {
           pushGlobalTimeFilterToAllSeries(globalTimeExpression, selectedSeries);
       return mergeSecondTreeToFirstTree(afterTransform, regularRightIExpression);
     }
-    throw new QueryFilterOptimizationException("unknown relation in IExpression:" + relation);
+    throw new QueryFilterOptimizationException(
+        Messages.format("error.read.expression_unknown_relation", relation));
   }
 
   /**
@@ -181,7 +185,8 @@ public class ExpressionOptimizer {
       GlobalTimeExpression timeFilter, List<Path> selectedSeries)
       throws QueryFilterOptimizationException {
     if (selectedSeries.isEmpty()) {
-      throw new QueryFilterOptimizationException("size of selectSeries could not be 0");
+      throw new QueryFilterOptimizationException(
+          Messages.get("error.read.expression_empty_select_series"));
     }
     IExpression expression =
         new SingleSeriesExpression(selectedSeries.get(0), timeFilter.getFilter());
@@ -203,8 +208,8 @@ public class ExpressionOptimizer {
       addTimeFilterToQueryFilter(timeFilter, ((BinaryExpression) expression).getRight());
     } else {
       throw new UnsupportedOperationException(
-          "IExpression should contains only SingleSeriesExpression but other type is found:"
-              + expression.getClass().getName());
+          Messages.format(
+              "error.read.expression_unexpected_type", expression.getClass().getName()));
     }
   }
 
@@ -230,7 +235,8 @@ public class ExpressionOptimizer {
     } else if (type == ExpressionType.OR) {
       return new GlobalTimeExpression(FilterFactory.or(left.getFilter(), right.getFilter()));
     }
-    throw new UnsupportedOperationException("unrecognized QueryFilterOperatorType :" + type);
+    throw new UnsupportedOperationException(
+        Messages.format("error.read.expression_unrecognized_operator", type));
   }
 
   private static class QueryFilterOptimizerHelper {

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/filter/basic/Filter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/filter/basic/Filter.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.read.filter.basic;
 
 import org.apache.tsfile.file.metadata.IMetadata;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.TimeRange;
 import org.apache.tsfile.read.common.block.TsBlock;
 import org.apache.tsfile.read.filter.factory.FilterFactory;
@@ -298,7 +299,8 @@ public abstract class Filter {
       case EXTRACT_VALUE_LTEQ:
         return new ExtractValueFilterOperators.ExtractValueLtEq(buffer);
       default:
-        throw new UnsupportedOperationException("Unsupported operator type:" + type);
+        throw new UnsupportedOperationException(
+            Messages.format("error.read.filter_unsupported_operator", type));
     }
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/filter/basic/ValueFilter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/filter/basic/ValueFilter.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.read.filter.basic;
 
 import org.apache.tsfile.file.metadata.IMetadata;
 import org.apache.tsfile.file.metadata.statistics.Statistics;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.TimeRange;
 import org.apache.tsfile.read.common.block.TsBlock;
 import org.apache.tsfile.utils.Binary;
@@ -175,7 +176,7 @@ public abstract class ValueFilter extends Filter {
 
   @Override
   public List<TimeRange> getTimeRanges() {
-    throw new UnsupportedOperationException("Value filter does not support getTimeRanges()");
+    throw new UnsupportedOperationException(Messages.get("error.read.value_filter_no_time_ranges"));
   }
 
   protected abstract ClassSerializeId getClassSerializeId();

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/filter/factory/TagFilterBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/filter/factory/TagFilterBuilder.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.read.filter.factory;
 import org.apache.tsfile.annotations.TsFileApi;
 import org.apache.tsfile.common.regexp.LikePattern;
 import org.apache.tsfile.file.metadata.TableSchema;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.filter.basic.Filter;
 import org.apache.tsfile.read.filter.operator.And;
 import org.apache.tsfile.read.filter.operator.Not;
@@ -43,7 +44,8 @@ public class TagFilterBuilder {
   private int getIdColumnIndex(String columnName) {
     int idColumnOrder = tableSchema.findIdColumnOrder(columnName);
     if (idColumnOrder == -1) {
-      throw new IllegalArgumentException("Column '" + columnName + "' is not a tag column");
+      throw new IllegalArgumentException(
+          Messages.format("error.read.tag_not_a_tag_column", columnName));
     }
     return idColumnOrder + 1;
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/filter/factory/ValueFilterApi.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/filter/factory/ValueFilterApi.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.read.filter.factory;
 
 import org.apache.tsfile.common.regexp.LikePattern;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.filter.basic.Filter;
 import org.apache.tsfile.read.filter.operator.BinaryFilterOperators;
 import org.apache.tsfile.read.filter.operator.BooleanFilterOperators;
@@ -74,7 +75,8 @@ public class ValueFilterApi {
       case STRING:
         return new StringFilterOperators.ValueGt(measurementIndex, (Binary) value);
       default:
-        throw new UnsupportedOperationException("Unsupported data type: " + type);
+        throw new UnsupportedOperationException(
+            Messages.format("error.read.filter_api_unsupported_type", type));
     }
   }
 
@@ -101,7 +103,8 @@ public class ValueFilterApi {
       case STRING:
         return new StringFilterOperators.ValueGtEq(measurementIndex, (Binary) value);
       default:
-        throw new UnsupportedOperationException("Unsupported data type: " + type);
+        throw new UnsupportedOperationException(
+            Messages.format("error.read.filter_api_unsupported_type", type));
     }
   }
 
@@ -127,7 +130,8 @@ public class ValueFilterApi {
       case STRING:
         return new StringFilterOperators.ValueLt(measurementIndex, (Binary) value);
       default:
-        throw new UnsupportedOperationException("Unsupported data type: " + type);
+        throw new UnsupportedOperationException(
+            Messages.format("error.read.filter_api_unsupported_type", type));
     }
   }
 
@@ -154,7 +158,8 @@ public class ValueFilterApi {
       case STRING:
         return new StringFilterOperators.ValueLtEq(measurementIndex, (Binary) value);
       default:
-        throw new UnsupportedOperationException("Unsupported data type: " + type);
+        throw new UnsupportedOperationException(
+            Messages.format("error.read.filter_api_unsupported_type", type));
     }
   }
 
@@ -180,7 +185,8 @@ public class ValueFilterApi {
       case STRING:
         return new StringFilterOperators.ValueEq(measurementIndex, (Binary) value);
       default:
-        throw new UnsupportedOperationException("Unsupported data type: " + type);
+        throw new UnsupportedOperationException(
+            Messages.format("error.read.filter_api_unsupported_type", type));
     }
   }
 
@@ -207,7 +213,8 @@ public class ValueFilterApi {
       case STRING:
         return new StringFilterOperators.ValueNotEq(measurementIndex, (Binary) value);
       default:
-        throw new UnsupportedOperationException("Unsupported data type: " + type);
+        throw new UnsupportedOperationException(
+            Messages.format("error.read.filter_api_unsupported_type", type));
     }
   }
 
@@ -250,7 +257,8 @@ public class ValueFilterApi {
         return new StringFilterOperators.ValueBetweenAnd(
             measurementIndex, (Binary) value1, (Binary) value2);
       default:
-        throw new UnsupportedOperationException("Unsupported data type: " + type);
+        throw new UnsupportedOperationException(
+            Messages.format("error.read.filter_api_unsupported_type", type));
     }
   }
 
@@ -285,7 +293,8 @@ public class ValueFilterApi {
         return new StringFilterOperators.ValueNotBetweenAnd(
             measurementIndex, (Binary) value1, (Binary) value2);
       default:
-        throw new UnsupportedOperationException("Unsupported data type: " + type);
+        throw new UnsupportedOperationException(
+            Messages.format("error.read.filter_api_unsupported_type", type));
     }
   }
 
@@ -310,7 +319,8 @@ public class ValueFilterApi {
       case STRING:
         return new StringFilterOperators.ValueLike(measurementIndex, pattern);
       default:
-        throw new UnsupportedOperationException("Unsupported data type: " + type);
+        throw new UnsupportedOperationException(
+            Messages.format("error.read.filter_api_unsupported_type", type));
     }
   }
 
@@ -335,7 +345,8 @@ public class ValueFilterApi {
       case STRING:
         return new StringFilterOperators.ValueNotLike(measurementIndex, pattern);
       default:
-        throw new UnsupportedOperationException("Unsupported data type: " + type);
+        throw new UnsupportedOperationException(
+            Messages.format("error.read.filter_api_unsupported_type", type));
     }
   }
 
@@ -360,7 +371,8 @@ public class ValueFilterApi {
       case STRING:
         return new StringFilterOperators.ValueRegexp(measurementIndex, pattern);
       default:
-        throw new UnsupportedOperationException("Unsupported data type: " + type);
+        throw new UnsupportedOperationException(
+            Messages.format("error.read.filter_api_unsupported_type", type));
     }
   }
 
@@ -385,7 +397,8 @@ public class ValueFilterApi {
       case STRING:
         return new StringFilterOperators.ValueNotRegexp(measurementIndex, pattern);
       default:
-        throw new UnsupportedOperationException("Unsupported data type: " + type);
+        throw new UnsupportedOperationException(
+            Messages.format("error.read.filter_api_unsupported_type", type));
     }
   }
 
@@ -412,7 +425,8 @@ public class ValueFilterApi {
       case STRING:
         return new StringFilterOperators.ValueIn(measurementIndex, (Set<Binary>) values);
       default:
-        throw new UnsupportedOperationException("Unsupported data type: " + type);
+        throw new UnsupportedOperationException(
+            Messages.format("error.read.filter_api_unsupported_type", type));
     }
   }
 
@@ -439,7 +453,8 @@ public class ValueFilterApi {
       case STRING:
         return new StringFilterOperators.ValueNotIn(measurementIndex, (Set<Binary>) values);
       default:
-        throw new UnsupportedOperationException("Unsupported data type: " + type);
+        throw new UnsupportedOperationException(
+            Messages.format("error.read.filter_api_unsupported_type", type));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/filter/operator/ExtractTimeFilterOperators.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/filter/operator/ExtractTimeFilterOperators.java
@@ -19,6 +19,7 @@
 
 package org.apache.tsfile.read.filter.operator;
 
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.TimeRange;
 import org.apache.tsfile.read.filter.basic.Filter;
 import org.apache.tsfile.read.filter.basic.OperatorType;
@@ -174,7 +175,8 @@ public final class ExtractTimeFilterOperators {
         case NS:
           return EXTRACT_TIMESTAMP_NS_PART;
         default:
-          throw new UnsupportedOperationException("Unexpected extract field: " + field);
+          throw new UnsupportedOperationException(
+              Messages.format("error.read.extract_unexpected_field", field));
       }
     }
 
@@ -263,7 +265,8 @@ public final class ExtractTimeFilterOperators {
                   .equals(
                       convertToZonedDateTime(timestamp2, zoneId).truncatedTo(ChronoUnit.MICROS));
         default:
-          throw new UnsupportedOperationException("Unexpected extract field: " + field);
+          throw new UnsupportedOperationException(
+              Messages.format("error.read.extract_unexpected_field", field));
       }
     }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/filter/operator/Not.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/filter/operator/Not.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.read.filter.operator;
 
 import org.apache.tsfile.file.metadata.IMetadata;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.TimeRange;
 import org.apache.tsfile.read.common.block.TsBlock;
 import org.apache.tsfile.read.filter.basic.Filter;
@@ -148,23 +149,23 @@ public class Not extends Filter {
     // [not filter.canSkip(block)] is not equivalent to [notFilter.canSkip(block)]
     // e.g. block min = 5, max = 15, filter = [value > 10], notFilter = [value <= 10)]
     //  not filter.canSkip(block) = true (expected false), notFilter.canSkip(block) = false
-    throw new IllegalArgumentException(CONTAIN_NOT_ERR_MSG + this);
+    throw new IllegalArgumentException(Messages.format("error.read.filter_contains_not", this));
   }
 
   @Override
   public boolean allSatisfy(IMetadata metadata) {
     // same as canSkip
-    throw new IllegalArgumentException(CONTAIN_NOT_ERR_MSG + this);
+    throw new IllegalArgumentException(Messages.format("error.read.filter_contains_not", this));
   }
 
   @Override
   public boolean satisfyStartEndTime(long startTime, long endTime) {
-    throw new IllegalArgumentException(CONTAIN_NOT_ERR_MSG + this);
+    throw new IllegalArgumentException(Messages.format("error.read.filter_contains_not", this));
   }
 
   @Override
   public boolean containStartEndTime(long startTime, long endTime) {
-    throw new IllegalArgumentException(CONTAIN_NOT_ERR_MSG + this);
+    throw new IllegalArgumentException(Messages.format("error.read.filter_contains_not", this));
   }
 
   public Filter getFilter() {

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/filter/operator/TimeFilterOperators.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/filter/operator/TimeFilterOperators.java
@@ -19,6 +19,7 @@
 
 package org.apache.tsfile.read.filter.operator;
 
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.TimeRange;
 import org.apache.tsfile.read.filter.basic.Filter;
 import org.apache.tsfile.read.filter.basic.OperatorType;
@@ -513,7 +514,7 @@ public final class TimeFilterOperators {
     public void serialize(DataOutputStream outputStream) throws IOException {
       super.serialize(outputStream);
       if (candidates == null) {
-        throw new IllegalArgumentException("set must not be null!");
+        throw new IllegalArgumentException(Messages.get("error.read.filter_timein_set_null"));
       }
       ReadWriteIOUtils.writeLongSet(candidates, outputStream);
     }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/query/dataset/AbstractResultSet.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/query/dataset/AbstractResultSet.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.read.query.dataset;
 import org.apache.tsfile.annotations.TsFileApi;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.NullFieldException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.Field;
 import org.apache.tsfile.read.common.RowRecord;
 
@@ -149,7 +150,7 @@ public abstract class AbstractResultSet implements ResultSet {
     Integer columnIndex = columnNameToColumnIndexMap.get(columnName);
     if (columnIndex == null) {
       throw new IllegalArgumentException(
-          "Can't find columnName " + columnName + " from result set");
+          Messages.format("error.read.result_set_column_not_found", columnName));
     }
     return isNull(columnIndex);
   }
@@ -162,14 +163,16 @@ public abstract class AbstractResultSet implements ResultSet {
   protected Field getNonNullField(int columnIndex) {
     Field field = getField(columnIndex);
     if (field == null) {
-      throw new NullFieldException("Field in columnIndex " + columnIndex + " is null");
+      throw new NullFieldException(
+          Messages.format("error.read.result_set_null_field", columnIndex));
     }
     return field;
   }
 
   protected Field getField(int columnIndex) {
     if (columnIndex > this.columnNameToColumnIndexMap.size() || columnIndex <= 0) {
-      throw new IndexOutOfBoundsException("column index " + columnIndex + " out of bound");
+      throw new IndexOutOfBoundsException(
+          Messages.format("error.read.result_set_index_out_of_bound", columnIndex));
     }
     Field field;
     if (columnIndex == 1) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/query/dataset/DataSetWithoutTimeGenerator.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/query/dataset/DataSetWithoutTimeGenerator.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.read.query.dataset;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.BatchData;
 import org.apache.tsfile.read.common.Field;
 import org.apache.tsfile.read.common.Path;
@@ -186,7 +187,8 @@ public class DataSetWithoutTimeGenerator extends QueryDataSet {
         Field.setTsPrimitiveValue((col.getVector())[0], field);
         break;
       default:
-        throw new UnSupportedDataTypeException("UnSupported" + col.getDataType());
+        throw new UnSupportedDataTypeException(
+            Messages.format("error.read.dataset_unsupported_type", col.getDataType()));
     }
     return field;
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/query/dataset/TableResultSet.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/query/dataset/TableResultSet.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.read.query.dataset;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.block.TsBlock;
 import org.apache.tsfile.read.reader.block.TsBlockReader;
 import org.apache.tsfile.utils.DateUtils;
@@ -139,7 +140,7 @@ public class TableResultSet extends AbstractResultSet {
     try {
       tsBlockReader.close();
     } catch (Exception e) {
-      LOG.error("Failed to close tsBlockReader");
+      LOG.error(Messages.get("log.read.table_result_set_close_error"));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/query/timegenerator/TimeGenerator.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/query/timegenerator/TimeGenerator.java
@@ -19,6 +19,7 @@
 
 package org.apache.tsfile.read.query.timegenerator;
 
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.Path;
 import org.apache.tsfile.read.expression.ExpressionType;
 import org.apache.tsfile.read.expression.IBinaryExpression;
@@ -71,12 +72,10 @@ public abstract class TimeGenerator {
   /** ATTENTION: this method should only be used when there is no `OR` node */
   public Object[] getValues(Path path) throws IOException {
     if (hasOrNode) {
-      throw new IOException(
-          "getValues() method should not be invoked when there is OR operator in where clause");
+      throw new IOException(Messages.get("error.read.time_generator_or_get_values"));
     }
     if (leafValuesCache.get(path) == null) {
-      throw new IOException(
-          "getValues() method should not be invoked by non-existent path in where clause");
+      throw new IOException(Messages.get("error.read.time_generator_path_not_found_values"));
     }
     return leafValuesCache.remove(path).toArray();
   }
@@ -84,12 +83,10 @@ public abstract class TimeGenerator {
   /** ATTENTION: this method should only be used when there is no `OR` node */
   public Object getValue(Path path) throws IOException {
     if (hasOrNode) {
-      throw new IOException(
-          "getValue() method should not be invoked when there is OR operator in where clause");
+      throw new IOException(Messages.get("error.read.time_generator_or_get_value"));
     }
     if (leafValuesCache.get(path) == null) {
-      throw new IOException(
-          "getValue() method should not be invoked by non-existent path in where clause");
+      throw new IOException(Messages.get("error.read.time_generator_path_not_found_value"));
     }
     return leafValuesCache.get(path).remove(0);
   }
@@ -122,7 +119,8 @@ public abstract class TimeGenerator {
         return new AndNode(leftChild, rightChild, isAscending());
       }
       throw new UnSupportedDataTypeException(
-          "Unsupported ExpressionType when construct OperatorNode: " + expression.getType());
+          Messages.format(
+              "error.read.time_generator_unsupported_expression", expression.getType()));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/query/timegenerator/node/AndNode.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/query/timegenerator/node/AndNode.java
@@ -19,6 +19,8 @@
 
 package org.apache.tsfile.read.query.timegenerator.node;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.io.IOException;
 import java.util.function.BiPredicate;
 
@@ -96,7 +98,7 @@ public class AndNode implements Node {
       hasCachedTime = false;
       return cachedTime;
     }
-    throw new IOException("no more data");
+    throw new IOException(Messages.get("error.read.node_no_more_data"));
   }
 
   @Override

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/query/timegenerator/node/LeafNode.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/query/timegenerator/node/LeafNode.java
@@ -19,6 +19,7 @@
 
 package org.apache.tsfile.read.query.timegenerator.node;
 
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.BatchData;
 import org.apache.tsfile.read.reader.IBatchReader;
 
@@ -68,7 +69,7 @@ public class LeafNode implements Node {
       cacheData.next();
       return cachedTime;
     }
-    throw new IOException("no more data");
+    throw new IOException(Messages.get("error.read.node_no_more_data"));
   }
 
   /**

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/query/timegenerator/node/OrNode.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/query/timegenerator/node/OrNode.java
@@ -19,6 +19,8 @@
 
 package org.apache.tsfile.read.query.timegenerator.node;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.io.IOException;
 
 public class OrNode implements Node {
@@ -95,7 +97,7 @@ public class OrNode implements Node {
       return popAndFillNextCache(
           leftValue > rightValue, leftValue < rightValue, leftValue, rightValue);
     }
-    throw new IOException("no more data");
+    throw new IOException(Messages.get("error.read.node_no_more_data"));
   }
 
   private long popAndFillNextCache(boolean popLeft, boolean popRight, long left, long right) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/reader/LocalTsFileInput.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/reader/LocalTsFileInput.java
@@ -19,6 +19,8 @@
 
 package org.apache.tsfile.read.reader;
 
+import org.apache.tsfile.i18n.Messages;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +50,7 @@ public class LocalTsFileInput implements TsFileInput {
     try {
       return channel.size();
     } catch (IOException e) {
-      logger.warn("Error happened while getting {} size", filePath);
+      logger.warn(Messages.get("log.read.local_input_size_error"), filePath);
       throw e;
     }
   }
@@ -58,7 +60,7 @@ public class LocalTsFileInput implements TsFileInput {
     try {
       return channel.position();
     } catch (IOException e) {
-      logger.warn("Error happened while getting {} current position", filePath);
+      logger.warn(Messages.get("log.read.local_input_position_error"), filePath);
       throw e;
     }
   }
@@ -69,7 +71,8 @@ public class LocalTsFileInput implements TsFileInput {
       channel.position(newPosition);
       return this;
     } catch (IOException e) {
-      logger.warn("Error happened while changing {} position to {}", filePath, newPosition);
+      logger.warn(
+          Messages.get("log.read.local_input_position_change_error"), filePath, newPosition);
       throw e;
     }
   }
@@ -79,11 +82,10 @@ public class LocalTsFileInput implements TsFileInput {
     try {
       return channel.read(dst);
     } catch (ClosedByInterruptException e) {
-      logger.warn(
-          "Current thread is interrupted by another thread when it is blocked in an I/O operation upon a channel.");
+      logger.warn(Messages.get("log.read.local_input_interrupted"));
       return -1;
     } catch (IOException e) {
-      logger.error("Error happened while reading {} from current position", filePath);
+      logger.error(Messages.get("log.read.local_input_read_current_error"), filePath);
       throw e;
     }
   }
@@ -93,11 +95,10 @@ public class LocalTsFileInput implements TsFileInput {
     try {
       return channel.read(dst, position);
     } catch (ClosedByInterruptException e) {
-      logger.warn(
-          "Current thread is interrupted by another thread when it is blocked in an I/O operation upon a channel.");
+      logger.warn(Messages.get("log.read.local_input_interrupted"));
       return -1;
     } catch (IOException e) {
-      logger.error("Error happened while reading {} from position {}", filePath, position);
+      logger.error(Messages.get("log.read.local_input_read_position_error"), filePath, position);
       throw e;
     }
   }
@@ -112,7 +113,7 @@ public class LocalTsFileInput implements TsFileInput {
     try {
       channel.close();
     } catch (IOException e) {
-      logger.error("Error happened while closing {}", filePath);
+      logger.error(Messages.get("log.read.local_input_close_error"), filePath);
       throw e;
     }
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/reader/TsFileLastReader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/reader/TsFileLastReader.java
@@ -27,6 +27,7 @@ import org.apache.tsfile.file.metadata.ChunkMetadata;
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.file.metadata.TimeseriesMetadata;
 import org.apache.tsfile.file.metadata.enums.CompressionType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.TimeValuePair;
 import org.apache.tsfile.read.TsFileSequenceReader;
 import org.apache.tsfile.read.common.BatchData;
@@ -89,7 +90,8 @@ public class TsFileLastReader
       try {
         init();
       } catch (IOException e) {
-        LOGGER.error("Cannot read timeseries metadata from {}", sequenceReader.getFileName(), e);
+        LOGGER.error(
+            Messages.get("log.read.last_reader_tsm_error"), sequenceReader.getFileName(), e);
         return false;
       }
     }
@@ -114,7 +116,8 @@ public class TsFileLastReader
       try {
         nextValue = new Pair<>(next.left, convertToLastPoints(next.right));
       } catch (IOException e) {
-        LOGGER.error("Cannot read timeseries metadata from {}", sequenceReader.getFileName(), e);
+        LOGGER.error(
+            Messages.get("log.read.last_reader_tsm_error"), sequenceReader.getFileName(), e);
         return false;
       }
     }
@@ -292,7 +295,7 @@ public class TsFileLastReader
                     } catch (InterruptedException e) {
                       Thread.currentThread().interrupt();
                     } catch (Exception e) {
-                      LOGGER.error("Error while reading timeseries metadata", e);
+                      LOGGER.error(Messages.get("log.read.last_reader_tsm_meta_error"), e);
                     } finally {
                       try {
                         lastValueQueue.put(new Pair<>(null, null));

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/reader/block/DeviceOrderedTsBlockReader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/reader/block/DeviceOrderedTsBlockReader.java
@@ -19,6 +19,7 @@
 
 package org.apache.tsfile.read.reader.block;
 
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.block.TsBlock;
 import org.apache.tsfile.read.controller.IChunkLoader;
 import org.apache.tsfile.read.controller.IMetadataQuerier;
@@ -70,7 +71,7 @@ public class DeviceOrderedTsBlockReader implements TsBlockReader {
             new SingleDeviceTsBlockReader(
                 nextTask, metadataQuerier, chunkLoader, blockSize, timeFilter, measurementFilter);
       } catch (IOException e) {
-        LOGGER.error("Failed to construct reader for {}", nextTask, e);
+        LOGGER.error(Messages.get("log.read.block_reader_construct_error"), nextTask, e);
       }
       if (currentReader != null && currentReader.hasNext()) {
         return true;

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/reader/block/SingleDeviceTsBlockReader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/reader/block/SingleDeviceTsBlockReader.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.read.reader.block;
 import org.apache.tsfile.block.column.Column;
 import org.apache.tsfile.file.metadata.AbstractAlignedChunkMetadata;
 import org.apache.tsfile.file.metadata.IChunkMetadata;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.BatchData;
 import org.apache.tsfile.read.common.block.TsBlock;
 import org.apache.tsfile.read.controller.IChunkLoader;
@@ -163,7 +164,7 @@ public class SingleDeviceTsBlockReader implements TsBlockReader {
         fillMeasurements(minTimeColumns);
         nextTime = null;
       } catch (IOException e) {
-        LOGGER.error("Cannot fill measurements", e);
+        LOGGER.error(Messages.get("log.read.block_reader_fill_measurements_error"), e);
         return false;
       }
 
@@ -259,7 +260,8 @@ public class SingleDeviceTsBlockReader implements TsBlockReader {
         Arrays.fill(column.getDoubles(), startPos, endPos, ((double) val));
         break;
       default:
-        throw new IllegalArgumentException("Unsupported data type: " + column.getDataType());
+        throw new IllegalArgumentException(
+            Messages.format("error.read.block_reader_unsupported_type", column.getDataType()));
     }
     column.setPositionCount(endPos);
   }
@@ -290,7 +292,8 @@ public class SingleDeviceTsBlockReader implements TsBlockReader {
         column.getLongs()[pos] = batchData.getLong();
         break;
       default:
-        throw new IllegalArgumentException("Unsupported data type: " + batchData.getDataType());
+        throw new IllegalArgumentException(
+            Messages.format("error.read.block_reader_unsupported_type", batchData.getDataType()));
     }
     column.setPositionCount(pos + 1);
   }
@@ -405,7 +408,9 @@ public class SingleDeviceTsBlockReader implements TsBlockReader {
                 block.getColumn(pos).getDoubles()[blockRowNum] = value.getDouble();
                 break;
               default:
-                throw new IllegalArgumentException("Unsupported data type: " + value.getDataType());
+                throw new IllegalArgumentException(
+                    Messages.format(
+                        "error.read.block_reader_unsupported_type", value.getDataType()));
             }
           } else {
             block.getColumn(pos).setNull(blockRowNum, blockRowNum + 1);

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/reader/chunk/AbstractChunkReader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/reader/chunk/AbstractChunkReader.java
@@ -23,6 +23,7 @@ import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.encoding.decoder.Decoder;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.BatchData;
 import org.apache.tsfile.read.filter.basic.Filter;
 import org.apache.tsfile.read.reader.IChunkReader;
@@ -70,7 +71,7 @@ public abstract class AbstractChunkReader implements IChunkReader {
   @Override
   public BatchData nextPageData() throws IOException {
     if (pageReaderList.isEmpty()) {
-      throw new IOException("No more page");
+      throw new IOException(Messages.get("error.read.no_more_page"));
     }
     return pageReaderList.remove(0).getAllSatisfiedPageData();
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/reader/chunk/ChunkReader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/reader/chunk/ChunkReader.java
@@ -27,6 +27,7 @@ import org.apache.tsfile.file.header.ChunkHeader;
 import org.apache.tsfile.file.header.PageHeader;
 import org.apache.tsfile.file.metadata.enums.EncryptionType;
 import org.apache.tsfile.file.metadata.statistics.Statistics;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.Chunk;
 import org.apache.tsfile.read.common.TimeRange;
 import org.apache.tsfile.read.filter.basic.Filter;
@@ -170,10 +171,10 @@ public class ChunkReader extends AbstractChunkReader {
     // doesn't have a complete page body
     if (compressedPageBodyLength > chunkBuffer.remaining()) {
       throw new IOException(
-          "do not has a complete page body. Expected:"
-              + compressedPageBodyLength
-              + ". Actual:"
-              + chunkBuffer.remaining());
+          Messages.format(
+              "error.read.chunk_incomplete_page_body",
+              compressedPageBodyLength,
+              chunkBuffer.remaining()));
     }
     chunkBuffer.get(compressedPageBody);
     return ByteBuffer.wrap(compressedPageBody);
@@ -193,13 +194,12 @@ public class ChunkReader extends AbstractChunkReader {
           0);
     } catch (Exception e) {
       throw new IOException(
-          "Uncompress error! uncompress size: "
-              + pageHeader.getUncompressedSize()
-              + "compressed size: "
-              + pageHeader.getCompressedSize()
-              + "page header: "
-              + pageHeader
-              + e.getMessage(),
+          Messages.format(
+              "error.read.uncompress_error_with_header",
+              pageHeader.getUncompressedSize(),
+              pageHeader.getCompressedSize(),
+              pageHeader,
+              e.getMessage()),
           e);
     }
     compressedPageData.position(compressedPageData.position() + compressedPageBodyLength);
@@ -224,13 +224,12 @@ public class ChunkReader extends AbstractChunkReader {
           decryptedPageData, 0, compressedPageBodyLength, uncompressedPageData, 0);
     } catch (Exception e) {
       throw new IOException(
-          "Uncompress error! uncompress size: "
-              + pageHeader.getUncompressedSize()
-              + "compressed size: "
-              + pageHeader.getCompressedSize()
-              + "page header: "
-              + pageHeader
-              + e.getMessage(),
+          Messages.format(
+              "error.read.uncompress_error_with_header",
+              pageHeader.getUncompressedSize(),
+              pageHeader.getCompressedSize(),
+              pageHeader,
+              e.getMessage()),
           e);
     }
     compressedPageData.position(compressedPageData.position() + compressedPageBodyLength);

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/reader/page/LazyLoadPageData.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/reader/page/LazyLoadPageData.java
@@ -24,6 +24,7 @@ import org.apache.tsfile.encrypt.EncryptParameter;
 import org.apache.tsfile.encrypt.EncryptUtils;
 import org.apache.tsfile.encrypt.IDecryptor;
 import org.apache.tsfile.file.header.PageHeader;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -64,13 +65,12 @@ public class LazyLoadPageData {
           decryptedPageData, 0, compressedPageBodyLength, uncompressedPageData, 0);
     } catch (Exception e) {
       throw new IOException(
-          "Uncompress error! uncompress size: "
-              + pageHeader.getUncompressedSize()
-              + "compressed size: "
-              + pageHeader.getCompressedSize()
-              + "page header: "
-              + pageHeader
-              + e.getMessage());
+          Messages.format(
+              "error.read.uncompress_error_with_header",
+              pageHeader.getUncompressedSize(),
+              pageHeader.getCompressedSize(),
+              pageHeader,
+              e.getMessage()));
     }
     return ByteBuffer.wrap(uncompressedPageData);
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/v4/DeviceTableModelReader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/v4/DeviceTableModelReader.java
@@ -25,6 +25,7 @@ import org.apache.tsfile.exception.read.ReadProcessException;
 import org.apache.tsfile.exception.write.NoMeasurementException;
 import org.apache.tsfile.exception.write.NoTableException;
 import org.apache.tsfile.file.metadata.TableSchema;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.TsFileSequenceReader;
 import org.apache.tsfile.read.controller.CachedChunkLoaderImpl;
 import org.apache.tsfile.read.controller.IChunkLoader;
@@ -118,7 +119,7 @@ public class DeviceTableModelReader implements ITsFileReader {
     try {
       this.fileReader.close();
     } catch (IOException e) {
-      LOG.warn("Meet exception when close file reader: ", e);
+      LOG.warn(Messages.get("log.read.v4_close_reader_error"), e);
     }
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/v4/TsFileReaderBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/v4/TsFileReaderBuilder.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.read.v4;
 
 import org.apache.tsfile.annotations.TsFileApi;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.File;
 import java.io.IOException;
@@ -43,7 +44,7 @@ public class TsFileReaderBuilder {
   @TsFileApi
   private void validateParameters() {
     if (file == null || !file.exists() || file.isDirectory()) {
-      throw new IllegalArgumentException("The file must be a non-null and non-directory File.");
+      throw new IllegalArgumentException(Messages.get("error.read.reader_builder_file_non_null"));
     }
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/v4/TsFileTreeReaderBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/v4/TsFileTreeReaderBuilder.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.read.v4;
 
 import org.apache.tsfile.annotations.TreeModel;
 import org.apache.tsfile.annotations.TsFileApi;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.File;
 import java.io.IOException;
@@ -45,7 +46,7 @@ public class TsFileTreeReaderBuilder {
   @TreeModel
   public ITsFileTreeReader build() throws IOException {
     if (this.file == null) {
-      throw new IllegalStateException("file must be set before build()");
+      throw new IllegalStateException(Messages.get("error.read.tree_reader_file_required"));
     }
     return new TsFileTreeReader(this.file);
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/utils/BytesUtils.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/utils/BytesUtils.java
@@ -19,6 +19,7 @@
 package org.apache.tsfile.utils;
 
 import org.apache.tsfile.common.conf.TSFileConfig;
+import org.apache.tsfile.i18n.Messages;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,7 +75,7 @@ public class BytesUtils {
    */
   public static byte[] intToBytes(int i, byte[] desc, int offset) {
     if (desc.length - offset < 4) {
-      throw new IllegalArgumentException("Invalid input: desc.length - offset < 4");
+      throw new IllegalArgumentException(Messages.get("error.utils.bytes_desc_offset_too_short"));
     }
     desc[0 + offset] = (byte) ((i >> 24) & 0xFF);
     desc[1 + offset] = (byte) ((i >> 16) & 0xFF);
@@ -112,13 +113,7 @@ public class BytesUtils {
         }
       }
     } catch (Exception e) {
-      LOG.error(
-          "tsfile-common BytesUtils: cannot convert an integer {} to a byte array, "
-              + "pos {}, width {}",
-          srcNum,
-          pos,
-          width,
-          e);
+      LOG.error(Messages.get("log.utils.bytes_int_to_bytes_error"), srcNum, pos, width, e);
     }
   }
 
@@ -130,7 +125,7 @@ public class BytesUtils {
    */
   public static byte[] intToTwoBytes(int i) {
     if (i > 0xFFFF) {
-      throw new IllegalArgumentException("Invalid input: " + i + " > 0xFFFF");
+      throw new IllegalArgumentException(Messages.format("error.utils.bytes_int_too_large", i));
     }
     byte[] ret = new byte[2];
     ret[1] = (byte) (i & 0xFF);
@@ -146,7 +141,7 @@ public class BytesUtils {
    */
   public static int twoBytesToInt(byte[] ret) {
     if (ret.length != 2) {
-      throw new IllegalArgumentException("Invalid input: ret.length != 2");
+      throw new IllegalArgumentException(Messages.get("error.utils.bytes_ret_length_not_two"));
     }
     int value = 0;
     value |= ret[0];
@@ -171,7 +166,7 @@ public class BytesUtils {
     }
 
     if (r > Integer.MAX_VALUE) {
-      throw new RuntimeException("Row count is larger than Integer.MAX_VALUE");
+      throw new RuntimeException(Messages.get("error.utils.bytes_row_count_too_large"));
     }
 
     return (int) r;
@@ -186,7 +181,7 @@ public class BytesUtils {
    */
   public static int bytesToInt(byte[] bytes, int offset) {
     if (bytes.length - offset < 4) {
-      throw new IllegalArgumentException("Invalid input: bytes.length - offset < 4");
+      throw new IllegalArgumentException(Messages.get("error.utils.bytes_offset_too_short_4"));
     }
 
     int value = 0;
@@ -251,7 +246,7 @@ public class BytesUtils {
    */
   public static void floatToBytes(float x, byte[] desc, int offset) {
     if (desc.length - offset < 4) {
-      throw new IllegalArgumentException("Invalid input: desc.length - offset < 4");
+      throw new IllegalArgumentException(Messages.get("error.utils.bytes_desc_offset_too_short"));
     }
     int l = Float.floatToIntBits(x);
     for (int i = 3 + offset; i >= offset; i--) {
@@ -268,7 +263,7 @@ public class BytesUtils {
    */
   public static float bytesToFloat(byte[] b) {
     if (b.length != 4) {
-      throw new IllegalArgumentException("Invalid input: b.length != 4");
+      throw new IllegalArgumentException(Messages.get("error.utils.bytes_b_length_not_four"));
     }
 
     int l;
@@ -291,7 +286,7 @@ public class BytesUtils {
    */
   public static float bytesToFloat(byte[] b, int offset) {
     if (b.length - offset < 4) {
-      throw new IllegalArgumentException("Invalid input: b.length - offset < 4");
+      throw new IllegalArgumentException(Messages.get("error.utils.bytes_b_offset_too_short_4"));
     }
 
     int l;
@@ -330,7 +325,7 @@ public class BytesUtils {
    */
   public static void doubleToBytes(double d, byte[] bytes, int offset) {
     if (bytes.length - offset < 8) {
-      throw new IllegalArgumentException("Invalid input: bytes.length - offset < 8");
+      throw new IllegalArgumentException(Messages.get("error.utils.bytes_offset_too_short_8"));
     }
 
     long value = Double.doubleToLongBits(d);
@@ -374,7 +369,7 @@ public class BytesUtils {
    */
   public static double bytesToDouble(byte[] bytes, int offset) {
     if (bytes.length - offset < 8) {
-      throw new IllegalArgumentException("Invalid input: bytes.length - offset < 8");
+      throw new IllegalArgumentException(Messages.get("error.utils.bytes_offset_too_short_8"));
     }
     long value = bytes[offset + 7];
     value &= 0xff;
@@ -447,7 +442,7 @@ public class BytesUtils {
    */
   public static boolean bytesToBool(byte[] b) {
     if (b.length != 1) {
-      throw new IllegalArgumentException("Invalid input: b.length != 1");
+      throw new IllegalArgumentException(Messages.get("error.utils.bytes_b_length_not_one"));
     }
 
     return b[0] != 0;
@@ -462,7 +457,7 @@ public class BytesUtils {
    */
   public static boolean bytesToBool(byte[] b, int offset) {
     if (b.length - offset < 1) {
-      throw new IllegalArgumentException("Invalid input: b.length - offset < 1");
+      throw new IllegalArgumentException(Messages.get("error.utils.bytes_b_offset_too_short_1"));
     }
     return b[offset] != 0;
   }
@@ -552,13 +547,7 @@ public class BytesUtils {
         }
       }
     } catch (Exception e) {
-      LOG.error(
-          "tsfile-common BytesUtils: cannot convert a long {} to a byte array, "
-              + "pos {}, width {}",
-          srcNum,
-          pos,
-          width,
-          e);
+      LOG.error(Messages.get("log.utils.bytes_long_to_bytes_error"), srcNum, pos, width, e);
     }
   }
 
@@ -630,7 +619,8 @@ public class BytesUtils {
    */
   public static long bytesToLongFromOffset(byte[] byteNum, int len, int offset) {
     if (byteNum.length - offset < len) {
-      throw new IllegalArgumentException("Invalid input: byteNum.length - offset < len");
+      throw new IllegalArgumentException(
+          Messages.get("error.utils.bytes_bytenum_offset_too_short"));
     }
     long num = 0;
     for (int ix = 0; ix < len; ix++) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/utils/DateUtils.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/utils/DateUtils.java
@@ -19,6 +19,8 @@
 
 package org.apache.tsfile.utils;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.sql.Date;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -39,28 +41,31 @@ public class DateUtils {
 
   public static Integer parseDateExpressionToInt(String dateExpression) {
     if (dateExpression == null || dateExpression.isEmpty()) {
-      throw new DateTimeParseException("Date expression is null or empty.", "", 0);
+      throw new DateTimeParseException(
+          Messages.get("error.utils.date_expression_null_or_empty"), "", 0);
     }
     LocalDate date;
     try {
       date = LocalDate.parse(dateExpression);
     } catch (DateTimeParseException e) {
       throw new DateTimeParseException(
-          "Invalid date format. Please use YYYY-MM-DD format.", dateExpression, 0);
+          Messages.get("error.utils.date_invalid_format"), dateExpression, 0);
     }
     if (date.getYear() < 1000 || date.getYear() > 9999) {
-      throw new DateTimeParseException("Year must be between 1000 and 9999.", dateExpression, 0);
+      throw new DateTimeParseException(
+          Messages.get("error.utils.date_year_out_of_range"), dateExpression, 0);
     }
     return date.getYear() * 10000 + date.getMonthValue() * 100 + date.getDayOfMonth();
   }
 
   public static Integer parseDateExpressionToInt(LocalDate localDate) {
     if (localDate == null) {
-      throw new DateTimeParseException("Date expression is null or empty.", "", 0);
+      throw new DateTimeParseException(
+          Messages.get("error.utils.date_expression_null_or_empty"), "", 0);
     }
     if (localDate.getYear() < 1000 || localDate.getYear() > 9999) {
       throw new DateTimeParseException(
-          "Year must be between 1000 and 9999.",
+          Messages.get("error.utils.date_year_out_of_range"),
           localDate.format(DateTimeFormatter.ISO_LOCAL_DATE),
           0);
     }
@@ -78,7 +83,8 @@ public class DateUtils {
     try {
       return LocalDate.of(date / 10000, (date / 100) % 100, date % 100);
     } catch (Exception e) {
-      throw new DateTimeParseException("Invalid date format.", "", 0);
+      throw new DateTimeParseException(
+          Messages.get("error.utils.date_invalid_format_local"), "", 0);
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/utils/FSUtils.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/utils/FSUtils.java
@@ -22,6 +22,7 @@ import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.fileSystem.FSPath;
 import org.apache.tsfile.fileSystem.FSType;
+import org.apache.tsfile.i18n.Messages;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,11 +71,9 @@ public class FSUtils {
         fsFileClass[i] = Class.forName(fsFileClassName[i]);
       } catch (ClassNotFoundException e) {
         logger.error(
-            "Failed to get "
-                + fsTypes[i].name()
-                + " file system. Please check your dependency of "
-                + fsTypes[i].name()
-                + " module.",
+            Messages.get("log.fs.fsutils_load_class_error"),
+            fsTypes[i].name(),
+            fsTypes[i].name(),
             e);
       }
     }

--- a/java/tsfile/src/main/java/org/apache/tsfile/utils/FilterDeserialize.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/utils/FilterDeserialize.java
@@ -14,6 +14,7 @@
 
 package org.apache.tsfile.utils;
 
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.filter.basic.Filter;
 import org.apache.tsfile.read.filter.basic.OperatorType;
 import org.apache.tsfile.read.filter.operator.BinaryFilterOperators;
@@ -31,7 +32,9 @@ import java.nio.ByteBuffer;
 
 public class FilterDeserialize {
 
-  private static final String UNSUPPORTED_DATATYPE_MESSAGE = "Unsupported class serialize id:";
+  private static final String UNSUPPORTED_OPERATOR_KEY =
+      "error.utils.filter_unsupported_operator_type";
+  private static final String UNSUPPORTED_CLASS_ID_KEY = "error.utils.filter_unsupported_class_id";
 
   public static Filter deserializeValueFilter(OperatorType type, ByteBuffer buffer) {
     ClassSerializeId classSerializeId = ClassSerializeId.values()[ReadWriteIOUtils.readInt(buffer)];
@@ -69,7 +72,7 @@ public class FilterDeserialize {
       case VALUE_NOT_BETWEEN_AND:
         return FilterDeserialize.deserializeValueNotBetweenAndFilter(classSerializeId, buffer);
       default:
-        throw new UnsupportedOperationException("Unsupported operator type:" + type);
+        throw new UnsupportedOperationException(Messages.format(UNSUPPORTED_OPERATOR_KEY, type));
     }
   }
 
@@ -91,7 +94,8 @@ public class FilterDeserialize {
       case STRING:
         return new StringFilterOperators.ValueEq(buffer);
       default:
-        throw new UnsupportedOperationException(UNSUPPORTED_DATATYPE_MESSAGE + classSerializeId);
+        throw new UnsupportedOperationException(
+            Messages.format(UNSUPPORTED_CLASS_ID_KEY, classSerializeId));
     }
   }
 
@@ -113,7 +117,8 @@ public class FilterDeserialize {
       case STRING:
         return new StringFilterOperators.ValueNotEq(buffer);
       default:
-        throw new UnsupportedOperationException(UNSUPPORTED_DATATYPE_MESSAGE + classSerializeId);
+        throw new UnsupportedOperationException(
+            Messages.format(UNSUPPORTED_CLASS_ID_KEY, classSerializeId));
     }
   }
 
@@ -135,7 +140,8 @@ public class FilterDeserialize {
       case STRING:
         return new StringFilterOperators.ValueGt(buffer);
       default:
-        throw new UnsupportedOperationException(UNSUPPORTED_DATATYPE_MESSAGE + classSerializeId);
+        throw new UnsupportedOperationException(
+            Messages.format(UNSUPPORTED_CLASS_ID_KEY, classSerializeId));
     }
   }
 
@@ -157,7 +163,8 @@ public class FilterDeserialize {
       case STRING:
         return new StringFilterOperators.ValueGtEq(buffer);
       default:
-        throw new UnsupportedOperationException(UNSUPPORTED_DATATYPE_MESSAGE + classSerializeId);
+        throw new UnsupportedOperationException(
+            Messages.format(UNSUPPORTED_CLASS_ID_KEY, classSerializeId));
     }
   }
 
@@ -179,7 +186,8 @@ public class FilterDeserialize {
       case STRING:
         return new StringFilterOperators.ValueLt(buffer);
       default:
-        throw new UnsupportedOperationException(UNSUPPORTED_DATATYPE_MESSAGE + classSerializeId);
+        throw new UnsupportedOperationException(
+            Messages.format(UNSUPPORTED_CLASS_ID_KEY, classSerializeId));
     }
   }
 
@@ -201,7 +209,8 @@ public class FilterDeserialize {
       case STRING:
         return new StringFilterOperators.ValueLtEq(buffer);
       default:
-        throw new UnsupportedOperationException(UNSUPPORTED_DATATYPE_MESSAGE + classSerializeId);
+        throw new UnsupportedOperationException(
+            Messages.format(UNSUPPORTED_CLASS_ID_KEY, classSerializeId));
     }
   }
 
@@ -224,7 +233,8 @@ public class FilterDeserialize {
       case STRING:
         return new StringFilterOperators.ValueIn(buffer);
       default:
-        throw new UnsupportedOperationException(UNSUPPORTED_DATATYPE_MESSAGE + classSerializeId);
+        throw new UnsupportedOperationException(
+            Messages.format(UNSUPPORTED_CLASS_ID_KEY, classSerializeId));
     }
   }
 
@@ -246,7 +256,8 @@ public class FilterDeserialize {
       case STRING:
         return new StringFilterOperators.ValueNotIn(buffer);
       default:
-        throw new UnsupportedOperationException(UNSUPPORTED_DATATYPE_MESSAGE + classSerializeId);
+        throw new UnsupportedOperationException(
+            Messages.format(UNSUPPORTED_CLASS_ID_KEY, classSerializeId));
     }
   }
 
@@ -268,7 +279,8 @@ public class FilterDeserialize {
       case STRING:
         return new StringFilterOperators.ValueBetweenAnd(buffer);
       default:
-        throw new UnsupportedOperationException(UNSUPPORTED_DATATYPE_MESSAGE + classSerializeId);
+        throw new UnsupportedOperationException(
+            Messages.format(UNSUPPORTED_CLASS_ID_KEY, classSerializeId));
     }
   }
 
@@ -290,7 +302,8 @@ public class FilterDeserialize {
       case STRING:
         return new StringFilterOperators.ValueNotBetweenAnd(buffer);
       default:
-        throw new UnsupportedOperationException(UNSUPPORTED_DATATYPE_MESSAGE + classSerializeId);
+        throw new UnsupportedOperationException(
+            Messages.format(UNSUPPORTED_CLASS_ID_KEY, classSerializeId));
     }
   }
 
@@ -312,7 +325,8 @@ public class FilterDeserialize {
       case STRING:
         return new StringFilterOperators.ValueRegexp(buffer);
       default:
-        throw new UnsupportedOperationException(UNSUPPORTED_DATATYPE_MESSAGE + classSerializeId);
+        throw new UnsupportedOperationException(
+            Messages.format(UNSUPPORTED_CLASS_ID_KEY, classSerializeId));
     }
   }
 
@@ -334,7 +348,8 @@ public class FilterDeserialize {
       case STRING:
         return new StringFilterOperators.ValueNotRegexp(buffer);
       default:
-        throw new UnsupportedOperationException(UNSUPPORTED_DATATYPE_MESSAGE + classSerializeId);
+        throw new UnsupportedOperationException(
+            Messages.format(UNSUPPORTED_CLASS_ID_KEY, classSerializeId));
     }
   }
 
@@ -356,7 +371,8 @@ public class FilterDeserialize {
       case STRING:
         return new StringFilterOperators.ValueLike(buffer);
       default:
-        throw new UnsupportedOperationException(UNSUPPORTED_DATATYPE_MESSAGE + classSerializeId);
+        throw new UnsupportedOperationException(
+            Messages.format(UNSUPPORTED_CLASS_ID_KEY, classSerializeId));
     }
   }
 
@@ -378,7 +394,8 @@ public class FilterDeserialize {
       case STRING:
         return new StringFilterOperators.ValueNotLike(buffer);
       default:
-        throw new UnsupportedOperationException(UNSUPPORTED_DATATYPE_MESSAGE + classSerializeId);
+        throw new UnsupportedOperationException(
+            Messages.format(UNSUPPORTED_CLASS_ID_KEY, classSerializeId));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/utils/Loader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/utils/Loader.java
@@ -18,6 +18,8 @@
  */
 package org.apache.tsfile.utils;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -47,7 +49,7 @@ public class Loader {
   /** function for getting the class loader of the given object. */
   public static ClassLoader getClassLoaderOfObject(Object o) {
     if (o == null) {
-      throw new NullPointerException("Input object cannot be null");
+      throw new NullPointerException(Messages.get("error.utils.loader_null_input"));
     }
     return getClassLoaderOfClass(o.getClass());
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/utils/NoSyncBufferedInputStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/utils/NoSyncBufferedInputStream.java
@@ -18,6 +18,8 @@
  */
 package org.apache.tsfile.utils;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -93,14 +95,14 @@ public class NoSyncBufferedInputStream extends FilterInputStream {
    */
   private InputStream getInIfOpen() throws IOException {
     InputStream input = in;
-    if (input == null) throw new IOException("Stream closed");
+    if (input == null) throw new IOException(Messages.get("error.utils.stream_closed"));
     return input;
   }
 
   /** Check to make sure that buffer has not been nulled out due to close; if not return it; */
   private byte[] getBufIfOpen() throws IOException {
     byte[] buffer = buf;
-    if (buffer == null) throw new IOException("Stream closed");
+    if (buffer == null) throw new IOException(Messages.get("error.utils.stream_closed"));
     return buffer;
   }
 
@@ -126,7 +128,8 @@ public class NoSyncBufferedInputStream extends FilterInputStream {
   public NoSyncBufferedInputStream(InputStream in, int size) {
     super(in);
     if (size <= 0) {
-      throw new IllegalArgumentException("Buffer size <= 0");
+      throw new IllegalArgumentException(
+          Messages.get("error.utils.buffer_size_not_positive_input"));
     }
     buf = new byte[size];
   }
@@ -322,7 +325,7 @@ public class NoSyncBufferedInputStream extends FilterInputStream {
    */
   public void reset() throws IOException {
     getBufIfOpen(); // Cause exception if closed
-    if (markpos < 0) throw new IOException("Resetting to invalid mark");
+    if (markpos < 0) throw new IOException(Messages.get("error.utils.reset_invalid_mark"));
     pos = markpos;
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/utils/NoSyncBufferedOutputStream.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/utils/NoSyncBufferedOutputStream.java
@@ -19,6 +19,8 @@
 
 package org.apache.tsfile.utils;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -58,7 +60,7 @@ public class NoSyncBufferedOutputStream extends FilterOutputStream {
   public NoSyncBufferedOutputStream(OutputStream out, int size) {
     super(out);
     if (size <= 0) {
-      throw new IllegalArgumentException("Buffer size <= 0");
+      throw new IllegalArgumentException(Messages.get("error.utils.buffer_size_not_positive"));
     }
     buf = new byte[size];
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/utils/ReadWriteForEncodingUtils.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/utils/ReadWriteForEncodingUtils.java
@@ -19,6 +19,7 @@
 package org.apache.tsfile.utils;
 
 import org.apache.tsfile.common.conf.TSFileConfig;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -29,8 +30,7 @@ import java.util.List;
 
 /** Utils to read/write stream. */
 public class ReadWriteForEncodingUtils {
-  private static final String TOO_LONG_BYTE_FORMAT =
-      "tsfile-common BytesUtils: encountered value (%d) that requires more than 4 bytes";
+  private static final String TOO_LONG_BYTE_KEY = "error.utils.too_long_byte_format";
 
   private ReadWriteForEncodingUtils() {}
 
@@ -276,7 +276,7 @@ public class ReadWriteForEncodingUtils {
       throws IOException {
     int paddedByteNum = (bitWidth + 7) / 8;
     if (paddedByteNum > 4) {
-      throw new IOException(String.format(TOO_LONG_BYTE_FORMAT, paddedByteNum));
+      throw new IOException(Messages.format(TOO_LONG_BYTE_KEY, paddedByteNum));
     }
     int offset = 0;
     while (paddedByteNum > 0) {
@@ -298,7 +298,7 @@ public class ReadWriteForEncodingUtils {
       long value, OutputStream out, int bitWidth) throws IOException {
     int paddedByteNum = (bitWidth + 7) / 8;
     if (paddedByteNum > 8) {
-      throw new IOException(String.format(TOO_LONG_BYTE_FORMAT, paddedByteNum));
+      throw new IOException(Messages.format(TOO_LONG_BYTE_KEY, paddedByteNum));
     }
     out.write(BytesUtils.longToBytes(value, paddedByteNum));
   }
@@ -315,7 +315,7 @@ public class ReadWriteForEncodingUtils {
       throws IOException {
     int paddedByteNum = (bitWidth + 7) / 8;
     if (paddedByteNum > 4) {
-      throw new IOException(String.format(TOO_LONG_BYTE_FORMAT, paddedByteNum));
+      throw new IOException(Messages.format(TOO_LONG_BYTE_KEY, paddedByteNum));
     }
     int result = 0;
     int offset = 0;
@@ -340,7 +340,7 @@ public class ReadWriteForEncodingUtils {
       throws IOException {
     int paddedByteNum = (bitWidth + 7) / 8;
     if (paddedByteNum > 8) {
-      throw new IOException(String.format(TOO_LONG_BYTE_FORMAT, paddedByteNum));
+      throw new IOException(Messages.format(TOO_LONG_BYTE_KEY, paddedByteNum));
     }
     long result = 0;
     for (int i = 0; i < paddedByteNum; i++) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/utils/ReadWriteIOUtils.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/utils/ReadWriteIOUtils.java
@@ -23,6 +23,7 @@ import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.file.metadata.enums.CompressionType;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.reader.TsFileInput;
 
 import java.io.DataOutputStream;
@@ -69,7 +70,7 @@ public class ReadWriteIOUtils {
 
   private static final byte[] magicStringBytes;
 
-  private static final String RETURN_ERROR = "Intend to read %d bytes but %d are actually returned";
+  private static final String RETURN_ERROR_KEY = "error.utils.rwio_short_read";
 
   static {
     magicStringBytes = BytesUtils.stringToBytes(TSFileConfig.MAGIC_STRING);
@@ -521,7 +522,7 @@ public class ReadWriteIOUtils {
     byte[] bytes = new byte[SHORT_LEN];
     int readLen = inputStream.read(bytes);
     if (readLen != SHORT_LEN) {
-      throw new IOException(String.format(RETURN_ERROR, SHORT_LEN, readLen));
+      throw new IOException(Messages.format(RETURN_ERROR_KEY, SHORT_LEN, readLen));
     }
     return BytesUtils.bytesToShort(bytes);
   }
@@ -536,7 +537,7 @@ public class ReadWriteIOUtils {
     byte[] bytes = new byte[FLOAT_LEN];
     int readLen = inputStream.read(bytes);
     if (readLen != FLOAT_LEN) {
-      throw new IOException(String.format(RETURN_ERROR, FLOAT_LEN, readLen));
+      throw new IOException(Messages.format(RETURN_ERROR_KEY, FLOAT_LEN, readLen));
     }
     return BytesUtils.bytesToFloat(bytes);
   }
@@ -553,7 +554,7 @@ public class ReadWriteIOUtils {
     byte[] bytes = new byte[DOUBLE_LEN];
     int readLen = inputStream.read(bytes);
     if (readLen != DOUBLE_LEN) {
-      throw new IOException(String.format(RETURN_ERROR, DOUBLE_LEN, readLen));
+      throw new IOException(Messages.format(RETURN_ERROR_KEY, DOUBLE_LEN, readLen));
     }
     return BytesUtils.bytesToDouble(bytes);
   }
@@ -570,7 +571,7 @@ public class ReadWriteIOUtils {
     byte[] bytes = new byte[INT_LEN];
     int readLen = inputStream.read(bytes);
     if (readLen != INT_LEN) {
-      throw new IOException(String.format(RETURN_ERROR, INT_LEN, readLen));
+      throw new IOException(Messages.format(RETURN_ERROR_KEY, INT_LEN, readLen));
     }
     return BytesUtils.bytesToInt(bytes);
   }
@@ -597,7 +598,7 @@ public class ReadWriteIOUtils {
     byte[] bytes = new byte[LONG_LEN];
     int readLen = inputStream.read(bytes);
     if (readLen != LONG_LEN) {
-      throw new IOException(String.format(RETURN_ERROR, LONG_LEN, readLen));
+      throw new IOException(Messages.format(RETURN_ERROR_KEY, LONG_LEN, readLen));
     }
     return BytesUtils.bytesToLong(bytes);
   }
@@ -618,7 +619,7 @@ public class ReadWriteIOUtils {
     byte[] bytes = new byte[strLength];
     int readLen = inputStream.read(bytes, 0, strLength);
     if (readLen != strLength) {
-      throw new IOException(String.format(RETURN_ERROR, strLength, readLen));
+      throw new IOException(Messages.format(RETURN_ERROR_KEY, strLength, readLen));
     }
     return new String(bytes, 0, strLength, TSFileConfig.STRING_CHARSET);
   }
@@ -634,7 +635,7 @@ public class ReadWriteIOUtils {
     byte[] bytes = new byte[strLength];
     int readLen = inputStream.read(bytes, 0, strLength);
     if (readLen != strLength) {
-      throw new IOException(String.format(RETURN_ERROR, strLength, readLen));
+      throw new IOException(Messages.format(RETURN_ERROR_KEY, strLength, readLen));
     }
     return new String(bytes, 0, strLength, TSFileConfig.STRING_CHARSET);
   }
@@ -887,7 +888,7 @@ public class ReadWriteIOUtils {
   /** write string list with self define length. */
   public static void writeStringList(List<String> list, ByteBuffer buffer) {
     if (list == null) {
-      throw new IllegalArgumentException("stringList must not be null!");
+      throw new IllegalArgumentException(Messages.get("error.utils.rwio_stringlist_null"));
     }
     int size = list.size();
     buffer.putInt(size);
@@ -900,7 +901,7 @@ public class ReadWriteIOUtils {
   public static void writeStringList(List<String> list, OutputStream outputStream)
       throws IOException {
     if (list == null) {
-      throw new IllegalArgumentException("stringList must not be null!");
+      throw new IllegalArgumentException(Messages.get("error.utils.rwio_stringlist_null"));
     }
     int size = list.size();
     write(size, outputStream);
@@ -922,13 +923,13 @@ public class ReadWriteIOUtils {
     return set;
   }
 
-  private static final String SET_NOT_NULL_MSG = "set must not be null!";
+  private static final String SET_NOT_NULL_KEY = "error.utils.rwio_set_null";
 
   // write integer set with self define length
   public static void writeIntegerSet(Set<Integer> set, OutputStream outputStream)
       throws IOException {
     if (set == null) {
-      throw new IllegalArgumentException(SET_NOT_NULL_MSG);
+      throw new IllegalArgumentException(Messages.get(SET_NOT_NULL_KEY));
     }
     int size = set.size();
     write(size, outputStream);
@@ -1027,7 +1028,7 @@ public class ReadWriteIOUtils {
   public static <T> void writeObjectSet(Set<T> set, DataOutputStream outputStream)
       throws IOException {
     if (set == null) {
-      throw new IllegalArgumentException(SET_NOT_NULL_MSG);
+      throw new IllegalArgumentException(Messages.get(SET_NOT_NULL_KEY));
     }
     write(set.size(), outputStream);
     for (T e : set) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/utils/StringContainer.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/utils/StringContainer.java
@@ -18,6 +18,8 @@
  */
 package org.apache.tsfile.utils;
 
+import org.apache.tsfile.i18n.Messages;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -261,7 +263,8 @@ public class StringContainer {
     int realIndex = index >= 0 ? index : count + index;
     if (realIndex < 0 || realIndex >= count) {
       throw new IndexOutOfBoundsException(
-          String.format("Index: %d, Real Index: %d, Size: %d", index, realIndex, count));
+          Messages.format(
+              "error.utils.string_container_index_out_of_bounds", index, realIndex, count));
     }
     if (realIndex < reverseList.size()) {
       return reverseList.get(reverseList.size() - 1 - realIndex);
@@ -286,12 +289,16 @@ public class StringContainer {
     int realEndIndex = end >= 0 ? end : count + end;
     if (realStartIndex < 0 || realStartIndex >= count) {
       throw new IndexOutOfBoundsException(
-          String.format(
-              "start Index: %d, Real start Index: %d, Size: %d", start, realStartIndex, count));
+          Messages.format(
+              "error.utils.string_container_start_index_out_of_bounds",
+              start,
+              realStartIndex,
+              count));
     }
     if (realEndIndex < 0 || realEndIndex >= count) {
       throw new IndexOutOfBoundsException(
-          String.format("end Index: %d, Real end Index: %d, Size: %d", end, realEndIndex, count));
+          Messages.format(
+              "error.utils.string_container_end_index_out_of_bounds", end, realEndIndex, count));
     }
     StringContainer ret = new StringContainer(joinSeparator);
     if (realStartIndex < reverseList.size()) {

--- a/java/tsfile/src/main/java/org/apache/tsfile/utils/TsFileGeneratorUtils.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/utils/TsFileGeneratorUtils.java
@@ -25,6 +25,7 @@ import org.apache.tsfile.exception.write.WriteProcessException;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.tsfile.fileSystem.FSFactoryProducer;
 import org.apache.tsfile.fileSystem.fsFactory.FSFactory;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.Path;
 import org.apache.tsfile.write.TsFileWriter;
 import org.apache.tsfile.write.record.TSRecord;
@@ -467,7 +468,8 @@ public class TsFileGeneratorUtils {
       case 5:
         return TSDataType.TEXT;
       default:
-        throw new IllegalArgumentException("Invalid input: " + num % 6);
+        throw new IllegalArgumentException(
+            Messages.format("error.utils.generator_invalid_input", num % 6));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/utils/TsFileSketchTool.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/utils/TsFileSketchTool.java
@@ -34,6 +34,7 @@ import org.apache.tsfile.file.metadata.TimeseriesMetadata;
 import org.apache.tsfile.file.metadata.TsFileMetadata;
 import org.apache.tsfile.file.metadata.enums.MetadataIndexNodeType;
 import org.apache.tsfile.fileSystem.FSFactoryProducer;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.TsFileCheckStatus;
 import org.apache.tsfile.read.TsFileSequenceReader;
 import org.apache.tsfile.read.common.Chunk;
@@ -91,8 +92,7 @@ public class TsFileSketchTool {
       allChunkGroupMetadata = new ArrayList<>();
       if (reader.selfCheck(new Schema(), allChunkGroupMetadata, false)
           != TsFileCheckStatus.COMPLETE_FILE) {
-        throw new IOException(
-            String.format("Cannot load file %s because the file has crashed.", filename));
+        throw new IOException(Messages.format("error.utils.sketch_tool_cannot_load", filename));
       }
     } catch (IOException e) {
       e.printStackTrace();

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/TsFileWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/TsFileWriter.java
@@ -32,6 +32,7 @@ import org.apache.tsfile.exception.write.NoTableException;
 import org.apache.tsfile.exception.write.WriteProcessException;
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.file.metadata.TableSchema;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.Path;
 import org.apache.tsfile.utils.MeasurementGroup;
 import org.apache.tsfile.utils.Pair;
@@ -215,8 +216,7 @@ public class TsFileWriter implements AutoCloseable {
       EncryptParameter firstEncryptParam)
       throws IOException {
     if (!fileWriter.canWrite()) {
-      throw new IOException(
-          "the given file Writer does not support writing any more. Maybe it is an complete TsFile");
+      throw new IOException(Messages.get("error.write.tsfile_writer_cannot_write"));
     }
     this.fileWriter = fileWriter;
 
@@ -229,11 +229,7 @@ public class TsFileWriter implements AutoCloseable {
     this.chunkGroupSizeThreshold = conf.getGroupSizeInByte();
     config.setTSFileStorageFs(conf.getTSFileStorageFs());
     if (this.pageSize >= chunkGroupSizeThreshold) {
-      LOG.warn(
-          "TsFile's page size {} is greater than chunk group size {}, please enlarge the chunk group"
-              + " size or decrease page size. ",
-          pageSize,
-          chunkGroupSizeThreshold);
+      LOG.warn(Messages.get("log.write.page_size_warn"), pageSize, chunkGroupSizeThreshold);
     }
     this.secondEncryptParam = EncryptUtils.getEncryptParameter(firstEncryptParam);
     String encryptLevel;
@@ -266,10 +262,8 @@ public class TsFileWriter implements AutoCloseable {
     this.chunkGroupSizeThreshold = memoryThreshold;
     if (this.pageSize >= chunkGroupSizeThreshold) {
       String errorMsg =
-          String.format(
-              "Invalid memory threshold configuration: page size %d must be smaller than chunk group size %d. "
-                  + "Please either increase the chunk group size or decrease the page size.",
-              pageSize, chunkGroupSizeThreshold);
+          Messages.format(
+              "error.write.tsfile_writer_page_size_too_large", pageSize, chunkGroupSizeThreshold);
       LOG.error(errorMsg);
       throw new IOException(errorMsg);
     }
@@ -288,13 +282,12 @@ public class TsFileWriter implements AutoCloseable {
       throws WriteProcessException {
     IDeviceID deviceID = IDeviceID.Factory.DEFAULT_FACTORY.create(deviceIdString);
     if (!getSchema().getSchemaTemplates().containsKey(templateName)) {
-      throw new WriteProcessException("given template is not existed! " + templateName);
+      throw new WriteProcessException(
+          Messages.format("error.write.tsfile_writer_template_not_found", templateName));
     }
     if (getSchema().getRegisteredTimeseriesMap().containsKey(deviceID)) {
       throw new WriteProcessException(
-          "this device "
-              + deviceIdString
-              + " has been registered, you can only use registerDevice method to register empty device.");
+          Messages.format("error.write.tsfile_writer_device_registered", deviceIdString));
     }
     getSchema().registerDevice(deviceID, templateName);
   }
@@ -320,14 +313,14 @@ public class TsFileWriter implements AutoCloseable {
       measurementGroup = getSchema().getSeriesSchema(deviceID);
       if (measurementGroup.isAligned()) {
         throw new WriteProcessException(
-            "given device " + deviceID + " has been registered for aligned timeseries.");
+            Messages.format("error.write.tsfile_writer_timeseries_registered_aligned", deviceID));
       } else if (measurementGroup
           .getMeasurementSchemaMap()
           .containsKey(measurementSchema.getMeasurementName())) {
         throw new WriteProcessException(
-            "given nonAligned timeseries "
-                + (deviceID + "." + measurementSchema.getMeasurementName())
-                + " has been registered.");
+            Messages.format(
+                "error.write.tsfile_writer_timeseries_registered",
+                deviceID + "." + measurementSchema.getMeasurementName()));
       }
     } else {
       measurementGroup = new MeasurementGroup(false);
@@ -373,12 +366,10 @@ public class TsFileWriter implements AutoCloseable {
     if (getSchema().containsDevice(deviceID)) {
       if (getSchema().getSeriesSchema(deviceID).isAligned()) {
         throw new WriteProcessException(
-            "given device "
-                + deviceID
-                + " has been registered for aligned timeseries and should not be expanded.");
+            Messages.format("error.write.tsfile_writer_device_aligned_no_expand", deviceID));
       } else {
         throw new WriteProcessException(
-            "given device " + deviceID + " has been registered for nonAligned timeseries.");
+            Messages.format("error.write.tsfile_writer_device_registered_nonaligned", deviceID));
       }
     }
     MeasurementGroup measurementGroup = new MeasurementGroup(true);
@@ -408,10 +399,8 @@ public class TsFileWriter implements AutoCloseable {
           if (flushedMeasurementsInDeviceMap.containsKey(deviceID)
               && !flushedMeasurementsInDeviceMap.get(deviceID).contains(s.getMeasurementName())) {
             throw new WriteProcessException(
-                "TsFile has flushed chunk group and should not add new measurement "
-                    + s.getMeasurementName()
-                    + " in device "
-                    + deviceID);
+                Messages.format(
+                    "error.write.tsfile_writer_new_measurement", s.getMeasurementName(), deviceID));
           }
         }
       }
@@ -468,10 +457,8 @@ public class TsFileWriter implements AutoCloseable {
           if (flushedMeasurementsInDeviceMap.containsKey(deviceID)
               && !flushedMeasurementsInDeviceMap.get(deviceID).contains(s.getMeasurementName())) {
             throw new WriteProcessException(
-                "TsFile has flushed chunk group and should not add new measurement "
-                    + s.getMeasurementName()
-                    + " in device "
-                    + deviceID);
+                Messages.format(
+                    "error.write.tsfile_writer_new_measurement", s.getMeasurementName(), deviceID));
           }
         }
       }
@@ -531,9 +518,8 @@ public class TsFileWriter implements AutoCloseable {
           throw new NoMeasurementException(dataPoint.getMeasurementId());
         } else {
           LOG.warn(
-              "Ignore nonAligned measurement "
-                  + dataPoint.getMeasurementId()
-                  + " , because it is not registered or in the default template");
+              Messages.get("log.write.ignore_nonaligned_measurement"),
+              dataPoint.getMeasurementId());
         }
       } else {
         schemas.add(measurementGroup.getMeasurementSchemaMap().get(dataPoint.getMeasurementId()));
@@ -662,7 +648,7 @@ public class TsFileWriter implements AutoCloseable {
       long memSize = calculateMemSizeForAllGroup();
       assert memSize > 0;
       if (memSize > chunkGroupSizeThreshold) {
-        LOG.debug("start to flush chunk groups, memory space occupy:{}", memSize);
+        LOG.debug(Messages.get("log.write.flush_chunk_groups"), memSize);
         recordCountForNextMemCheck = recordCount * chunkGroupSizeThreshold / memSize;
         return flush();
       } else {
@@ -692,9 +678,10 @@ public class TsFileWriter implements AutoCloseable {
         long dataSize = groupWriter.flushToFileWriter(fileWriter);
         if (fileWriter.getPos() - pos != dataSize) {
           throw new IOException(
-              String.format(
-                  "Flushed data size is inconsistent with computation! Estimated: %d, Actual: %d",
-                  dataSize, fileWriter.getPos() - pos));
+              Messages.format(
+                  "error.write.tsfile_writer_flush_inconsistent",
+                  dataSize,
+                  fileWriter.getPos() - pos));
         }
         fileWriter.endChunkGroup();
         if (groupWriter instanceof AlignedChunkGroupWriterImpl) {
@@ -741,7 +728,7 @@ public class TsFileWriter implements AutoCloseable {
   @Override
   @TsFileApi
   public void close() throws IOException {
-    LOG.info("start close file");
+    LOG.info(Messages.get("log.write.close_file"));
     flush();
     fileWriter.endFile();
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkGroupWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkGroupWriterImpl.java
@@ -30,6 +30,7 @@ import org.apache.tsfile.exception.write.WriteProcessException;
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.file.metadata.enums.CompressionType;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.DateUtils;
 import org.apache.tsfile.write.UnSupportedDataTypeException;
@@ -196,7 +197,7 @@ public class AlignedChunkGroupWriterImpl implements IChunkGroupWriter {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Data type %s is not supported.", point.getType()));
+              Messages.format("error.write.type_not_supported", point.getType()));
       }
     }
     if (!emptyValueChunkWriters.isEmpty()) {
@@ -289,8 +290,8 @@ public class AlignedChunkGroupWriterImpl implements IChunkGroupWriter {
             break;
           default:
             throw new UnSupportedDataTypeException(
-                String.format(
-                    "Data type %s is not supported.",
+                Messages.format(
+                    "error.write.type_not_supported",
                     measurementSchemas.get(columnIndex).getType()));
         }
       }
@@ -312,7 +313,7 @@ public class AlignedChunkGroupWriterImpl implements IChunkGroupWriter {
 
   @Override
   public long flushToFileWriter(TsFileIOWriter tsfileWriter) throws IOException {
-    LOG.debug("start flush device id:{}", deviceId);
+    LOG.debug(Messages.get("log.write.flush_device"), deviceId);
     // make sure all the pages have been compressed into buffers, so that we can get correct
     // groupWriter.getCurrentChunkGroupSize().
     sealAllChunks();
@@ -383,7 +384,7 @@ public class AlignedChunkGroupWriterImpl implements IChunkGroupWriter {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Data type %s is not supported.", dataType));
+              Messages.format("error.write.type_not_supported", dataType));
       }
     }
   }
@@ -421,12 +422,12 @@ public class AlignedChunkGroupWriterImpl implements IChunkGroupWriter {
   protected void checkIsHistoryData(long time) throws WriteProcessException {
     if (isInitLastTime && time <= lastTime) {
       throw new WriteProcessException(
-          "Not allowed to write out-of-order data in timeseries "
-              + deviceId
-              + TsFileConstant.PATH_SEPARATOR
-              + ""
-              + ", time should later than "
-              + lastTime);
+          Messages.format(
+              "error.write.chunk_group_aligned_out_of_order",
+              deviceId,
+              TsFileConstant.PATH_SEPARATOR,
+              "",
+              lastTime));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/AlignedChunkWriterImpl.java
@@ -29,6 +29,7 @@ import org.apache.tsfile.exception.write.PageException;
 import org.apache.tsfile.file.header.PageHeader;
 import org.apache.tsfile.file.metadata.enums.CompressionType;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.block.column.TimeColumn;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.TsPrimitiveType;
@@ -392,7 +393,8 @@ public class AlignedChunkWriterImpl implements IChunkWriter {
           chunkWriter.write(times, column.getFloats(), column.isNull(), batchSize, arrayOffset);
           break;
         default:
-          throw new UnsupportedOperationException("Unknown data type " + tsDataType);
+          throw new UnsupportedOperationException(
+              Messages.format("error.write.chunk_unknown_type", tsDataType));
       }
     }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ChunkWriterImpl.java
@@ -28,6 +28,7 @@ import org.apache.tsfile.exception.write.PageException;
 import org.apache.tsfile.file.header.ChunkHeader;
 import org.apache.tsfile.file.header.PageHeader;
 import org.apache.tsfile.file.metadata.statistics.Statistics;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.PublicBAOS;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
@@ -293,7 +294,7 @@ public class ChunkWriterImpl implements IChunkWriter {
    */
   private void checkPageSizeAndMayOpenANewPage() {
     if (pageWriter.getPointNumber() == maxNumberOfPointsInPage) {
-      logger.debug("current line count reaches the upper bound, write page {}", measurementSchema);
+      logger.debug(Messages.get("log.write.chunk_writer_write_page"), measurementSchema);
       writePageToPageBuffer();
     } else if (pageWriter.getPointNumber()
         >= valueCountInOnePageForNextCheck) { // need to check memory size
@@ -302,7 +303,7 @@ public class ChunkWriterImpl implements IChunkWriter {
       if (currentPageSize > pageSizeThreshold) { // memory size exceeds threshold
         // we will write the current page
         logger.debug(
-            "enough size, write page {}, pageSizeThreshold:{}, currentPateSize:{}, valueCountInOnePage:{}",
+            Messages.get("log.write.page_enough_size"),
             measurementSchema.getMeasurementName(),
             pageSizeThreshold,
             currentPageSize,
@@ -338,7 +339,7 @@ public class ChunkWriterImpl implements IChunkWriter {
       numOfPages++;
       this.statistics.mergeStatistics(pageWriter.getStatistics());
     } catch (IOException e) {
-      logger.error("meet error in pageWriter.writePageHeaderAndDataIntoBuff,ignore this page:", e);
+      logger.error(Messages.get("log.write.chunk_writer_page_error"), e);
     } finally {
       // clear start time stamp for next initializing
       pageWriter.reset(measurementSchema);
@@ -433,8 +434,7 @@ public class ChunkWriterImpl implements IChunkWriter {
       throws PageException {
     // write the page header to pageBuffer
     try {
-      logger.debug(
-          "start to flush a page header into buffer, buffer position {} ", pageBuffer.size());
+      logger.debug(Messages.get("log.write.page_header_flush_start"), pageBuffer.size());
       // serialize pageHeader  see writePageToPageBuffer method
       if (numOfPages == 0) { // record the firstPageStatistics
         this.firstPageStatistics = header.getStatistics();
@@ -458,7 +458,7 @@ public class ChunkWriterImpl implements IChunkWriter {
         header.getStatistics().serialize(pageBuffer);
       }
       logger.debug(
-          "finish to flush a page header {} of {} into buffer, buffer position {} ",
+          Messages.get("log.write.page_header_flush_done"),
           header,
           measurementSchema.getMeasurementName(),
           pageBuffer.size());
@@ -466,7 +466,7 @@ public class ChunkWriterImpl implements IChunkWriter {
       statistics.mergeStatistics(header.getStatistics());
 
     } catch (IOException e) {
-      throw new PageException("IO Exception in writeDataPageHeader,ignore this page", e);
+      throw new PageException(Messages.get("error.write.page_write_header_io_exception"), e);
     }
     numOfPages++;
     // write page content to temp PBAOS
@@ -515,11 +515,7 @@ public class ChunkWriterImpl implements IChunkWriter {
     int dataSize = (int) (writer.getPos() - dataOffset);
     if (dataSize != pageBuffer.size()) {
       throw new IOException(
-          "Bytes written is inconsistent with the size of data: "
-              + dataSize
-              + " !="
-              + " "
-              + pageBuffer.size());
+          Messages.format("error.write.chunk_bytes_inconsistent", dataSize, pageBuffer.size()));
     }
 
     writer.endCurrentChunk();

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/NonAlignedChunkGroupWriterImpl.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/NonAlignedChunkGroupWriterImpl.java
@@ -25,6 +25,7 @@ import org.apache.tsfile.enums.ColumnCategory;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.exception.write.WriteProcessException;
 import org.apache.tsfile.file.metadata.IDeviceID;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.DateUtils;
 import org.apache.tsfile.write.UnSupportedDataTypeException;
@@ -170,7 +171,7 @@ public class NonAlignedChunkGroupWriterImpl implements IChunkGroupWriter {
             break;
           default:
             throw new UnSupportedDataTypeException(
-                String.format("Data type %s is not supported.", tsDataType));
+                Messages.format("error.write.type_not_supported", tsDataType));
         }
         lastTimeMap.put(measurementId, time);
       }
@@ -181,7 +182,7 @@ public class NonAlignedChunkGroupWriterImpl implements IChunkGroupWriter {
 
   @Override
   public long flushToFileWriter(TsFileIOWriter fileWriter) throws IOException {
-    LOG.debug("start flush device id:{}", deviceId);
+    LOG.debug(Messages.get("log.write.flush_device"), deviceId);
     // make sure all the pages have been compressed into buffers, so that we can get correct
     // groupWriter.getCurrentChunkGroupSize().
     sealAllChunks();
@@ -221,12 +222,12 @@ public class NonAlignedChunkGroupWriterImpl implements IChunkGroupWriter {
     final Long lastTime = lastTimeMap.get(measurementId);
     if (lastTime != null && time <= lastTime) {
       throw new WriteProcessException(
-          "Not allowed to write out-of-order data in timeseries "
-              + deviceId
-              + TsFileConstant.PATH_SEPARATOR
-              + measurementId
-              + ", time should later than "
-              + lastTimeMap.get(measurementId));
+          Messages.format(
+              "error.write.chunk_group_non_aligned_out_of_order",
+              deviceId,
+              TsFileConstant.PATH_SEPARATOR,
+              measurementId,
+              lastTimeMap.get(measurementId)));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/TimeChunkWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/TimeChunkWriter.java
@@ -32,6 +32,7 @@ import org.apache.tsfile.file.metadata.enums.CompressionType;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.tsfile.file.metadata.statistics.Statistics;
 import org.apache.tsfile.file.metadata.statistics.TimeStatistics;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.PublicBAOS;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 import org.apache.tsfile.write.page.TimePageWriter;
@@ -150,7 +151,7 @@ public class TimeChunkWriter {
    */
   public boolean checkPageSizeAndMayOpenANewPage() {
     if (pageWriter.getPointNumber() >= maxNumberOfPointsInPage) {
-      logger.debug("current line count reaches the upper bound, write page {}", measurementId);
+      logger.debug(Messages.get("log.write.chunk_writer_write_page"), measurementId);
       return true;
     } else if (pageWriter.getPointNumber()
         >= valueCountInOnePageForNextCheck) { // need to check memory size
@@ -159,7 +160,7 @@ public class TimeChunkWriter {
       if (currentPageSize > pageSizeThreshold) { // memory size exceeds threshold
         // we will write the current page
         logger.debug(
-            "enough size, write page {}, pageSizeThreshold:{}, currentPateSize:{}, valueCountInOnePage:{}",
+            Messages.get("log.write.page_enough_size"),
             measurementId,
             pageSizeThreshold,
             currentPageSize,
@@ -200,7 +201,7 @@ public class TimeChunkWriter {
       numOfPages++;
       this.statistics.mergeStatistics(pageWriter.getStatistics());
     } catch (IOException e) {
-      logger.error("meet error in pageWriter.writePageHeaderAndDataIntoBuff,ignore this page:", e);
+      logger.error(Messages.get("log.write.chunk_writer_page_error"), e);
     } finally {
       // clear start time stamp for next initializing
       pageWriter.reset();
@@ -211,8 +212,7 @@ public class TimeChunkWriter {
       throws PageException {
     // write the page header to pageBuffer
     try {
-      logger.debug(
-          "start to flush a page header into buffer, buffer position {} ", pageBuffer.size());
+      logger.debug(Messages.get("log.write.page_header_flush_start"), pageBuffer.size());
       // serialize pageHeader  see writePageToPageBuffer method
       if (numOfPages == 0) { // record the firstPageStatistics
         this.firstPageStatistics = header.getStatistics();
@@ -236,14 +236,12 @@ public class TimeChunkWriter {
         header.getStatistics().serialize(pageBuffer);
       }
       logger.debug(
-          "finish to flush a page header {} of time page into buffer, buffer position {} ",
-          header,
-          pageBuffer.size());
+          Messages.get("log.write.page_header_flush_done_time"), header, pageBuffer.size());
 
       statistics.mergeStatistics(header.getStatistics());
 
     } catch (IOException e) {
-      throw new PageException("IO Exception in writeDataPageHeader,ignore this page", e);
+      throw new PageException(Messages.get("error.write.page_write_header_io_exception"), e);
     }
     numOfPages++;
     // write page content to temp PBAOS
@@ -334,11 +332,7 @@ public class TimeChunkWriter {
     int dataSize = (int) (writer.getPos() - dataOffset);
     if (dataSize != pageBuffer.size()) {
       throw new IOException(
-          "Bytes written is inconsistent with the size of data: "
-              + dataSize
-              + " !="
-              + " "
-              + pageBuffer.size());
+          Messages.format("error.write.chunk_bytes_inconsistent", dataSize, pageBuffer.size()));
     }
 
     writer.endCurrentChunk();

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ValueChunkWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/chunk/ValueChunkWriter.java
@@ -31,6 +31,7 @@ import org.apache.tsfile.file.header.PageHeader;
 import org.apache.tsfile.file.metadata.enums.CompressionType;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.tsfile.file.metadata.statistics.Statistics;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.PublicBAOS;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
@@ -227,7 +228,7 @@ public class ValueChunkWriter {
       numOfPages++;
       this.statistics.mergeStatistics(pageWriter.getStatistics());
     } catch (IOException e) {
-      logger.error("meet error in pageWriter.writePageHeaderAndDataIntoBuff,ignore this page:", e);
+      logger.error(Messages.get("log.write.chunk_writer_page_error"), e);
     } finally {
       // clear start time stamp for next initializing
       pageWriter.reset(dataType);
@@ -238,8 +239,7 @@ public class ValueChunkWriter {
       throws PageException {
     // write the page header to pageBuffer
     try {
-      logger.debug(
-          "start to flush a page header into buffer, buffer position {} ", pageBuffer.size());
+      logger.debug(Messages.get("log.write.page_header_flush_start"), pageBuffer.size());
       // serialize pageHeader  see writePageToPageBuffer method
       if (numOfPages == 0) { // record the firstPageStatistics
 
@@ -276,15 +276,13 @@ public class ValueChunkWriter {
         }
       }
       logger.debug(
-          "finish to flush a page header {} of time page into buffer, buffer position {} ",
-          header,
-          pageBuffer.size());
+          Messages.get("log.write.page_header_flush_done_time"), header, pageBuffer.size());
 
       if (header.getStatistics() != null) {
         statistics.mergeStatistics(header.getStatistics());
       }
     } catch (IOException e) {
-      throw new PageException("IO Exception in writeDataPageHeader,ignore this page", e);
+      throw new PageException(Messages.get("error.write.page_write_header_io_exception"), e);
     }
     numOfPages++;
     // write page content to temp PBAOS
@@ -342,7 +340,7 @@ public class ValueChunkWriter {
 
   public boolean checkPageSizeAndMayOpenANewPage() {
     if (pageWriter.getPointNumber() == maxNumberOfPointsInPage) {
-      logger.debug("current line count reaches the upper bound, write page {}", measurementId);
+      logger.debug(Messages.get("log.write.chunk_writer_write_page"), measurementId);
       return true;
     } else if (pageWriter.getPointNumber()
         >= valueCountInOnePageForNextCheck) { // need to check memory size
@@ -351,7 +349,7 @@ public class ValueChunkWriter {
       if (currentPageSize > pageSizeThreshold) { // memory size exceeds threshold
         // we will write the current page
         logger.debug(
-            "enough size, write page {}, pageSizeThreshold:{}, currentPageSize:{}, valueCountInOnePage:{}",
+            Messages.get("log.write.page_enough_size_value"),
             measurementId,
             pageSizeThreshold,
             currentPageSize,
@@ -442,11 +440,7 @@ public class ValueChunkWriter {
     int dataSize = (int) (writer.getPos() - dataOffset);
     if (dataSize != pageBuffer.size()) {
       throw new IOException(
-          "Bytes written is inconsistent with the size of data: "
-              + dataSize
-              + " !="
-              + " "
-              + pageBuffer.size());
+          Messages.format("error.write.chunk_bytes_inconsistent", dataSize, pageBuffer.size()));
     }
 
     writer.endCurrentChunk();

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/record/Tablet.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/record/Tablet.java
@@ -27,6 +27,7 @@ import org.apache.tsfile.enums.ColumnCategory;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.file.metadata.StringArrayDeviceID;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Accountable;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.BitMap;
@@ -66,7 +67,6 @@ import static org.apache.tsfile.utils.RamUsageEstimator.shallowSizeOfList;
 public class Tablet implements Accountable {
   private static final long TABLET_SIZE = RamUsageEstimator.shallowSizeOfInstance(Tablet.class);
   private static final int DEFAULT_SIZE = 1024;
-  private static final String NOT_SUPPORT_DATATYPE = "Data type %s is not supported.";
   private static final LocalDate EMPTY_DATE = LocalDate.of(1000, 1, 1);
 
   /** DeviceId if using tree-view interfaces or TableName when using table-view interfaces. */
@@ -318,9 +318,11 @@ public class Tablet implements Accountable {
         {
           if (value != null && !(value instanceof Binary) && !(value instanceof String)) {
             throw new IllegalArgumentException(
-                String.format(
-                    "Expected value of type Binary or String for data type %s, but got %s",
-                    dataType, value.getClass().getName()));
+                Messages.format(
+                    "error.write.tablet_expected_type",
+                    "Binary or String",
+                    dataType,
+                    value.getClass().getName()));
           }
           final Binary[] sensor = (Binary[]) values[indexOfSchema];
           if (value instanceof Binary) {
@@ -337,9 +339,11 @@ public class Tablet implements Accountable {
         {
           if (value != null && !(value instanceof Float)) {
             throw new IllegalArgumentException(
-                String.format(
-                    "Expected value of type Float for data type %s, but got %s",
-                    dataType, value.getClass().getName()));
+                Messages.format(
+                    "error.write.tablet_expected_type",
+                    "Float",
+                    dataType,
+                    value.getClass().getName()));
           }
           final float[] sensor = (float[]) values[indexOfSchema];
           sensor[rowIndex] = value != null ? (float) value : Float.MIN_VALUE;
@@ -349,9 +353,11 @@ public class Tablet implements Accountable {
         {
           if (value != null && !(value instanceof Integer)) {
             throw new IllegalArgumentException(
-                String.format(
-                    "Expected value of type Integer for data type %s, but got %s",
-                    dataType, value.getClass().getName()));
+                Messages.format(
+                    "error.write.tablet_expected_type",
+                    "Integer",
+                    dataType,
+                    value.getClass().getName()));
           }
           final int[] sensor = (int[]) values[indexOfSchema];
           sensor[rowIndex] = value != null ? (int) value : Integer.MIN_VALUE;
@@ -361,9 +367,11 @@ public class Tablet implements Accountable {
         {
           if (value != null && !(value instanceof LocalDate)) {
             throw new IllegalArgumentException(
-                String.format(
-                    "Expected value of type LocalDate for data type %s, but got %s",
-                    dataType, value.getClass().getName()));
+                Messages.format(
+                    "error.write.tablet_expected_type",
+                    "LocalDate",
+                    dataType,
+                    value.getClass().getName()));
           }
           final LocalDate[] sensor = (LocalDate[]) values[indexOfSchema];
           sensor[rowIndex] = value != null ? (LocalDate) value : EMPTY_DATE;
@@ -374,9 +382,11 @@ public class Tablet implements Accountable {
         {
           if (value != null && !(value instanceof Long)) {
             throw new IllegalArgumentException(
-                String.format(
-                    "Expected value of type Long for data type %s, but got %s",
-                    dataType, value.getClass().getName()));
+                Messages.format(
+                    "error.write.tablet_expected_type",
+                    "Long",
+                    dataType,
+                    value.getClass().getName()));
           }
           final long[] sensor = (long[]) values[indexOfSchema];
           sensor[rowIndex] = value != null ? (long) value : Long.MIN_VALUE;
@@ -386,9 +396,11 @@ public class Tablet implements Accountable {
         {
           if (value != null && !(value instanceof Double)) {
             throw new IllegalArgumentException(
-                String.format(
-                    "Expected value of type Double for data type %s, but got %s",
-                    dataType, value.getClass().getName()));
+                Messages.format(
+                    "error.write.tablet_expected_type",
+                    "Double",
+                    dataType,
+                    value.getClass().getName()));
           }
           final double[] sensor = (double[]) values[indexOfSchema];
           sensor[rowIndex] = value != null ? (double) value : Double.MIN_VALUE;
@@ -398,16 +410,19 @@ public class Tablet implements Accountable {
         {
           if (value != null && !(value instanceof Boolean)) {
             throw new IllegalArgumentException(
-                String.format(
-                    "Expected value of type Boolean for data type %s, but got %s",
-                    dataType, value.getClass().getName()));
+                Messages.format(
+                    "error.write.tablet_expected_type",
+                    "Boolean",
+                    dataType,
+                    value.getClass().getName()));
           }
           final boolean[] sensor = (boolean[]) values[indexOfSchema];
           sensor[rowIndex] = value != null && (boolean) value;
           break;
         }
       default:
-        throw new UnSupportedDataTypeException(String.format(NOT_SUPPORT_DATATYPE, dataType));
+        throw new UnSupportedDataTypeException(
+            Messages.format("error.write.type_not_supported", dataType));
     }
   }
 
@@ -421,7 +436,7 @@ public class Tablet implements Accountable {
   public void addValue(int rowIndex, int columnIndex, int val) {
     if (!(values[columnIndex] instanceof int[]) && !(values[columnIndex] instanceof long[])) {
       throw new IllegalArgumentException(
-          "The data type of column index " + columnIndex + " is not INT32 or INT64");
+          Messages.format("error.write.tablet_col_wrong_type", columnIndex, "INT32 or INT64"));
     }
     if (values[columnIndex] instanceof int[]) {
       final int[] sensor = (int[]) values[columnIndex];
@@ -444,7 +459,7 @@ public class Tablet implements Accountable {
   public void addValue(int rowIndex, int columnIndex, long val) {
     if (!(values[columnIndex] instanceof long[])) {
       throw new IllegalArgumentException(
-          "The data type of column index " + columnIndex + " is not INT64/TIMESTAMP");
+          Messages.format("error.write.tablet_col_wrong_type", columnIndex, "INT64/TIMESTAMP"));
     }
     final long[] sensor = (long[]) values[columnIndex];
     sensor[rowIndex] = val;
@@ -461,7 +476,7 @@ public class Tablet implements Accountable {
   public void addValue(int rowIndex, int columnIndex, float val) {
     if (!(values[columnIndex] instanceof float[])) {
       throw new IllegalArgumentException(
-          "The data type of column index " + columnIndex + " is not FLOAT");
+          Messages.format("error.write.tablet_col_wrong_type", columnIndex, "FLOAT"));
     }
     final float[] sensor = (float[]) values[columnIndex];
     sensor[rowIndex] = val;
@@ -478,7 +493,7 @@ public class Tablet implements Accountable {
   public void addValue(int rowIndex, int columnIndex, double val) {
     if (!(values[columnIndex] instanceof double[])) {
       throw new IllegalArgumentException(
-          "The data type of column index " + columnIndex + " is not DOUBLE");
+          Messages.format("error.write.tablet_col_wrong_type", columnIndex, "DOUBLE"));
     }
     final double[] sensor = (double[]) values[columnIndex];
     sensor[rowIndex] = val;
@@ -495,7 +510,7 @@ public class Tablet implements Accountable {
   public void addValue(int rowIndex, int columnIndex, boolean val) {
     if (!(values[columnIndex] instanceof boolean[])) {
       throw new IllegalArgumentException(
-          "The data type of column index " + columnIndex + " is not BOOLEAN");
+          Messages.format("error.write.tablet_col_wrong_type", columnIndex, "BOOLEAN"));
     }
     final boolean[] sensor = (boolean[]) values[columnIndex];
     sensor[rowIndex] = val;
@@ -513,7 +528,7 @@ public class Tablet implements Accountable {
     if (!(values[columnIndex] instanceof Binary[])
         || !schemas.get(columnIndex).getType().isTextStringOrBlob()) {
       throw new IllegalArgumentException(
-          "The data type of column index " + columnIndex + " is not TEXT/STRING/BLOB");
+          Messages.format("error.write.tablet_col_wrong_type", columnIndex, "TEXT/STRING/BLOB"));
     }
     if (val == null) {
       return;
@@ -554,7 +569,7 @@ public class Tablet implements Accountable {
     if (!(values[columnIndex] instanceof Binary[])
         || schemas.get(columnIndex).getType() != TSDataType.OBJECT) {
       throw new IllegalArgumentException(
-          "The data type of column index " + columnIndex + " is not OBJECT");
+          Messages.format("error.write.tablet_col_wrong_type", columnIndex, "OBJECT"));
     }
     if (objectPath == null) {
       return;
@@ -569,7 +584,7 @@ public class Tablet implements Accountable {
     if (!(values[columnIndex] instanceof Binary[])
         || !schemas.get(columnIndex).getType().isTextStringOrBlob()) {
       throw new IllegalArgumentException(
-          "The data type of column index " + columnIndex + " is not TEXT/STRING/BLOB");
+          Messages.format("error.write.tablet_col_wrong_type", columnIndex, "TEXT/STRING/BLOB"));
     }
     if (val == null) {
       return;
@@ -589,7 +604,7 @@ public class Tablet implements Accountable {
   public void addValue(int rowIndex, int columnIndex, LocalDate val) {
     if (!(values[columnIndex] instanceof LocalDate[])) {
       throw new IllegalArgumentException(
-          "The data type of column index " + columnIndex + " is not DATE");
+          Messages.format("error.write.tablet_col_wrong_type", columnIndex, "DATE"));
     }
     if (val == null) {
       return;
@@ -603,7 +618,7 @@ public class Tablet implements Accountable {
     if (!(values[columnIndex] instanceof Binary[])
         || schemas.get(columnIndex).getType() != TSDataType.OBJECT) {
       throw new IllegalArgumentException(
-          "The data type of column index " + columnIndex + " is not OBJECT");
+          Messages.format("error.write.tablet_col_wrong_type", columnIndex, "OBJECT"));
     }
     final Binary[] sensor = (Binary[]) values[columnIndex];
     byte[] val = new byte[content.length + 9];
@@ -616,11 +631,12 @@ public class Tablet implements Accountable {
 
   private int getColumnIndexByMeasurement(String measurement) {
     if (measurement == null) {
-      throw new IllegalArgumentException("measurement should be non null value");
+      throw new IllegalArgumentException(Messages.get("error.write.tablet_null_measurement"));
     }
     Integer columnIndex = measurementIndex.get(measurement);
     if (columnIndex == null) {
-      throw new IllegalArgumentException("No measurement for " + measurement);
+      throw new IllegalArgumentException(
+          Messages.format("error.write.tablet_no_measurement", measurement));
     }
     return columnIndex;
   }
@@ -724,7 +740,8 @@ public class Tablet implements Accountable {
         valueColumn = new LocalDate[capacity];
         break;
       default:
-        throw new UnSupportedDataTypeException(String.format(NOT_SUPPORT_DATATYPE, dataType));
+        throw new UnSupportedDataTypeException(
+            Messages.format("error.write.type_not_supported", dataType));
     }
     return valueColumn;
   }
@@ -865,7 +882,7 @@ public class Tablet implements Accountable {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Data type %s is not supported.", dataType));
+              Messages.format("error.write.type_not_supported", dataType));
       }
     }
   }
@@ -1015,8 +1032,7 @@ public class Tablet implements Accountable {
             break;
           default:
             throw new UnSupportedDataTypeException(
-                String.format(
-                    "data type %s is not supported when convert data at client", types[i]));
+                Messages.format("error.write.tablet_client_type_not_supported", types[i]));
         }
       }
     }
@@ -1173,7 +1189,7 @@ public class Tablet implements Accountable {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Data type %s is not supported.", schemas.get(i).getType()));
+              Messages.format("error.write.type_not_supported", schemas.get(i).getType()));
       }
     }
 
@@ -1271,7 +1287,8 @@ public class Tablet implements Accountable {
       case DATE:
         return ((LocalDate[]) values[j])[i];
       default:
-        throw new IllegalArgumentException("Unsupported type: " + schemas.get(j).getType());
+        throw new IllegalArgumentException(
+            Messages.format("error.write.tablet_unsupported_type", schemas.get(j).getType()));
     }
   }
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/BooleanDataPoint.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/BooleanDataPoint.java
@@ -19,6 +19,7 @@
 package org.apache.tsfile.write.record.datapoint;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.write.chunk.ChunkWriterImpl;
 
 import org.slf4j.Logger;
@@ -45,7 +46,7 @@ public class BooleanDataPoint extends DataPoint {
   @Override
   public void writeTo(long time, ChunkWriterImpl writer) {
     if (writer == null) {
-      LOG.warn("given IChunkWriter is null, do nothing and return");
+      LOG.warn(Messages.get("log.write.datapoint_chunk_writer_null"));
       return;
     }
     writer.write(time, value);

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/DataPoint.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/DataPoint.java
@@ -21,6 +21,7 @@ package org.apache.tsfile.write.record.datapoint;
 
 import org.apache.tsfile.common.conf.TSFileConfig;
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.utils.DateUtils;
 import org.apache.tsfile.utils.StringContainer;
@@ -97,12 +98,12 @@ public abstract class DataPoint {
           break;
         default:
           throw new UnSupportedDataTypeException(
-              String.format("Data type %s is not supported.", dataType));
+              Messages.format("error.write.type_not_supported", dataType));
       }
     } catch (Exception e) {
       throw new UnSupportedDataTypeException(
-          String.format(
-              "Data type of %s is %s, but input value is %s", measurementId, dataType, value));
+          Messages.format(
+              "error.write.datapoint_type_value_mismatch", measurementId, dataType, value));
     }
 
     return dataPoint;
@@ -135,31 +136,38 @@ public abstract class DataPoint {
   }
 
   public void setInteger(int value) {
-    throw new UnsupportedOperationException("set Integer not support in DataPoint");
+    throw new UnsupportedOperationException(
+        Messages.format("error.write.datapoint_set_not_supported", "Integer"));
   }
 
   public void setLong(long value) {
-    throw new UnsupportedOperationException("set Long not support in DataPoint");
+    throw new UnsupportedOperationException(
+        Messages.format("error.write.datapoint_set_not_supported", "Long"));
   }
 
   public void setBoolean(boolean value) {
-    throw new UnsupportedOperationException("set Boolean not support in DataPoint");
+    throw new UnsupportedOperationException(
+        Messages.format("error.write.datapoint_set_not_supported", "Boolean"));
   }
 
   public void setFloat(float value) {
-    throw new UnsupportedOperationException("set Float not support in DataPoint");
+    throw new UnsupportedOperationException(
+        Messages.format("error.write.datapoint_set_not_supported", "Float"));
   }
 
   public void setDouble(double value) {
-    throw new UnsupportedOperationException("set Double not support in DataPoint");
+    throw new UnsupportedOperationException(
+        Messages.format("error.write.datapoint_set_not_supported", "Double"));
   }
 
   public void setString(Binary value) {
-    throw new UnsupportedOperationException("set String not support in DataPoint");
+    throw new UnsupportedOperationException(
+        Messages.format("error.write.datapoint_set_not_supported", "String"));
   }
 
   public void setDate(LocalDate value) {
-    throw new UnsupportedOperationException("set Date not support in DataPoint");
+    throw new UnsupportedOperationException(
+        Messages.format("error.write.datapoint_set_not_supported", "Date"));
   }
 
   public IMeasurementSchema getMeasurementSchema() {

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/DateDataPoint.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/DateDataPoint.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.write.record.datapoint;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.DateUtils;
 import org.apache.tsfile.write.chunk.ChunkWriterImpl;
 
@@ -44,7 +45,7 @@ public class DateDataPoint extends DataPoint {
   @Override
   public void writeTo(long time, ChunkWriterImpl writer) throws IOException {
     if (writer == null) {
-      LOG.warn("given IChunkWriter is null, do nothing and return");
+      LOG.warn(Messages.get("log.write.datapoint_chunk_writer_null"));
       return;
     }
     writer.write(time, DateUtils.parseDateExpressionToInt(value));

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/DoubleDataPoint.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/DoubleDataPoint.java
@@ -19,6 +19,7 @@
 package org.apache.tsfile.write.record.datapoint;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.write.chunk.ChunkWriterImpl;
 
 import org.slf4j.Logger;
@@ -45,7 +46,7 @@ public class DoubleDataPoint extends DataPoint {
   @Override
   public void writeTo(long time, ChunkWriterImpl writer) {
     if (writer == null) {
-      LOG.warn("given IChunkWriter is null, do nothing and return");
+      LOG.warn(Messages.get("log.write.datapoint_chunk_writer_null"));
       return;
     }
     writer.write(time, value);

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/FloatDataPoint.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/FloatDataPoint.java
@@ -19,6 +19,7 @@
 package org.apache.tsfile.write.record.datapoint;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.write.chunk.ChunkWriterImpl;
 
 import org.slf4j.Logger;
@@ -45,7 +46,7 @@ public class FloatDataPoint extends DataPoint {
   @Override
   public void writeTo(long time, ChunkWriterImpl writer) {
     if (writer == null) {
-      LOG.warn("given IChunkWriter is null, do nothing and return");
+      LOG.warn(Messages.get("log.write.datapoint_chunk_writer_null"));
       return;
     }
     writer.write(time, value);

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/IntDataPoint.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/IntDataPoint.java
@@ -19,6 +19,7 @@
 package org.apache.tsfile.write.record.datapoint;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.write.chunk.ChunkWriterImpl;
 
 import org.slf4j.Logger;
@@ -45,7 +46,7 @@ public class IntDataPoint extends DataPoint {
   @Override
   public void writeTo(long time, ChunkWriterImpl writer) {
     if (writer == null) {
-      LOG.warn("given IChunkWriter is null, do nothing and return");
+      LOG.warn(Messages.get("log.write.datapoint_chunk_writer_null"));
       return;
     }
     writer.write(time, value);

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/LongDataPoint.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/LongDataPoint.java
@@ -19,6 +19,7 @@
 package org.apache.tsfile.write.record.datapoint;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.write.chunk.ChunkWriterImpl;
 
 import org.slf4j.Logger;
@@ -45,7 +46,7 @@ public class LongDataPoint extends DataPoint {
   @Override
   public void writeTo(long time, ChunkWriterImpl writer) {
     if (writer == null) {
-      LOG.warn("given IChunkWriter is null, do nothing and return");
+      LOG.warn(Messages.get("log.write.datapoint_chunk_writer_null"));
       return;
     }
     writer.write(time, value);

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/StringDataPoint.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/record/datapoint/StringDataPoint.java
@@ -19,6 +19,7 @@
 package org.apache.tsfile.write.record.datapoint;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Binary;
 import org.apache.tsfile.write.chunk.ChunkWriterImpl;
 
@@ -46,7 +47,7 @@ public class StringDataPoint extends DataPoint {
   @Override
   public void writeTo(long time, ChunkWriterImpl writer) {
     if (writer == null) {
-      LOG.warn("given IChunkWriter is null, do nothing and return");
+      LOG.warn(Messages.get("log.write.datapoint_chunk_writer_null"));
       return;
     }
     writer.write(time, value);

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/schema/MeasurementSchema.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/schema/MeasurementSchema.java
@@ -25,6 +25,7 @@ import org.apache.tsfile.encoding.encoder.TSEncodingBuilder;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.file.metadata.enums.CompressionType;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 import org.apache.tsfile.utils.StringContainer;
@@ -247,22 +248,26 @@ public class MeasurementSchema
 
   @Override
   public List<String> getSubMeasurementsList() {
-    throw new UnsupportedOperationException("unsupported method for MeasurementSchema");
+    throw new UnsupportedOperationException(
+        Messages.get("error.write.schema_measurement_method_unsupported"));
   }
 
   @Override
   public List<TSDataType> getSubMeasurementsTSDataTypeList() {
-    throw new UnsupportedOperationException("unsupported method for MeasurementSchema");
+    throw new UnsupportedOperationException(
+        Messages.get("error.write.schema_measurement_method_unsupported"));
   }
 
   @Override
   public List<TSEncoding> getSubMeasurementsTSEncodingList() {
-    throw new UnsupportedOperationException("unsupported method for MeasurementSchema");
+    throw new UnsupportedOperationException(
+        Messages.get("error.write.schema_measurement_method_unsupported"));
   }
 
   @Override
   public List<Encoder> getSubMeasurementsEncoderList() {
-    throw new UnsupportedOperationException("unsupported method for MeasurementSchema");
+    throw new UnsupportedOperationException(
+        Messages.get("error.write.schema_measurement_method_unsupported"));
   }
 
   /**

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/schema/MeasurementSchemaBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/schema/MeasurementSchemaBuilder.java
@@ -23,6 +23,7 @@ import org.apache.tsfile.common.conf.TSFileDescriptor;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.file.metadata.enums.CompressionType;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -58,10 +59,10 @@ public class MeasurementSchemaBuilder {
    */
   public MeasurementSchemaBuilder(String measurementName, TSDataType dataType) {
     if (measurementName == null || measurementName.trim().isEmpty()) {
-      throw new IllegalArgumentException("Measurement name cannot be null or empty");
+      throw new IllegalArgumentException(Messages.get("error.write.schema_builder_null_name"));
     }
     if (dataType == null) {
-      throw new IllegalArgumentException("Data type cannot be null");
+      throw new IllegalArgumentException(Messages.get("error.write.schema_builder_null_type"));
     }
 
     this.measurementName = measurementName;
@@ -103,7 +104,7 @@ public class MeasurementSchemaBuilder {
    */
   public MeasurementSchemaBuilder withProperty(String key, String value) {
     if (key == null || value == null) {
-      throw new IllegalArgumentException("Property key and value cannot be null");
+      throw new IllegalArgumentException(Messages.get("error.write.schema_builder_null_property"));
     }
     if (this.props == null) {
       this.props = new HashMap<>();

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/schema/VectorMeasurementSchema.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/schema/VectorMeasurementSchema.java
@@ -25,6 +25,7 @@ import org.apache.tsfile.encoding.encoder.TSEncodingBuilder;
 import org.apache.tsfile.enums.TSDataType;
 import org.apache.tsfile.file.metadata.enums.CompressionType;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 import org.apache.tsfile.utils.StringContainer;
@@ -167,7 +168,8 @@ public class VectorMeasurementSchema
   @Deprecated // Aligned series should not invoke this method
   @Override
   public CompressionType getCompressor() {
-    throw new UnsupportedOperationException("Aligned series should not invoke this method");
+    throw new UnsupportedOperationException(
+        Messages.get("error.write.schema_vector_aligned_no_compressor"));
   }
 
   public CompressionType getTimeCompressor() {
@@ -186,7 +188,8 @@ public class VectorMeasurementSchema
 
   @Override
   public TSEncoding getEncodingType() {
-    throw new UnsupportedOperationException("unsupported method for VectorMeasurementSchema");
+    throw new UnsupportedOperationException(
+        Messages.get("error.write.schema_vector_method_unsupported"));
   }
 
   @Override
@@ -201,7 +204,8 @@ public class VectorMeasurementSchema
 
   @Override
   public void setDataType(TSDataType dataType) {
-    throw new UnsupportedOperationException("unsupported method for VectorMeasurementSchema");
+    throw new UnsupportedOperationException(
+        Messages.get("error.write.schema_vector_method_unsupported"));
   }
 
   @Override
@@ -219,12 +223,14 @@ public class VectorMeasurementSchema
 
   @Override
   public Encoder getValueEncoder() {
-    throw new UnsupportedOperationException("unsupported method for VectorMeasurementSchema");
+    throw new UnsupportedOperationException(
+        Messages.get("error.write.schema_vector_method_unsupported"));
   }
 
   @Override
   public Map<String, String> getProps() {
-    throw new UnsupportedOperationException("unsupported method for VectorMeasurementSchema");
+    throw new UnsupportedOperationException(
+        Messages.get("error.write.schema_vector_method_unsupported"));
   }
 
   @Override
@@ -416,7 +422,7 @@ public class VectorMeasurementSchema
       byte[] compressors = new byte[measurementSize + 1];
       int read = inputStream.read(compressors);
       if (read != measurementSize) {
-        throw new IOException("Unexpected end of stream when reading compressors");
+        throw new IOException(Messages.get("error.write.schema_vector_unexpected_end_of_stream"));
       }
       vectorMeasurementSchema.compressors = compressors;
     }

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/v4/AbstractTableModelTsFileWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/v4/AbstractTableModelTsFileWriter.java
@@ -26,6 +26,7 @@ import org.apache.tsfile.encrypt.EncryptParameter;
 import org.apache.tsfile.encrypt.EncryptUtils;
 import org.apache.tsfile.encrypt.IEncryptor;
 import org.apache.tsfile.file.metadata.IDeviceID;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.write.chunk.AlignedChunkGroupWriterImpl;
 import org.apache.tsfile.write.chunk.IChunkGroupWriter;
 import org.apache.tsfile.write.chunk.NonAlignedChunkGroupWriterImpl;
@@ -119,11 +120,7 @@ abstract class AbstractTableModelTsFileWriter implements ITsFileWriter {
     this.pageSize = conf.getPageSizeInByte();
     this.chunkGroupSizeThreshold = chunkGroupSizeThreshold;
     if (this.pageSize >= chunkGroupSizeThreshold) {
-      LOG.warn(
-          "TsFile's page size {} is greater than chunk group size {}, please enlarge the chunk group"
-              + " size or decrease page size. ",
-          pageSize,
-          chunkGroupSizeThreshold);
+      LOG.warn(Messages.get("log.write.page_size_warn"), pageSize, chunkGroupSizeThreshold);
     }
 
     this.secondEncryptParam = EncryptUtils.getEncryptParameter(firstEncryptParam);
@@ -192,7 +189,7 @@ abstract class AbstractTableModelTsFileWriter implements ITsFileWriter {
     if (recordCount >= recordCountForNextMemCheck) {
       long memSize = calculateMemSizeForAllGroup();
       if (memSize > chunkGroupSizeThreshold) {
-        LOG.debug("start to flush chunk groups, memory space occupy:{}", memSize);
+        LOG.debug(Messages.get("log.write.flush_chunk_groups"), memSize);
         recordCountForNextMemCheck = recordCount * chunkGroupSizeThreshold / memSize;
         flush();
       } else {
@@ -218,9 +215,10 @@ abstract class AbstractTableModelTsFileWriter implements ITsFileWriter {
         long dataSize = groupWriter.flushToFileWriter(fileWriter);
         if (fileWriter.getPos() - pos != dataSize) {
           throw new IOException(
-              String.format(
-                  "Flushed data size is inconsistent with computation! Estimated: %d, Actual: %d",
-                  dataSize, fileWriter.getPos() - pos));
+              Messages.format(
+                  "error.write.tsfile_writer_flush_inconsistent",
+                  dataSize,
+                  fileWriter.getPos() - pos));
         }
         fileWriter.endChunkGroup();
         if (groupWriter instanceof AlignedChunkGroupWriterImpl) {
@@ -268,12 +266,12 @@ abstract class AbstractTableModelTsFileWriter implements ITsFileWriter {
   @Override
   @TsFileApi
   public void close() {
-    LOG.info("start close file");
+    LOG.info(Messages.get("log.write.close_file"));
     try {
       flush();
       fileWriter.endFile();
     } catch (IOException e) {
-      LOG.warn("Meet exception when close file writer. ", e);
+      LOG.warn(Messages.get("log.write.close_file_exception"), e);
     }
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/v4/DeviceTableModelWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/v4/DeviceTableModelWriter.java
@@ -27,6 +27,7 @@ import org.apache.tsfile.exception.write.NoTableException;
 import org.apache.tsfile.exception.write.WriteProcessException;
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.file.metadata.TableSchema;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.utils.Pair;
 import org.apache.tsfile.utils.WriteUtils;
 import org.apache.tsfile.write.chunk.AlignedChunkGroupWriterImpl;
@@ -93,7 +94,7 @@ public class DeviceTableModelWriter extends AbstractTableModelTsFileWriter {
       tableName = this.tableName;
     }
     if (tableName == null) {
-      throw new WriteProcessException("Table name is null");
+      throw new WriteProcessException(Messages.get("error.write.v4_table_name_null"));
     }
 
     final TableSchema tableSchema = getSchema().getTableSchemaMap().get(tableName);

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/v4/TableTsBlock2TsFileWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/v4/TableTsBlock2TsFileWriter.java
@@ -25,6 +25,7 @@ import org.apache.tsfile.exception.write.WriteProcessException;
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.file.metadata.StringArrayDeviceID;
 import org.apache.tsfile.file.metadata.TableSchema;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.block.TsBlock;
 import org.apache.tsfile.read.common.block.column.TimeColumn;
 import org.apache.tsfile.utils.Pair;
@@ -218,7 +219,7 @@ public class TableTsBlock2TsFileWriter extends DeviceTableModelWriter {
       int pointCount = 0;
       for (int rowIndex = startRowIndex; rowIndex < endRowIndex; rowIndex++) {
         if (timeColumn.isNull(rowIndex)) {
-          throw new WriteProcessException("All values in time column should not be null");
+          throw new WriteProcessException(Messages.get("error.write.v4_all_time_null"));
         }
         long time = timeColumn.getLong(rowIndex);
         checkIsHistoryData(time);
@@ -252,8 +253,8 @@ public class TableTsBlock2TsFileWriter extends DeviceTableModelWriter {
               break;
             default:
               throw new UnSupportedDataTypeException(
-                  String.format(
-                      "Data type %s is not supported.", valueChunkWriter.getDataType().getType()));
+                  Messages.format(
+                      "error.write.type_not_supported", valueChunkWriter.getDataType().getType()));
           }
         }
         timeChunkWriter.write(time);

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/v4/TsFileTreeWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/v4/TsFileTreeWriter.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.write.v4;
 
 import org.apache.tsfile.exception.write.WriteProcessException;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.write.TsFileWriter;
 import org.apache.tsfile.write.record.TSRecord;
 import org.apache.tsfile.write.record.Tablet;
@@ -61,7 +62,8 @@ public class TsFileTreeWriter implements AutoCloseable {
     try {
       tsFileWriter.registerTimeseries(deviceId, schema);
     } catch (WriteProcessException e) {
-      throw new WriteProcessException("Failed to register timeseries for device " + deviceId, e);
+      throw new WriteProcessException(
+          Messages.format("error.write.v4_tree_writer_register_failed", deviceId), e);
     }
   }
 
@@ -78,7 +80,7 @@ public class TsFileTreeWriter implements AutoCloseable {
       tsFileWriter.registerAlignedTimeseries(deviceId, schemas);
     } catch (WriteProcessException e) {
       throw new WriteProcessException(
-          "Failed to register aligned timeseries for device " + deviceId, e);
+          Messages.format("error.write.v4_tree_writer_register_aligned_failed", deviceId), e);
     }
   }
 
@@ -93,7 +95,8 @@ public class TsFileTreeWriter implements AutoCloseable {
     try {
       tsFileWriter.writeTree(tablet);
     } catch (IOException | WriteProcessException e) {
-      throw new WriteProcessException("Failed to write tablet data", e);
+      throw new WriteProcessException(
+          Messages.get("error.write.v4_tree_writer_write_tablet_failed"), e);
     }
   }
 
@@ -108,7 +111,8 @@ public class TsFileTreeWriter implements AutoCloseable {
     try {
       tsFileWriter.writeRecord(record);
     } catch (IOException | WriteProcessException e) {
-      throw new WriteProcessException("Failed to write TSRecord", e);
+      throw new WriteProcessException(
+          Messages.get("error.write.v4_tree_writer_write_record_failed"), e);
     }
   }
 
@@ -123,7 +127,7 @@ public class TsFileTreeWriter implements AutoCloseable {
     try {
       tsFileWriter.close();
     } catch (IOException e) {
-      throw new IOException("Failed to close TsFileTreeWriter", e);
+      throw new IOException(Messages.get("error.write.v4_tree_writer_close_failed"), e);
     }
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/v4/TsFileTreeWriterBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/v4/TsFileTreeWriterBuilder.java
@@ -20,6 +20,7 @@
 package org.apache.tsfile.write.v4;
 
 import org.apache.tsfile.common.conf.TSFileDescriptor;
+import org.apache.tsfile.i18n.Messages;
 
 import java.io.File;
 import java.io.IOException;
@@ -60,7 +61,7 @@ public class TsFileTreeWriterBuilder {
    */
   public TsFileTreeWriter build() throws IOException {
     if (file == null) {
-      throw new IllegalArgumentException("Output file must be specified");
+      throw new IllegalArgumentException(Messages.get("error.write.v4_output_file_required"));
     }
 
     return new TsFileTreeWriter(file, memoryThreshold);

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/v4/TsFileWriterBuilder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/v4/TsFileWriterBuilder.java
@@ -22,6 +22,7 @@ package org.apache.tsfile.write.v4;
 import org.apache.tsfile.annotations.TsFileApi;
 import org.apache.tsfile.external.commons.lang3.StringUtils;
 import org.apache.tsfile.file.metadata.TableSchema;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.write.schema.IMeasurementSchema;
 
 import java.io.File;
@@ -60,20 +61,20 @@ public class TsFileWriterBuilder {
 
   private void validateParameters() {
     if (file == null || file.isDirectory()) {
-      throw new IllegalArgumentException("The file must be a non-null and non-directory File.");
+      throw new IllegalArgumentException(Messages.get("error.write.v4_file_non_null"));
     }
     if (this.tableSchema == null) {
-      throw new IllegalArgumentException("TableSchema must not be null.");
+      throw new IllegalArgumentException(Messages.get("error.write.v4_table_schema_non_null"));
     }
     if (this.memoryThresholdInByte <= 0) {
-      throw new IllegalArgumentException("Memory threshold must be > 0 bytes.");
+      throw new IllegalArgumentException(Messages.get("error.write.v4_memory_threshold_positive"));
     }
     if (StringUtils.isBlank(this.tableSchema.getTableName())) {
-      throw new IllegalArgumentException("TableName must not be blank.");
+      throw new IllegalArgumentException(Messages.get("error.write.v4_table_name_blank"));
     }
     for (IMeasurementSchema columnSchema : this.tableSchema.getColumnSchemas()) {
       if (columnSchema == null || StringUtils.isBlank(columnSchema.getMeasurementName())) {
-        throw new IllegalArgumentException("Column name must not be blank.");
+        throw new IllegalArgumentException(Messages.get("error.write.v4_column_name_blank"));
       }
     }
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/writer/ForceAppendTsFileWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/writer/ForceAppendTsFileWriter.java
@@ -26,6 +26,7 @@ import org.apache.tsfile.file.metadata.ChunkMetadata;
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.file.metadata.TsFileMetadata;
 import org.apache.tsfile.fileSystem.FSFactoryProducer;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.TsFileSequenceReader;
 
 import org.slf4j.Logger;
@@ -55,7 +56,7 @@ public class ForceAppendTsFileWriter extends TsFileIOWriter {
 
   public ForceAppendTsFileWriter(File file, EncryptParameter param) throws IOException {
     if (logger.isDebugEnabled()) {
-      logger.debug("{} writer is opened.", file.getName());
+      logger.debug(Messages.get("log.write.writer_opened"), file.getName());
     }
     this.out = FSFactoryProducer.getFileOutputFactory().getTsFileOutput(file.getPath(), true);
     this.file = file;
@@ -63,7 +64,8 @@ public class ForceAppendTsFileWriter extends TsFileIOWriter {
 
     // file doesn't exist
     if (file.length() == 0 || !file.exists()) {
-      throw new TsFileNotCompleteException("File " + file.getPath() + " is not a complete TsFile");
+      throw new TsFileNotCompleteException(
+          Messages.format("error.write.force_append_not_complete", file.getPath()));
     }
 
     try (TsFileSequenceReader reader =
@@ -72,7 +74,7 @@ public class ForceAppendTsFileWriter extends TsFileIOWriter {
       // this tsfile is not complete
       if (!reader.isComplete()) {
         throw new TsFileNotCompleteException(
-            "File " + file.getPath() + " is not a complete TsFile");
+            Messages.format("error.write.force_append_not_complete", file.getPath()));
       }
       TsFileMetadata tsFileMetadata = reader.readFileMetadata();
       // truncate metadata and marker

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/writer/RestorableTsFileIOWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/writer/RestorableTsFileIOWriter.java
@@ -27,6 +27,7 @@ import org.apache.tsfile.file.metadata.ChunkGroupMetadata;
 import org.apache.tsfile.file.metadata.ChunkMetadata;
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.fileSystem.FSFactoryProducer;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.TsFileCheckStatus;
 import org.apache.tsfile.read.TsFileSequenceReader;
 import org.apache.tsfile.read.common.Path;
@@ -121,7 +122,7 @@ public class RestorableTsFileIOWriter extends TsFileIOWriter {
   public RestorableTsFileIOWriter(File file, boolean truncate, EncryptParameter param)
       throws IOException {
     if (logger.isDebugEnabled()) {
-      logger.debug("{} is opened.", file.getName());
+      logger.debug(Messages.get("log.write.writer_opened"), file.getName());
     }
     this.file = file;
     this.out = FSFactoryProducer.getFileOutputFactory().getTsFileOutput(file.getPath(), true);
@@ -151,7 +152,8 @@ public class RestorableTsFileIOWriter extends TsFileIOWriter {
           } else if (truncatedSize == TsFileCheckStatus.INCOMPATIBLE_FILE) {
             out.close();
             throw new NotCompatibleTsFileException(
-                String.format("%s is not in TsFile format.", file.getAbsolutePath()));
+                Messages.format(
+                    "error.write.restorable_writer_not_compatible", file.getAbsolutePath()));
           } else {
             crashed = true;
             canWrite = true;

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/writer/TsFileIOWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/writer/TsFileIOWriter.java
@@ -42,6 +42,7 @@ import org.apache.tsfile.file.metadata.enums.MetadataIndexNodeType;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.tsfile.file.metadata.statistics.Statistics;
 import org.apache.tsfile.fileSystem.FSFactoryProducer;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.Chunk;
 import org.apache.tsfile.read.common.Path;
 import org.apache.tsfile.utils.BloomFilter;
@@ -269,7 +270,7 @@ public class TsFileIOWriter implements AutoCloseable {
     updateTableSize(deviceId);
     this.currentChunkGroupDeviceId = deviceId;
     if (logger.isDebugEnabled()) {
-      logger.debug("start chunk group:{}, file position {}", deviceId, out.getPosition());
+      logger.debug(Messages.get("log.write.start_chunk_group"), deviceId, out.getPosition());
     }
     chunkMetadataList = new ArrayList<>();
     ChunkGroupHeader chunkGroupHeader = new ChunkGroupHeader(currentChunkGroupDeviceId);
@@ -365,7 +366,7 @@ public class TsFileIOWriter implements AutoCloseable {
     endCurrentChunk();
     if (logger.isDebugEnabled()) {
       logger.debug(
-          "end flushing a chunk:{}, totalvalue:{}",
+          Messages.get("log.write.end_flush_chunk"),
           chunkHeader.getMeasurementID(),
           chunkMetadata.getNumOfPoints());
     }
@@ -441,7 +442,7 @@ public class TsFileIOWriter implements AutoCloseable {
 
     long footerIndex = out.getPosition();
     if (logger.isDebugEnabled()) {
-      logger.debug("start to flush the footer,file pos:{}", footerIndex);
+      logger.debug(Messages.get("log.write.start_flush_footer"), footerIndex);
     }
 
     // write magic string
@@ -717,7 +718,7 @@ public class TsFileIOWriter implements AutoCloseable {
               .computeIfAbsent(device, x -> new ArrayList<>())
               .add(TSMIterator.constructOneTimeseriesMetadata(entry.getKey(), entry.getValue()));
         } catch (IOException e) {
-          logger.error("Failed to get device timeseries metadata map", e);
+          logger.error(Messages.get("log.write.tsm_device_metadata_error"), e);
           return null;
         }
       }
@@ -770,14 +771,14 @@ public class TsFileIOWriter implements AutoCloseable {
       try {
         if (logger.isDebugEnabled()) {
           logger.debug(
-              "Flushing chunk metadata, total size is {}, count is {}, avg size is {}",
+              Messages.get("log.write.flush_chunk_metadata"),
               currentChunkMetadataSize,
               chunkMetadataCount,
               currentChunkMetadataSize / chunkMetadataCount);
         }
         return sortAndFlushChunkMetadata();
       } catch (IOException e) {
-        logger.error("Meets exception when flushing metadata to temp file for {}", file, e);
+        logger.error(Messages.get("log.write.flush_metadata_exception"), file, e);
         throw e;
       }
     } else {
@@ -821,7 +822,7 @@ public class TsFileIOWriter implements AutoCloseable {
           new Pair<>(
               new Pair<>(seriesPath.getIDeviceID(), seriesPath.getMeasurement()),
               iChunkMetadataList));
-      logger.debug("Flushing {}", seriesPath);
+      logger.debug(Messages.get("log.write.flushing_series"), seriesPath);
     }
 
     // notify the listeners

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/writer/tsmiterator/DiskTSMIterator.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/writer/tsmiterator/DiskTSMIterator.java
@@ -26,6 +26,7 @@ import org.apache.tsfile.file.metadata.IChunkMetadata;
 import org.apache.tsfile.file.metadata.IDeviceID;
 import org.apache.tsfile.file.metadata.IDeviceID.Deserializer;
 import org.apache.tsfile.file.metadata.TimeseriesMetadata;
+import org.apache.tsfile.i18n.Messages;
 import org.apache.tsfile.read.common.Path;
 import org.apache.tsfile.read.reader.LocalTsFileInput;
 import org.apache.tsfile.read.reader.TsFileInput;
@@ -88,7 +89,7 @@ public class DiskTSMIterator extends TSMIterator {
       }
     } catch (IOException e) {
       if (!Thread.currentThread().isInterrupted()) {
-        LOG.error("Meets IOException when reading timeseries metadata from disk", e);
+        LOG.error(Messages.get("log.write.tsm_disk_read_error"), e);
       }
       throw e;
     }
@@ -111,8 +112,7 @@ public class DiskTSMIterator extends TSMIterator {
     int readSize = ReadWriteIOUtils.readAsPossible(input, chunkBuffer);
     if (readSize < chunkBufferSize) {
       throw new IOException(
-          String.format(
-              "Expected to read %s bytes, but actually read %s bytes", chunkBufferSize, readSize));
+          Messages.format("error.write.disk_tsm_read_size_mismatch", chunkBufferSize, readSize));
     }
     chunkBuffer.flip();
 


### PR DESCRIPTION
## Summary

- Adds runtime `ResourceBundle`-based i18n for all log and exception messages in `java/common`, `java/tsfile`, and `java/tools`
- A single published JAR supports both English (default) and Simplified Chinese; locale is selected at JVM startup via `-Dtsfile.locale=zh` or `Locale.getDefault()`
- 521 message keys, ~900+ call sites migrated across ~110 files
- Includes complete Simplified Chinese translation
- Drift-prevention unit tests enforce key-set alignment between `messages.properties` and `messages_zh.properties` at build time

## Why runtime (vs. compile-time profile)

IoTDB's recent i18n PR ([apache/iotdb#17613](https://github.com/apache/iotdb/pull/17613)) uses a Maven profile to inline locale-specific strings into the JAR at compile time. TsFile cannot adopt that same model without either publishing two artifacts per release or forking the version, since downstreams (IoTDB and others) consume tsfile as a versioned dependency. A runtime ResourceBundle approach keeps a single published artifact while letting downstream IoTDB switch locale via a JVM startup option.

Locale resolution order at JVM startup (once at class load):
1. `-Dtsfile.locale=<tag>` system property (e.g. `zh`, `zh-CN`)
2. `Locale.getDefault()`
3. English fallback via `ResourceBundle`'s root-bundle mechanism

## Architecture

- `org.apache.tsfile.i18n.Messages` (in `java/common`) provides `get(key)` for SLF4J patterns (`{}` placeholders) and `format(key, args)` for exception patterns (`%1$s` positional placeholders).
- A custom `ResourceBundle.Control` loads `.properties` files as UTF-8 (Java 8 default is ISO-8859-1) so Chinese characters can be written directly without `\uXXXX` escapes.
- Resources live at `java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties` (English, root bundle) and `messages_zh.properties` (Chinese).
- `MessagesTest` enforces key-set alignment + all values non-empty in both locales.
- Technical terms (`TsFile`, `Chunk`, `Page`, `Schema`, class/method names, type names, codec names like `RLE`/`GORILLA`) are kept in English in Chinese translations, matching IoTDB's convention.

## IoTDB integration

IoTDB's Chinese build (the `with-zh-locale` profile in apache/iotdb#17613) should add `-Dtsfile.locale=zh` to its startup scripts (e.g. `start-datanode.sh`, `start-confignode.sh`) to also receive Chinese messages from tsfile. No coordinated release is required — IoTDB can adopt this whenever convenient.

## Migration scope

Migrated all literal-string log and exception messages in:

| Module | Keys added |
|--------|------------|
| `common` | 16 |
| `tsfile/write` | 70 |
| `tsfile/read/common` | 51 |
| `tsfile/read` (rest) | 84 |
| `tsfile/encoding` | 58 |
| `tsfile/file` | 17 |
| `tsfile/external` | 65 |
| `tsfile/encrypt` | 13 |
| `tsfile/compress` | 7 |
| `tsfile/fileSystem` | 41 |
| `tsfile/utils` | 37 |
| `tools` | 61 |
| **Total** | **521** (incl. 1 seed) |

Each migration commit is its own logical scope so reviewers can review per-area.

Sites correctly skipped (not migrated):
- Variable/data-only constructor args: `throw new X(deviceId.toString())`, `throw new X(String.valueOf(type))`, `throw new X(getClass().getName())`
- Exception wrapping with no message: `throw new X(e)`
- No-arg throws: `throw new X()`
- Utility methods that pass through caller-supplied format strings (e.g. `Validate.isTrue(boolean, String, Object...)`)

## Test plan

- [x] All existing tests pass under default (English) locale: `./mvnw test -P with-java`
- [x] `MessagesTest` drift-prevention tests pass — verifies en/zh key set alignment + all values non-empty
- [x] `MessagesTest` passes under `-Duser.language=zh -Duser.country=CN` (simulated Chinese locale)
- [x] Spot tests under `-Dtsfile.locale=zh` show Chinese output without test failures
- [x] `./mvnw spotless:check -P with-java` clean
- [x] Key count verified: 521 keys in each `.properties` file