### PR TITLE
Fix typos in comments, docs, build scripts, and i18n messages

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -187,7 +187,7 @@
 * Added accountable function to measurementSchema by @Caideyipi in #509
 * Correct the retained size calculation for BinaryColumn and BinaryColumnBuilder by @JackieTien97 in #514
 * add switch to disable native lz4 (#480) by @jt2594838 in #515
-* Correct the memroy calculation of BinaryColumnBuilder by @JackieTien97 in #530
+* Correct the memory calculation of BinaryColumnBuilder by @JackieTien97 in #530
 * Fetch max tsblock line number each time from TSFileConfig by @JackieTien97 in #535
 * Support set default compression by data type & Bump org.apache.commons:commons-lang3 from 3.15.0 to 3.18.0 by @jt2594838 in #547
 * Avoid calculating shallow size of map by @shuwenwei in #566

--- a/cpp/build.sh
+++ b/cpp/build.sh
@@ -149,7 +149,7 @@ then
   cd build/minsizerel
 else
   echo ""
-  echo "unknow build type: ${build_type}, valid build types(case intensive): Debug, Release, RelWithDebInfo, MinSizeRel"
+  echo "unknown build type: ${build_type}, valid build types(case insensitive): Debug, Release, RelWithDebInfo, MinSizeRel"
   echo ""
   exit 1
 fi

--- a/cpp/examples/CMakeLists.txt
+++ b/cpp/examples/CMakeLists.txt
@@ -18,7 +18,7 @@ under the License.
 ]]
 cmake_minimum_required(VERSION 3.10)
 project(examples)
-message("Running in exampes directory")
+message("Running in examples directory")
 
 if (NOT MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")

--- a/cpp/src/common/allocator/byte_stream.h
+++ b/cpp/src/common/allocator/byte_stream.h
@@ -55,21 +55,21 @@ class OptionalAtomic {
         }
     }
 
