### PR TITLE
Remove unused PROJECT_SRC_DIR from cpp CMakeLists

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -244,9 +244,6 @@ endif()
 # All libs will be stored here, including libtsfile, compress-encoding lib.
 set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 
-# TsFile code will be stored here.
-set(PROJECT_SRC_DIR ${PROJECT_SOURCE_DIR}/src)
-
 # All include files will be installed here.
 # Use global var so that tests may also use this
 set(LIBRARY_INCLUDE_DIR ${PROJECT_BINARY_DIR}/include CACHE STRING "TsFile includes")


### PR DESCRIPTION
## Summary
- Delete the dead `PROJECT_SRC_DIR` variable from `cpp/CMakeLists.txt`. It was introduced in #364 and has never been referenced anywhere in the build (verified across the full git history).
- Follow-up to the post-#829 review discussion: consumers (CLI, tests, examples, external users) should resolve library headers from the staged include tree (`LIBRARY_INCLUDE_DIR`) and link the shared library, never reach into `cpp/src` — so a variable pointing at the source tree should not exist as a temptation for future targets.

## Test plan
- [x] Fresh Debug configure + full build (`-DBUILD_TEST=ON -DENABLE_ANTLR4=OFF`): library, `tsfile-cli`, and `TsFile_Test` all compile and link.
- [x] Full GTest regression suite: 641 tests from 106 suites, all passed.
- [x] `tsfile-cli` smoke: `--version` / `--help`, plus a `write` (stdin CSV) → `count` → `cat` round-trip.
- [x] `grep PROJECT_SRC_DIR` over the repo and the generated `CMakeCache.txt`: zero remaining references.