### PR TITLE
Drop CMAKE_CURRENT_SOURCE_DIR from tsfile-cli include dirs

### DIFF
--- a/cpp/tools/CMakeLists.txt
+++ b/cpp/tools/CMakeLists.txt
@@ -26,7 +26,7 @@ add_library(tsfile_cli_obj OBJECT ${TSFILE_CLI_SRCS})
 # Tool-own headers (cli/, commands/, format/) resolve from this directory;
 # library headers come from the staged include tree like the rest of the build.
 target_include_directories(tsfile_cli_obj PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_SOURCE_DIR}/tools
         ${LIBRARY_INCLUDE_DIR}
         ${THIRD_PARTY_INCLUDE})
 
@@ -39,7 +39,7 @@ target_compile_definitions(tsfile_cli_obj PRIVATE
         TSFILE_CLI_VERSION="${TsFile_CPP_VERSION}")
 
 add_executable(tsfile_cli tools_main.cc $<TARGET_OBJECTS:tsfile_cli_obj>)
-target_include_directories(tsfile_cli PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(tsfile_cli PRIVATE ${CMAKE_SOURCE_DIR}/tools)
 target_link_libraries(tsfile_cli tsfile)
 set_target_properties(tsfile_cli PROPERTIES
         OUTPUT_NAME tsfile-cli


### PR DESCRIPTION
## Summary
- Replace `${CMAKE_CURRENT_SOURCE_DIR}` with `${CMAKE_SOURCE_DIR}/tools` in `cpp/tools/CMakeLists.txt`, for both the `tsfile_cli_obj` object library and the `tsfile_cli` executable. Addresses post-merge review feedback on #829.
- Matches the existing convention in `cpp/test/CMakeLists.txt`, which already uses `${CMAKE_SOURCE_DIR}/tools` for tool headers. Tool-own headers (`cli/`, `commands/`, `format/`) still resolve; library headers continue to come from the staged include tree.

## Test plan
- [x] Debug build (`-DENABLE_ANTLR4=OFF`): `tsfile` library + `tsfile_cli` compile and link; all headers resolve from the staged include tree.
- [x] `tsfile-cli --version` / `--help` run correctly.