### PR TITLE
Fix Windows CI failures for the Python wheel build.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -281,7 +281,7 @@ jobs:
           case "${{ matrix.python-version }}" in
             3.9) BLACK_VER_PROP="-Dblack.version=25.11.0" ;;
           esac
-          ../mvnw package -DskipTests \
+          ../mvnw package -DskipTests -Dmaven.test.skip=true \
             -Dspotless.check.skip=true -Dspotless.apply.skip=true \
             ${BLACK_VER_PROP}
           ls -la dist/

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -206,6 +206,9 @@ jobs:
             -Dspotless.check.skip=true -Dspotless.apply.skip=true
           test -d cpp/target/build/lib
           test -d cpp/target/build/include
+          cp /mingw64/bin/libstdc++-6.dll cpp/target/build/lib/
+          cp /mingw64/bin/libgcc_s_seh-1.dll cpp/target/build/lib/
+          cp /mingw64/bin/libwinpthread-1.dll cpp/target/build/lib/
 
       - name: Upload C++ build output
         uses: actions/upload-artifact@v7
@@ -265,6 +268,9 @@ jobs:
           ls -laR cpp/target/build/include/
           test -f cpp/target/build/lib/libtsfile.dll
           test -f cpp/target/build/lib/libtsfile.dll.a
+          test -f cpp/target/build/lib/libstdc++-6.dll
+          test -f cpp/target/build/lib/libgcc_s_seh-1.dll
+          test -f cpp/target/build/lib/libwinpthread-1.dll
 
       - name: Build wheel
         shell: msys2 {0}