-    FORCE_INLINE T atomic_faa(const T increament) {
+    FORCE_INLINE T atomic_faa(const T increment) {
         if (UNLIKELY(enable_atomic_)) {
-            return ATOMIC_FAA(&val_, increament);
+            return ATOMIC_FAA(&val_, increment);
         } else {
             T old_val = val_;
-            val_ = val_ + increament;
+            val_ = val_ + increment;
             return old_val;
         }
     }
 
-    FORCE_INLINE T atomic_aaf(const T increament) {
+    FORCE_INLINE T atomic_aaf(const T increment) {
         if (UNLIKELY(enable_atomic_)) {
-            return ATOMIC_AAF(&val_, increament);
+            return ATOMIC_AAF(&val_, increment);
         } else {
-            val_ = val_ + increament;
+            val_ = val_ + increment;
             return val_;
         }
     }
@@ -378,7 +378,7 @@ class ByteStream {
 
     // reader @want_len bytes to @buf, @read_len indicates real len we reader.
     // if ByteStream do not have so many bytes, it will return E_PARTIAL_READ if
-    // no other error occure.
+    // no other error occur.
     int read_buf(uint8_t* buf, const uint32_t want_len, uint32_t& read_len) {
         int ret = common::E_OK;
         bool partial_read = (read_pos_ + want_len > total_size_.load());
@@ -540,7 +540,7 @@ class ByteStream {
                 return b;
             }
             if (UNLIKELY(cur_ == nullptr)) {
-                // this consumer did not initialiazed.
+                // this consumer did not initialized.
                 cur_ = host_.head_.load();
                 read_offset_within_cur_page_ = 0;
             }
@@ -717,7 +717,7 @@ FORCE_INLINE int copy_bs_to_buf(ByteStream& bs, char* src_buf,
 
 FORCE_INLINE uint32_t get_var_uint_size(
     uint32_t
-        ui32)  // return: the length of usigned number after varint encoding.
+        ui32)  // return: the length of unsigned number after varint encoding.
 {
     uint32_t bytes = 0;
     while ((ui32 & 0xFFFFFF80) != 0) {

--- a/cpp/src/common/cache/lru_cache.h
+++ b/cpp/src/common/cache/lru_cache.h
@@ -80,7 +80,7 @@ class Cache {
         prune();
     }
     /**
-      for backward compatibity. redirects to tryGetCopy()
+      for backward compatibility. redirects to tryGetCopy()
      */
     bool tryGet(const Key& kIn, Value& vOut) { return tryGetCopy(kIn, vOut); }
 

--- a/cpp/src/common/global.cc
+++ b/cpp/src/common/global.cc
@@ -157,7 +157,7 @@ int init_common() {
 }
 
 bool is_timestamp_column_name(const char* time_col_name) {
-    // both "time" and "timestamp" refer to timestmap column.
+    // both "time" and "timestamp" refer to timestamp column.
     int32_t len = strlen(time_col_name);
     if (len == 4) {
         return strncasecmp(time_col_name, "time", 4) == 0;

--- a/cpp/src/common/seq_tvlist.inc
+++ b/cpp/src/common/seq_tvlist.inc
@@ -170,5 +170,5 @@ int32_t SeqTVList<Type>::binary_search_upper(int64_t time)
   return start;
 }
 
-} // namepsace storage
+} // namespace storage
 

--- a/cpp/src/encoding/int32_sprintz_encoder.h
+++ b/cpp/src/encoding/int32_sprintz_encoder.h
@@ -164,7 +164,7 @@ class Int32SprintzEncoder : public SprintzEncoder {
         } else if (predict_method_ == "fire") {
             pred = fire(value, prev);
         } else {
-            // unsupport
+            // unsupported
             ASSERT(false);
         }
 

--- a/cpp/src/file/CMakeLists.txt
+++ b/cpp/src/file/CMakeLists.txt
@@ -16,7 +16,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 ]]
-message("running in src/file diectory")
+message("running in src/file directory")
 
 message("CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/cpp/src/file/tsfile_io_writer.cc
+++ b/cpp/src/file/tsfile_io_writer.cc
@@ -799,7 +799,7 @@ int TsFileIOWriter::generate_root(
                 if (RET_FAIL(to->push_back(cur_index_node))) {
                 }
 #if DEBUG_SE
-                std::cout << "genereate root 2, "
+                std::cout << "generate root 2, "
                              "alloc_and_init_meta_index_node. cur_index_node="
                           << *cur_index_node << std::endl;
 #endif

--- a/cpp/src/parser/PathLexer.g4
+++ b/cpp/src/parser/PathLexer.g4
@@ -52,7 +52,7 @@ TIMESTAMP
  * 3. Operators
  */
 
-// Operators. Arithmetics
+// Operators. Arithmetic
 
 MINUS : '-';
 PLUS : '+';
@@ -60,7 +60,7 @@ DIV : '/';
 MOD : '%';
 
 
-// Operators. Comparation
+// Operators. Comparison
 
 OPERATOR_DEQ : '==';
 OPERATOR_SEQ : '=';

--- a/cpp/src/utils/util_define.h
+++ b/cpp/src/utils/util_define.h
@@ -84,7 +84,7 @@ typedef int mode_t;
 #define TSFILE_API
 #endif
 
-/* ======== unsued ======== */
+/* ======== unused ======== */
 #define UNUSED(v) ((void)(v))
 #if __cplusplus >= 201703L
 #define MAYBE_UNUSED [[maybe_unused]]

--- a/cpp/src/writer/CMakeLists.txt
+++ b/cpp/src/writer/CMakeLists.txt
@@ -16,7 +16,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 ]]
-message("running in src/write diectory")
+message("running in src/write directory")
 
 message("CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/cpp/src/writer/page_writer.cc
+++ b/cpp/src/writer/page_writer.cc
@@ -56,7 +56,7 @@ int PageData::init(ByteStream& time_bs, ByteStream& value_bs,
     } else {
         // TODO
         // NOTE: different compressor may have different compress API
-        // Be carefull about the memory.
+        // Be careful about the memory.
         if (RET_FAIL(compressor->reset(true))) {
         } else if (RET_FAIL(compressor->compress(
                        uncompressed_buf_, uncompressed_size_, compressed_buf_,

--- a/cpp/src/writer/time_page_writer.cc
+++ b/cpp/src/writer/time_page_writer.cc
@@ -48,7 +48,7 @@ int TimePageData::init(ByteStream& time_bs, Compressor* compressor) {
     } else {
         // TODO
         // NOTE: different compressor may have different compress API
-        // Be carefull about the memory.
+        // Be careful about the memory.
         if (RET_FAIL(compressor->reset(true))) {
         } else if (RET_FAIL(compressor->compress(
                        uncompressed_buf_, uncompressed_size_, compressed_buf_,

--- a/cpp/src/writer/value_page_writer.cc
+++ b/cpp/src/writer/value_page_writer.cc
@@ -62,7 +62,7 @@ int ValuePageData::init(ByteStream& col_notnull_bitmap_bs, ByteStream& value_bs,
     } else {
         // TODO
         // NOTE: different compressor may have different compress API
-        // Be carefull about the memory.
+        // Be careful about the memory.
         if (RET_FAIL(compressor->reset(true))) {
         } else if (RET_FAIL(compressor->compress(
                        uncompressed_buf_, uncompressed_size_, compressed_buf_,

--- a/cpp/test/common/row_record_test.cc
+++ b/cpp/test/common/row_record_test.cc
@@ -55,7 +55,7 @@ TEST(FieldTest, IsLiteral) {
 
 TEST(FieldTest, SetValue) {
     Field field;
-    common::PageArena pa;  // dosen't matter
+    common::PageArena pa;  // doesn't matter
     int32_t i32_val = 123;
     field.set_value(common::INT32, &i32_val, common::get_len(common::INT32),
                     pa);

--- a/cpp/test/writer/tsfile_writer_test.cc
+++ b/cpp/test/writer/tsfile_writer_test.cc
@@ -660,7 +660,7 @@ TEST_F(TsFileWriterTest, FlushMultipleDevice) {
             break;
         }
         record = qds->get_row_record();
-        // if empty chunk is writen, the timestamp should be NULL
+        // if empty chunk is written, the timestamp should be NULL
         if (!record) {
             break;
         }

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -38,7 +38,7 @@ highlights:
         details: TsFile employs advanced compression techniques to minimize storage requirements, resulting in reduced disk space consumption and improved system efficiency.
 
       - title: Flexible Schema and Metadata Management
-        details: TsFile allows for directly write data without pre defining the schema, which is flexible for data aquisition.
+        details: TsFile allows for directly write data without pre defining the schema, which is flexible for data acquisition.
 
       - title: High Query Performance with time range
         details: TsFile has indexed devices, sensors and time dimensions to accelerate query performance, enabling fast filtering and retrieval of time series data.

--- a/docs/src/stage/QuickStart.md
+++ b/docs/src/stage/QuickStart.md
@@ -446,7 +446,7 @@ The ReadOnlyTsFile class has two `query` method to perform a query.
 
         > **What is Partial Query ?**
         >
-        > In some distributed file systems(e.g. HDFS), a file is split into severval parts which are called "Blocks" and stored in different nodes. Executing a query paralleled in each nodes involved makes better efficiency. Thus Partial Query is needed. Paritial Query only selects the results stored in the part split by ```QueryConstant.PARTITION_START_OFFSET``` and ```QueryConstant.PARTITION_END_OFFSET``` for a TsFile.
+        > In some distributed file systems(e.g. HDFS), a file is split into several parts which are called "Blocks" and stored in different nodes. Executing a query paralleled in each nodes involved makes better efficiency. Thus Partial Query is needed. Partial Query only selects the results stored in the part split by ```QueryConstant.PARTITION_START_OFFSET``` and ```QueryConstant.PARTITION_END_OFFSET``` for a TsFile.
 
 * QueryDataset Interface
 

--- a/docs/src/zh/Development/Community-Project-Committers.md
+++ b/docs/src/zh/Development/Community-Project-Committers.md
@@ -71,7 +71,7 @@
 我们的社区存在以下四种身份
 
 - PMC
-- Committe
+- Committer
 - Contributor
 - User
 
@@ -79,5 +79,5 @@
 
 - 若想了解四种身份的详细内容，请查看[社区组织架构](../Community/About.md)
 - 若想成为 PMC ，请查看：[社区评选规章](../Community/About.md#pmc)
-- 若想成为 Committe ，请查看：[社区评选规章](../Community/About.md#committe)
+- 若想成为 Committer ，请查看：[社区评选规章](../Community/About.md#committer)
 - 若想成为 Contributor ，请查看：[社区评选规章](../Community/About.md#contributor)

--- a/java/common/src/main/java/org/apache/tsfile/block/column/Column.java
+++ b/java/common/src/main/java/org/apache/tsfile/block/column/Column.java
@@ -178,9 +178,9 @@ public interface Column {
   Column subColumnCopy(int fromIndex);
 
   /**
-   * Create a new colum from the current colum by keeping the same elements only with respect to
+   * Create a new column from the current column by keeping the same elements only with respect to
    * {@code positions} that starts at {@code offset} and has length of {@code length}. The
-   * implementation may return a view over the data in this colum or may return a copy, and the
+   * implementation may return a view over the data in this column or may return a copy, and the
    * implementation is allowed to retain the positions array for use in the view.
    */
   Column getPositions(int[] positions, int offset, int length);

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
@@ -722,16 +722,16 @@ error.encoding.ts_encoding_builder_unsupported_type = %1$s doesn't support data 
 log.encoding.flush_data_failed = flush data to stream failed!
 
 # DoubleSprintzEncoder — encoding error
-log.encoding.sprintz_double_encode_error = Error occured when encoding INT32 Type value with with Sprintz
+log.encoding.sprintz_double_encode_error = Error occurred when encoding INT32 Type value with Sprintz
 
 # FloatSprintzEncoder — encoding error
-log.encoding.sprintz_float_encode_error = Error occured when encoding Float Type value with with Sprintz
+log.encoding.sprintz_float_encode_error = Error occurred when encoding Float Type value with Sprintz
 
 # IntSprintzEncoder — encoding error
-log.encoding.sprintz_int_encode_error = Error occured when encoding INT32 Type value with with Sprintz
+log.encoding.sprintz_int_encode_error = Error occurred when encoding INT32 Type value with Sprintz
 
 # LongSprintzEncoder — encoding error
-log.encoding.sprintz_long_encode_error = Error occured when encoding INT64 Type value with with Sprintz
+log.encoding.sprintz_long_encode_error = Error occurred when encoding INT64 Type value with Sprintz
 
 # DictionaryEncoder — flush error
 log.encoding.dictionary_encoder_flush_error = tsfile-encoding DictionaryEncoder: error occurs when flushing
@@ -778,7 +778,7 @@ log.encoding.long_rle_decoder_read_error = tsfile-encoding IntRleDecoder: error 
 log.encoding.dictionary_decoder_error = tsfile-decoding DictionaryDecoder: error occurs when decoding
 
 # FloatSprintzDecoder / IntSprintzDecoder / DoubleSprintzDecoder / LongSprintzDecoder — readInt error (4 sites, 1 key)
-log.encoding.sprintz_decoder_read_error = Error occured when readInt with Sprintz Decoder.
+log.encoding.sprintz_decoder_read_error = Error occurred when readInt with Sprintz Decoder.
 
 # TSEncodingBuilder — max string length negative value warning
 log.encoding.ts_encoding_max_string_length_negative = cannot set max string length to negative value, replaced with default value:{}

--- a/java/examples/src/main/java/org/apache/tsfile/TsFileSequenceRead.java
+++ b/java/examples/src/main/java/org/apache/tsfile/TsFileSequenceRead.java
@@ -46,7 +46,7 @@ import java.util.Map;
 
 /** This tool is used to read TsFile sequentially, including nonAligned or aligned timeseries. */
 public class TsFileSequenceRead {
-  // if you wanna print detailed datas in pages, then turn it true.
+  // if you wanna print detailed data in pages, then turn it true.
   private static boolean printDetail = false;
   public static final String POINT_IN_PAGE = "\t\tpoints in the page: ";
   private static int MASK = 0x80;

--- a/java/tsfile/README.md
+++ b/java/tsfile/README.md
@@ -147,7 +147,7 @@ Read TsFile Example
 
 ### Prerequisites
 
-To build TsFile wirh Java, you need to have:
+To build TsFile with Java, you need to have:
 
 1. Java >= 1.8 (1.8, 11 to 17 are verified. Please make sure the environment path has been set accordingly).
 2. Maven >= 3.6.3 (If you want to compile TsFile from source code).

--- a/java/tsfile/src/main/antlr4/org/apache/tsfile/parser/PathLexer.g4
+++ b/java/tsfile/src/main/antlr4/org/apache/tsfile/parser/PathLexer.g4
@@ -52,7 +52,7 @@ TIMESTAMP
  * 3. Operators
  */
 
-// Operators. Arithmetics
+// Operators. Arithmetic
 
 MINUS : '-';
 PLUS : '+';
@@ -60,7 +60,7 @@ DIV : '/';
 MOD : '%';
 
 
-// Operators. Comparation
+// Operators. Comparison
 
 OPERATOR_DEQ : '==';
 OPERATOR_SEQ : '=';

--- a/java/tsfile/src/main/java/org/apache/tsfile/common/conf/TSFileConfig.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/common/conf/TSFileConfig.java
@@ -226,7 +226,7 @@ public class TSFileConfig implements Serializable {
   /** full path of kerberos keytab file. */
   private String kerberosKeytabFilePath = "/path";
 
-  /** kerberos pricipal. */
+  /** kerberos principal. */
   private String kerberosPrincipal = "principal";
 
   /** The acceptable error rate of bloom filter. */

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/IntRleEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/IntRleEncoder.java
@@ -122,7 +122,7 @@ public class IntRleEncoder extends RleEncoder<Integer> {
     if (values == null) {
       return 0;
     }
-    // try to caculate max value
+    // try to calculate max value
     int groupNum = (values.size() / 8 + 1) / 63 + 1;
     return (long) 8 + groupNum * 5 + values.size() * 4;
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/IntZigzagEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/IntZigzagEncoder.java
@@ -96,7 +96,7 @@ public class IntZigzagEncoder extends Encoder {
     if (values == null) {
       return 0;
     }
-    // try to caculate max value
+    // try to calculate max value
     return (long) 8 + values.size() * 4;
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/LongRleEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/LongRleEncoder.java
@@ -115,7 +115,7 @@ public class LongRleEncoder extends RleEncoder<Long> {
     if (values == null) {
       return 0;
     }
-    // try to caculate max value
+    // try to calculate max value
     int groupNum = (values.size() / 8 + 1) / 63 + 1;
     return (long) 8 + groupNum * 5 + values.size() * 8;
   }

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/LongZigzagEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/LongZigzagEncoder.java
@@ -107,7 +107,7 @@ public class LongZigzagEncoder extends Encoder {
     if (values == null) {
       return 0;
     }
-    // try to caculate max value
+    // try to calculate max value
     return (long) 8 + values.size() * 4;
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/RleEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/RleEncoder.java
@@ -213,7 +213,7 @@ public abstract class RleEncoder<T extends Comparable<T>> extends Encoder {
   protected void encodeValue(T value) {
     if (!isBitWidthSaved) {
       // save bit width in header,
-      // perpare for read
+      // prepare for read
       byteCache.write(bitWidth);
       isBitWidthSaved = true;
     }
@@ -249,7 +249,7 @@ public abstract class RleEncoder<T extends Comparable<T>> extends Encoder {
       }
 
     } else {
-      // we encounter a differnt value
+      // we encounter a different value
       if (repeatCount >= TSFileConfig.RLE_MIN_REPEATED_NUM) {
         try {
           writeRleRun();

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/SDTEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/SDTEncoder.java
@@ -30,7 +30,7 @@ public class SDTEncoder {
   private int lastReadInt;
   private float lastReadFloat;
 
-  // the last stored time and vlaue we compare current point against lastStoredPair
+  // the last stored time and value we compare current point against lastStoredPair
   private long lastStoredTimestamp;
 
   private long lastStoredLong;

--- a/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/SprintzEncoder.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/encoding/encoder/SprintzEncoder.java
@@ -47,7 +47,7 @@ public abstract class SprintzEncoder extends Encoder {
   /** output stream to buffer {@code <bitwidth> <encoded-data>}. */
   protected ByteArrayOutputStream byteCache;
 
-  // selecet the predict method
+  // select the predict method
   protected String predictMethod =
       TSFileDescriptor.getInstance().getConfig().getSprintzPredictScheme();
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/header/ChunkHeader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/header/ChunkHeader.java
@@ -209,7 +209,7 @@ public class ChunkHeader {
   public static ChunkHeader deserializeFrom(
       TsFileInput input, long offset, LongConsumer ioSizeRecorder) throws IOException {
 
-    // only 6 bytes, no need to call ioSizeRecorder.accept alone, combine into the remaining raed
+    // only 6 bytes, no need to call ioSizeRecorder.accept alone, combine into the remaining read
     // operation
     ByteBuffer buffer = ByteBuffer.allocate(Byte.BYTES + Integer.BYTES + 1);
     input.read(buffer, offset);

--- a/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/IDeviceID.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/file/metadata/IDeviceID.java
@@ -58,7 +58,7 @@ public interface IDeviceID extends Comparable<IDeviceID>, Accountable, Serializa
 
   /**
    * @return how many segments this DeviceId consists of. For a path-DeviceId, like "root.a.b.c.d",
-   *     it is 5; fot a tuple-DeviceId, like "(table1, beijing, turbine)", it is 3.
+   *     it is 5; for a tuple-DeviceId, like "(table1, beijing, turbine)", it is 3.
    */
   int segmentNum();
 

--- a/java/tsfile/src/test/java/org/apache/tsfile/read/reader/TsFileLastReaderTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/read/reader/TsFileLastReaderTest.java
@@ -103,7 +103,7 @@ public class TsFileLastReaderTest {
     }
   }
 
-  // the second half measurements will have an emtpy last chunk each
+  // the second half measurements will have an empty last chunk each
   private void createFileWithLastEmptyChunks(int deviceNum, int measurementNum, int seriesPointNum)
       throws IOException, WriteProcessException {
     try (TsFileWriter writer = new TsFileWriter(file)) {

--- a/pom.xml
+++ b/pom.xml
@@ -948,14 +948,14 @@
                                 <rule implementation="org.jacoco.maven.RuleConfiguration">
                                     <element>BUNDLE</element>
                                     <limits>　　
-                                        <!-- Cover methodes >=30%. (the plugin does not support
+                                        <!-- Cover methods >=30%. (the plugin does not support
                                         ignore getter and setter and toString etc..) -->
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>METHOD</counter>
                                             <value>COVEREDRATIO</value>
                                             <minimum>0.00</minimum>
                                         </limit>
-                                        <!-- if-else, swtich etc.. >=70% -->
+                                        <!-- if-else, switch etc.. >=70% -->
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>


### PR DESCRIPTION
## Summary

Repository-wide typo cleanup found with `codespell` and triaged by hand.
**42 fixes across 38 files**, grouped into four commits (`cpp` / `java` /
`docs` / `build`). All changes are limited to comments, Javadoc,
documentation, log/message strings, CMake/`build.sh` messages, and one
file-local C++ variable. No program logic, public identifiers, or test
expectations were modified.

### Representative fixes
- **C++**: `carefull`→careful, `timestmap`→timestamp, `namepsace`→namespace, `diectory`→directory, `genereate`→generate, `usigned`→unsigned, and the file-local parameter `increament`→increment (6 uses in `byte_stream.h`).
- **Java**: `caculate`→calculate (RLE/Zigzag encoders), `colum`→column, `differnt`→different, `perpare`→prepare, `vlaue`→value, `raed`→read, `fot`→for, `pricipal`→principal (Javadoc).
- **i18n** (`messages.properties`): `occured`→occurred and a duplicated `with with` in Sprintz log messages. Only **values** changed; keys are untouched, so the en/zh key-set alignment enforced by `MessagesTest` still holds.
- **Docs**: `aquisition`→acquisition, `severval`→several, `Paritial`→Partial, `wirh`→with, `memroy`→memory. In the Chinese committers doc, `Committe`→`Committer` (the Apache role) — this also repairs a broken anchor so it points to `About.md#committer`, matching the existing `### Committer` heading.
- **Build**: `methodes`→methods, `swtich`→switch in `pom.xml` JaCoCo comments.

### Intentionally NOT changed
- `QueryExpression::destory()` in `cpp/src/reader/expression.{cc,h}` — it is a **public API method name**; renaming would be a breaking change and belongs in a dedicated refactor.
- i18n `supproted` / `greather` — explicitly preserved for backward compatibility (documented inline in the resource bundle).
- `bais` (= `ByteArrayInputStream` convention), `notIn` / `testIn` (API and test method names) — identifiers, not typos.
- `external/commons/collections4/*` (`overriden`, `removeable`, `tothe`) — vendored Apache Commons code, left as-is to ease upstream syncing.

## Test plan
- [ ] `./mvnw spotless:check` (formatting unaffected — comment/string-only edits)
- [ ] `./mvnw clean verify -P with-java` (sanity; `MessagesTest` should still pass since only message values changed)
- [ ] `./mvnw clean verify -P with-cpp` (comment/variable-only changes; build unaffected)