@@ -300,4 +306,3 @@ jobs:
         with:
           name: tsfile-wheels-windows-py${{ matrix.python-version }}
           path: python/dist/*.whl
-

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -257,13 +257,22 @@ jobs:
           name: tsfile-cpp-windows
           path: cpp/target/build/
 
+      - name: Verify C++ artifacts exist
+        shell: msys2 {0}
+        run: |
+          set -euxo pipefail
+          ls -laR cpp/target/build/lib/
+          ls -laR cpp/target/build/include/
+          test -f cpp/target/build/lib/libtsfile.dll
+          test -f cpp/target/build/lib/libtsfile.dll.a
+
       - name: Build wheel
         shell: msys2 {0}
         run: |
           set -euxo pipefail
           export JAVA_HOME="$(cygpath "$JAVA_HOME")"
           export PYTHON_HOME="$(cygpath "$pythonLocation")"
-          export PATH="$PYTHON_HOME:$PYTHON_HOME/Scripts:$JAVA_HOME/bin:$PATH"
+          export PATH="/mingw64/bin:$PYTHON_HOME:$PYTHON_HOME/Scripts:$JAVA_HOME/bin:$PATH"
 
           # Build wheel via Maven (no clean — keep C++ artifacts from previous job)
           chmod +x mvnw || true
@@ -278,8 +287,11 @@ jobs:
           ls -la dist/
 
       - name: Verify wheel
-        shell: bash
+        shell: msys2 {0}
         run: |
+          set -euxo pipefail
+          export PYTHON_HOME="$(cygpath "$pythonLocation")"
+          export PATH="$PYTHON_HOME:$PYTHON_HOME/Scripts:$PATH"
           python -m pip install python/dist/*.whl
           python -c "import tsfile, tsfile.tsfile_reader as r; print('import-ok')"
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -29,7 +29,7 @@ endif ()
 if (POLICY CMP0079)
     cmake_policy(SET CMP0079 NEW)
 endif ()
-set(TsFile_CPP_VERSION 2.2.1.dev)
+set(TsFile_CPP_VERSION 2.3.1)
 
 if (MSVC)
     # MSVC does not provide a /std:c++11 flag; C++11 is its implicit baseline.

--- a/cpp/src/reader/filter/and_filter.h
+++ b/cpp/src/reader/filter/and_filter.h
@@ -30,22 +30,22 @@ class AndFilter : public BinaryFilter {
     ~AndFilter() {}
     AndFilter(Filter* left, Filter* right) : BinaryFilter(left, right) {}
 
-    FORCE_INLINE bool satisfy(Statistic* statistic) {
+    bool satisfy(Statistic* statistic) {
         return left_->satisfy(statistic) && right_->satisfy(statistic);
     }
 
-    FORCE_INLINE bool satisfy(int64_t time, int64_t value) {
+    bool satisfy(int64_t time, int64_t value) {
         return left_->satisfy(time, value) && right_->satisfy(time, value);
     }
 
-    FORCE_INLINE bool satisfy_start_end_time(int64_t start_time,
-                                             int64_t end_time) {
+    bool satisfy_start_end_time(int64_t start_time,
+                                int64_t end_time) {
         return left_->satisfy_start_end_time(start_time, end_time) &&
                right_->satisfy_start_end_time(start_time, end_time);
     }
 
-    FORCE_INLINE bool contain_start_end_time(int64_t start_time,
-                                             int64_t end_time) {
+    bool contain_start_end_time(int64_t start_time,
+                                int64_t end_time) {
         return left_->contain_start_end_time(start_time, end_time) &&
                right_->contain_start_end_time(start_time, end_time);
     }

--- a/cpp/src/reader/filter/and_filter.h
+++ b/cpp/src/reader/filter/and_filter.h
@@ -38,14 +38,12 @@ class AndFilter : public BinaryFilter {
         return left_->satisfy(time, value) && right_->satisfy(time, value);
     }
 
-    FORCE_INLINE bool satisfy_start_end_time(int64_t start_time,
-                                             int64_t end_time) {
+    bool satisfy_start_end_time(int64_t start_time, int64_t end_time) {
         return left_->satisfy_start_end_time(start_time, end_time) &&
                right_->satisfy_start_end_time(start_time, end_time);
     }
 
-    FORCE_INLINE bool contain_start_end_time(int64_t start_time,
-                                             int64_t end_time) {
+    bool contain_start_end_time(int64_t start_time, int64_t end_time) {
         return left_->contain_start_end_time(start_time, end_time) &&
                right_->contain_start_end_time(start_time, end_time);
     }

--- a/cpp/src/reader/filter/and_filter.h
+++ b/cpp/src/reader/filter/and_filter.h
@@ -30,7 +30,7 @@ class AndFilter : public BinaryFilter {
     ~AndFilter() {}
     AndFilter(Filter* left, Filter* right) : BinaryFilter(left, right) {}
 
-    bool satisfy(Statistic* statistic) {
+    FORCE_INLINE bool satisfy(Statistic* statistic) {
         return left_->satisfy(statistic) && right_->satisfy(statistic);
     }
 
@@ -38,12 +38,14 @@ class AndFilter : public BinaryFilter {
         return left_->satisfy(time, value) && right_->satisfy(time, value);
     }
 
-    bool satisfy_start_end_time(int64_t start_time, int64_t end_time) {
+    FORCE_INLINE bool satisfy_start_end_time(int64_t start_time,
+                                             int64_t end_time) {
         return left_->satisfy_start_end_time(start_time, end_time) &&
                right_->satisfy_start_end_time(start_time, end_time);
     }
 
-    bool contain_start_end_time(int64_t start_time, int64_t end_time) {
+    FORCE_INLINE bool contain_start_end_time(int64_t start_time,
+                                             int64_t end_time) {
         return left_->contain_start_end_time(start_time, end_time) &&
                right_->contain_start_end_time(start_time, end_time);
     }

--- a/cpp/src/reader/filter/and_filter.h
+++ b/cpp/src/reader/filter/and_filter.h
@@ -38,14 +38,12 @@ class AndFilter : public BinaryFilter {
         return left_->satisfy(time, value) && right_->satisfy(time, value);
     }
 
-    bool satisfy_start_end_time(int64_t start_time,
-                                int64_t end_time) {
+    bool satisfy_start_end_time(int64_t start_time, int64_t end_time) {
         return left_->satisfy_start_end_time(start_time, end_time) &&
                right_->satisfy_start_end_time(start_time, end_time);
     }
 
-    bool contain_start_end_time(int64_t start_time,
-                                int64_t end_time) {
+    bool contain_start_end_time(int64_t start_time, int64_t end_time) {
         return left_->contain_start_end_time(start_time, end_time) &&
                right_->contain_start_end_time(start_time, end_time);
     }

--- a/cpp/src/reader/filter/and_filter.h
+++ b/cpp/src/reader/filter/and_filter.h
@@ -30,7 +30,7 @@ class AndFilter : public BinaryFilter {
     ~AndFilter() {}
     AndFilter(Filter* left, Filter* right) : BinaryFilter(left, right) {}
 
-    FORCE_INLINE bool satisfy(Statistic* statistic) {
+    bool satisfy(Statistic* statistic) {
         return left_->satisfy(statistic) && right_->satisfy(statistic);
     }
 

--- a/cpp/src/reader/filter/or_filter.h
+++ b/cpp/src/reader/filter/or_filter.h
@@ -30,7 +30,7 @@ class OrFilter : public BinaryFilter {
     OrFilter(Filter* left, Filter* right) : BinaryFilter(left, right) {}
     ~OrFilter() {}
 
-    bool satisfy(Statistic* statistic) {
+    FORCE_INLINE bool satisfy(Statistic* statistic) {
         return left_->satisfy(statistic) || right_->satisfy(statistic);
     }
 
@@ -38,12 +38,14 @@ class OrFilter : public BinaryFilter {
         return left_->satisfy(time, value) || right_->satisfy(time, value);
     }
 
-    bool satisfy_start_end_time(int64_t start_time, int64_t end_time) {
+    FORCE_INLINE bool satisfy_start_end_time(int64_t start_time,
+                                             int64_t end_time) {
         return left_->satisfy_start_end_time(start_time, end_time) ||
                right_->satisfy_start_end_time(start_time, end_time);
     }
 
-    bool contain_start_end_time(int64_t start_time, int64_t end_time) {
+    FORCE_INLINE bool contain_start_end_time(int64_t start_time,
+                                             int64_t end_time) {
         return left_->contain_start_end_time(start_time, end_time) ||
                right_->contain_start_end_time(start_time, end_time);
     }

--- a/cpp/src/reader/filter/or_filter.h
+++ b/cpp/src/reader/filter/or_filter.h
@@ -30,7 +30,7 @@ class OrFilter : public BinaryFilter {
     OrFilter(Filter* left, Filter* right) : BinaryFilter(left, right) {}
     ~OrFilter() {}
 
-    FORCE_INLINE bool satisfy(Statistic* statistic) {
+    bool satisfy(Statistic* statistic) {
         return left_->satisfy(statistic) || right_->satisfy(statistic);
     }
 

--- a/cpp/src/reader/filter/or_filter.h
+++ b/cpp/src/reader/filter/or_filter.h
@@ -38,14 +38,12 @@ class OrFilter : public BinaryFilter {
         return left_->satisfy(time, value) || right_->satisfy(time, value);
     }
 
-    bool satisfy_start_end_time(int64_t start_time,
-                                int64_t end_time) {
+    bool satisfy_start_end_time(int64_t start_time, int64_t end_time) {
         return left_->satisfy_start_end_time(start_time, end_time) ||
                right_->satisfy_start_end_time(start_time, end_time);
     }
 
-    bool contain_start_end_time(int64_t start_time,
-                                int64_t end_time) {
+    bool contain_start_end_time(int64_t start_time, int64_t end_time) {
         return left_->contain_start_end_time(start_time, end_time) ||
                right_->contain_start_end_time(start_time, end_time);
     }

--- a/cpp/src/reader/filter/or_filter.h
+++ b/cpp/src/reader/filter/or_filter.h
@@ -38,14 +38,12 @@ class OrFilter : public BinaryFilter {
         return left_->satisfy(time, value) || right_->satisfy(time, value);
     }
 
-    FORCE_INLINE bool satisfy_start_end_time(int64_t start_time,
-                                             int64_t end_time) {
+    bool satisfy_start_end_time(int64_t start_time, int64_t end_time) {
         return left_->satisfy_start_end_time(start_time, end_time) ||
                right_->satisfy_start_end_time(start_time, end_time);
     }
 
-    FORCE_INLINE bool contain_start_end_time(int64_t start_time,
-                                             int64_t end_time) {
+    bool contain_start_end_time(int64_t start_time, int64_t end_time) {
         return left_->contain_start_end_time(start_time, end_time) ||
                right_->contain_start_end_time(start_time, end_time);
     }

--- a/cpp/src/reader/filter/or_filter.h
+++ b/cpp/src/reader/filter/or_filter.h
@@ -30,22 +30,22 @@ class OrFilter : public BinaryFilter {
     OrFilter(Filter* left, Filter* right) : BinaryFilter(left, right) {}
     ~OrFilter() {}
 
-    FORCE_INLINE bool satisfy(Statistic* statistic) {
+    bool satisfy(Statistic* statistic) {
         return left_->satisfy(statistic) || right_->satisfy(statistic);
     }
 
-    FORCE_INLINE bool satisfy(int64_t time, int64_t value) {
+    bool satisfy(int64_t time, int64_t value) {
         return left_->satisfy(time, value) || right_->satisfy(time, value);
     }
 
-    FORCE_INLINE bool satisfy_start_end_time(int64_t start_time,
-                                             int64_t end_time) {
+    bool satisfy_start_end_time(int64_t start_time,
+                                int64_t end_time) {
         return left_->satisfy_start_end_time(start_time, end_time) ||
                right_->satisfy_start_end_time(start_time, end_time);
     }
 
-    FORCE_INLINE bool contain_start_end_time(int64_t start_time,
-                                             int64_t end_time) {
+    bool contain_start_end_time(int64_t start_time,
+                                int64_t end_time) {
         return left_->contain_start_end_time(start_time, end_time) ||
                right_->contain_start_end_time(start_time, end_time);
     }

--- a/python/pom.xml
+++ b/python/pom.xml
@@ -142,6 +142,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
+                            <skip>${skipTests:-false}</skip>
                             <executable>${python.venv.bin}${python.exe.bin}</executable>
                             <arguments>
                                 <argument>-m</argument>
@@ -158,6 +159,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
+                            <skip>${skipTests:-false}</skip>
                             <executable>${python.venv.bin}pytest</executable>
                             <arguments>
                                 <argument>${project.basedir}/tests</argument>

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -28,7 +28,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tsfile"
-version = "2.2.1.dev"
+version = "2.3.1"
 requires-python = ">=3.9"
 description = "TsFile Python"
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/python/setup.py
+++ b/python/setup.py
@@ -30,7 +30,7 @@ from setuptools.command.build_ext import build_ext
 ROOT = Path(__file__).parent.resolve()
 PKG = ROOT / "tsfile"
 
-version = "2.2.1.dev"
+version = "2.3.1"
 
 
 def _find_cpp_build():
@@ -214,8 +214,11 @@ elif sys.platform == "darwin":
     extra_compile_args += ["-O3", "-std=c++11", "-fvisibility=hidden", "-fPIC"]
     extra_link_args += ["-Wl,-rpath,@loader_path", "-stdlib=libc++"]
 elif sys.platform == "win32":
-    libraries = ["tsfile"]
     if win_toolchain == "mingw":
+        # Resolve EH/runtime symbols from MinGW runtimes before libtsfile.dll.a.
+        # Otherwise _Unwind_Resume is recorded against libtsfile.dll and loading
+        # the .pyd fails with WinError 127 on Windows.
+        libraries = ["gcc_s", "stdc++", "tsfile"]
         extra_compile_args += [
             "-O2",
             "-std=c++11",
@@ -225,6 +228,7 @@ elif sys.platform == "win32":
             "-D_WIN64",
         ]
     else:  # msvc
+        libraries = ["tsfile"]
         # cl.exe rejects the GCC-style flags above. Mirror the options the
         # C++ module itself is built with (see cpp/CMakeLists.txt). C++17 is
         # required because Cython 3 emits inline variables (error C7525); the

--- a/python/setup.py
+++ b/python/setup.py
@@ -151,19 +151,36 @@ elif sys.platform == "win32":
         # Copy MinGW runtime DLLs next to tsfile.dll so Python can find them.
         # Python 3.8+ does not search PATH for DLLs; they must sit in the
         # same directory as the .pyd extensions (os.add_dll_directory).
+        _mingw_search_dirs = []
+        for _dir in os.environ.get("PATH", "").split(os.pathsep):
+            if _dir:
+                _mingw_search_dirs.append(Path(_dir))
+        _msys_prefix = os.environ.get("MSYSTEM_PREFIX")
+        if _msys_prefix:
+            _mingw_search_dirs.append(Path(_msys_prefix) / "bin")
+        for _extra in (
+            Path("C:/msys64/mingw64/bin"),
+            Path("C:/ProgramData/mingw64/mingw64/bin"),
+        ):
+            if _extra.is_dir():
+                _mingw_search_dirs.append(_extra)
+
         for _mingw_dll in (
             "libstdc++-6.dll",
             "libgcc_s_seh-1.dll",
             "libwinpthread-1.dll",
         ):
-            for _dir in os.environ.get("PATH", "").split(os.pathsep):
-                _src = Path(_dir) / _mingw_dll
+            for _dir in _mingw_search_dirs:
+                _src = _dir / _mingw_dll
                 if _src.is_file():
                     shutil.copy2(_src, PKG / _mingw_dll)
                     print(f"setup.py: copied {_mingw_dll} from {_src}")
                     break
             else:
-                print(f"setup.py: WARNING - {_mingw_dll} not found on PATH")
+                raise FileNotFoundError(
+                    f"setup.py: MinGW runtime DLL {_mingw_dll} not found; "
+                    "ensure mingw-w64-x86_64-gcc is on PATH or MSYSTEM_PREFIX is set"
+                )
 else:
     raise RuntimeError(f"Unsupported platform: {sys.platform}")
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -30,7 +30,7 @@ from setuptools.command.build_ext import build_ext
 ROOT = Path(__file__).parent.resolve()
 PKG = ROOT / "tsfile"
 
-version = "2.3.1"
+version = "2.2.1.dev"
 
 
 def _find_cpp_build():

--- a/python/setup.py
+++ b/python/setup.py
@@ -151,7 +151,11 @@ elif sys.platform == "win32":
         # Copy MinGW runtime DLLs next to tsfile.dll so Python can find them.
         # Python 3.8+ does not search PATH for DLLs; they must sit in the
         # same directory as the .pyd extensions (os.add_dll_directory).
-        _mingw_search_dirs = []
+        # Prefer runtime DLLs captured from the same MSYS2 environment that
+        # built libtsfile.dll.  Mixing MinGW runtime DLLs from a different
+        # install can load successfully but fail later with WinError 127 when
+        # libtsfile.dll imports a newer runtime symbol.
+        _mingw_search_dirs = [CPP_LIB]
         for _dir in os.environ.get("PATH", "").split(os.pathsep):
             if _dir:
                 _mingw_search_dirs.append(Path(_dir))

--- a/python/setup.py
+++ b/python/setup.py
@@ -30,7 +30,7 @@ from setuptools.command.build_ext import build_ext
 ROOT = Path(__file__).parent.resolve()
 PKG = ROOT / "tsfile"
 
-version = "2.2.1.dev"
+version = "2.3.1"
 
 
 def _find_cpp_build():

--- a/python/tsfile/__init__.py
+++ b/python/tsfile/__init__.py
@@ -22,15 +22,32 @@ import sys
 
 _pkg_dir = os.path.dirname(os.path.abspath(__file__))
 
+
+def _preload_dll(path):
+    if not os.path.isfile(path):
+        return
+    try:
+        ctypes.CDLL(path)
+    except OSError:
+        pass
+
+
 if sys.platform == "win32":
     # Keep the handle alive for the lifetime of this module. CPython's reference
     # counting frees the object immediately if not stored, which calls
     # RemoveDllDirectory and undoes the registration before any .pyd is loaded.
     _dll_dir = os.add_dll_directory(_pkg_dir)
-    # Preload the tsfile DLL so Windows finds it by base-name when loading the
-    # Cython extensions. Store the handle to prevent the DLL from being
-    # unloaded prematurely.
+    # Preload MinGW runtime DLLs before libtsfile.dll. Python 3.8+ does not
+    # search PATH for DLL dependencies; they must live next to the extensions.
+    for _mingw_dll in (
+        "libwinpthread-1.dll",
+        "libgcc_s_seh-1.dll",
+        "libstdc++-6.dll",
+    ):
+        _preload_dll(os.path.join(_pkg_dir, _mingw_dll))
+    # Preload the tsfile DLL so Windows finds it when loading Cython extensions.
     # MSVC builds produce "tsfile.dll"; MinGW builds produce "libtsfile.dll".
+    _tsfile_cdll = None
     for _dll_name in ("tsfile.dll", "libtsfile.dll"):
         _tsfile_dll = os.path.join(_pkg_dir, _dll_name)
         if os.path.isfile(_tsfile_dll):


### PR DESCRIPTION
  Changes:

  - Fix MinGW C++ build failure by removing problematic FORCE_INLINE usage from AndFilter and OrFilter.
  - Package and preload required MinGW runtime DLLs with Windows wheels to avoid WinError 127 on import.
  - Ensure Windows wheel jobs use the expected Python/MSYS2 paths and verify C++ artifacts before building wheels.
  - Skip Python tests during wheel packaging while keeping wheel import verification.
  - Sync Python package version to 2.3.1.
  - Fix C++ Spotless formatting violations.

  Validation:

  - mvnw.cmd -P with-cpp spotless:check
  - pytest tests on Windows, 144 passed.