### PR TITLE
[Python][C++] Fix tree-model TsFileDataFrame returning empty data on reused readers and uppercase names

### DIFF
--- a/cpp/src/common/device_id.cc
+++ b/cpp/src/common/device_id.cc
@@ -103,6 +103,13 @@ std::string StringArrayDeviceID::get_device_name() const {
 }
 
 void StringArrayDeviceID::init_prefix_segments() {
+    // Idempotent: device IDs are cached and reused across queries, so clear
+    // previous prefixes before rebuilding to avoid accumulation and leaks.
+    for (const auto& prefix_segment : prefix_segments_) {
+        delete prefix_segment;
+    }
+    prefix_segments_.clear();
+
 #ifdef ENABLE_ANTLR4
     auto splits = storage::PathNodesGenerator::invokeParser(*segments_[0]);
 #else
@@ -130,6 +137,7 @@ int StringArrayDeviceID::serialize(common::ByteStream& write_stream) {
 
 int StringArrayDeviceID::deserialize(common::ByteStream& read_stream) {
     int ret = common::E_OK;
+
     uint32_t num_segments;
     if (RET_FAIL(common::SerializationUtil::read_var_uint(num_segments,
                                                           read_stream))) {

--- a/cpp/src/common/schema.h
+++ b/cpp/src/common/schema.h
@@ -209,7 +209,6 @@ class TableSchema {
             to_lowercase_inplace(table_name_);
         }
         for (const common::ColumnSchema& column_schema : column_schemas) {
-
             column_schemas_.emplace_back(std::make_shared<MeasurementSchema>(
                 column_schema.get_column_name(),
                 column_schema.get_data_type()));
@@ -459,7 +458,6 @@ class TableSchema {
         for (size_t i = 0; i < column_schemas_.size(); ++i) {
             if (column_schemas_[i]->measurement_name_ == lookup_name &&
                 column_categories_[i] == common::ColumnCategory::TAG) {
-
                 return column_order;
             } else if (column_categories_[i] == common::ColumnCategory::TAG) {
                 column_order++;

--- a/cpp/src/common/schema.h
+++ b/cpp/src/common/schema.h
@@ -198,9 +198,19 @@ class TableSchema {
      * in the table.
      */
     TableSchema(const std::string& table_name,
-                const std::vector<common::ColumnSchema>& column_schemas)
-        : table_name_(table_name), updatable_(false) {
-        to_lowercase_inplace(table_name_);
+                const std::vector<common::ColumnSchema>& column_schemas,
+                bool virtual_table = false)
+        : table_name_(table_name),
+          is_virtual_table_(virtual_table),
+          updatable_(false) {
+        // Virtual tables are synthesized from tree-model paths, where device
+        // path segments and measurement names are case-sensitive. Only real
+        // (table-model) schemas are normalized to lower case; lower-casing a
+        // tree schema would collapse case-distinct measurements (e.g.
+        // "temperature" and "Temperature") into a single column.
+        if (!is_virtual_table_) {
+            to_lowercase_inplace(table_name_);
+        }
         for (const common::ColumnSchema& column_schema : column_schemas) {
             column_schemas_.emplace_back(std::make_shared<MeasurementSchema>(
                 column_schema.get_column_name(),
@@ -210,7 +220,9 @@ class TableSchema {
         }
         int idx = 0;
         for (const auto& measurement_schema : column_schemas_) {
-            to_lowercase_inplace(measurement_schema->measurement_name_);
+            if (!is_virtual_table_) {
+                to_lowercase_inplace(measurement_schema->measurement_name_);
+            }
             column_pos_index_.insert(
                 std::make_pair(measurement_schema->measurement_name_, idx++));
         }
@@ -325,21 +337,23 @@ class TableSchema {
     int32_t get_columns_num() const { return column_schemas_.size(); }
 
     int find_column_index(const std::string& column_name) {
-        std::string lower_case_column_name = to_lower(column_name);
-        auto it = column_pos_index_.find(lower_case_column_name);
+        // Real tables are case-insensitive; virtual (tree-derived) tables keep
+        // the original casing so case-distinct measurements stay separate.
+        std::string lookup_name =
+            is_virtual_table_ ? column_name : to_lower(column_name);
+        auto it = column_pos_index_.find(lookup_name);
         if (it != column_pos_index_.end()) {
             return it->second;
         } else {
             int index = -1;
             for (size_t i = 0; i < column_schemas_.size(); ++i) {
-                if (column_schemas_[i]->measurement_name_ ==
-                    lower_case_column_name) {
+                if (column_schemas_[i]->measurement_name_ == lookup_name) {
                     index = static_cast<int>(i);
                     break;
                 }
             }
             if (index != -1) {
-                column_pos_index_[lower_case_column_name] = index;
+                column_pos_index_[lookup_name] = index;
             }
             return index;
         }
@@ -440,13 +454,14 @@ class TableSchema {
     }
 
     int32_t find_id_column_order(const std::string& column_name) {
-        std::string lower_case_column_name = to_lower(column_name);
+        std::string lookup_name =
+            is_virtual_table_ ? column_name : to_lower(column_name);
 
         int column_order = 0;
         for (size_t i = 0; i < column_schemas_.size(); ++i) {
-            if (column_schemas_[i]->measurement_name_ ==
-                    lower_case_column_name &&
+            if (column_schemas_[i]->measurement_name_ == lookup_name &&
                 column_categories_[i] == common::ColumnCategory::TAG) {
+
                 return column_order;
             } else if (column_categories_[i] == common::ColumnCategory::TAG) {
                 column_order++;

--- a/cpp/src/common/schema.h
+++ b/cpp/src/common/schema.h
@@ -203,15 +203,13 @@ class TableSchema {
         : table_name_(table_name),
           is_virtual_table_(virtual_table),
           updatable_(false) {
-        // Virtual tables are synthesized from tree-model paths, where device
-        // path segments and measurement names are case-sensitive. Only real
-        // (table-model) schemas are normalized to lower case; lower-casing a
-        // tree schema would collapse case-distinct measurements (e.g.
-        // "temperature" and "Temperature") into a single column.
+        // Virtual (tree-derived) schemas are case-sensitive; only real tables
+        // are normalized to lower case.
         if (!is_virtual_table_) {
             to_lowercase_inplace(table_name_);
         }
         for (const common::ColumnSchema& column_schema : column_schemas) {
+
             column_schemas_.emplace_back(std::make_shared<MeasurementSchema>(
                 column_schema.get_column_name(),
                 column_schema.get_data_type()));
@@ -337,9 +335,9 @@ class TableSchema {
     int32_t get_columns_num() const { return column_schemas_.size(); }
 
     int find_column_index(const std::string& column_name) {
-        // Real tables are case-insensitive; virtual (tree-derived) tables keep
-        // the original casing so case-distinct measurements stay separate.
+        // Virtual tables match case-sensitively; real tables are lower-cased.
         std::string lookup_name =
+
             is_virtual_table_ ? column_name : to_lower(column_name);
         auto it = column_pos_index_.find(lookup_name);
         if (it != column_pos_index_.end()) {

--- a/cpp/src/reader/table_query_executor.cc
+++ b/cpp/src/reader/table_query_executor.cc
@@ -233,8 +233,12 @@ int TableQueryExecutor::query_on_tree(
         }
     }
 
-    auto schema = std::make_shared<TableSchema>("default", col_schema);
-    schema->set_virtual_table();
+    // Tree-derived (virtual) tables are case-sensitive: keep the original
+    // casing of device path segments and measurement names so that
+    // case-distinct series (e.g. "temperature" vs "Temperature") map to
+    // separate columns instead of colliding.
+    auto schema = std::make_shared<TableSchema>("default", col_schema,
+                                                /*virtual_table=*/true);
     std::shared_ptr<ColumnMapping> column_mapping =
         std::make_shared<ColumnMapping>();
     for (size_t i = 0; i < col_schema.size(); ++i) {

--- a/cpp/test/common/device_id_test.cc
+++ b/cpp/test/common/device_id_test.cc
@@ -99,4 +99,24 @@ TEST(DeviceIdTest, NullTagVsLiteralNullAreDistinct) {
     ASSERT_FALSE(null_first == literal_null);
     ASSERT_TRUE(null_first != literal_null);
 }
+
+// Regression: cached device IDs are reused across queries, so
+// split_table_name() must be idempotent and not accumulate prefix segments.
+TEST(DeviceIdTest, SplitTableNameIsIdempotent) {
+    StringArrayDeviceID device_id("root.ln.wf01.wt01");
+
+    const std::vector<std::string> expected = {"root", "ln", "wf01", "wt01"};
+
+    for (int round = 0; round < 3; ++round) {
+        device_id.split_table_name();
+
+        ASSERT_EQ(static_cast<int>(expected.size()),
+                  device_id.get_split_seg_num());
+        for (int i = 0; i < device_id.get_split_seg_num(); ++i) {
+            std::string* seg = device_id.get_split_segname_at(i);
+            ASSERT_NE(nullptr, seg);
+            ASSERT_EQ(expected[static_cast<size_t>(i)], *seg);
+        }
+    }
+}
 }  // namespace storage

--- a/python/tests/test_tsfile_dataset.py
+++ b/python/tests/test_tsfile_dataset.py
@@ -1552,7 +1552,6 @@ def test_dataset_tree_model_reads_uppercase_measurement_names(tmp_path):
 
 
 def test_tree_reader_handles_stale_path_columns_after_reused_queries(tmp_path):
-
     """Reusing a reader must not leak prefix path state across queries.
 
     Reading one device series then another reuses the cached device id; stale

--- a/python/tests/test_tsfile_dataset.py
+++ b/python/tests/test_tsfile_dataset.py
@@ -1551,6 +1551,98 @@ def test_dataset_tree_model_reads_uppercase_measurement_names(tmp_path):
         )
 
 
+def test_dataset_tree_model_case_distinct_measurements_do_not_collide(tmp_path, capsys):
+    """Case-distinct measurements on one device must not be conflated.
+
+    ``temperature`` and ``Temperature`` are two independent series; each must
+    return its own values instead of an empty array or the other's data.
+    """
+    from tsfile import Field, RowRecord, TimeseriesSchema, TsFileWriter
+
+    path = tmp_path / "tree_case.tsfile"
+
+    writer = TsFileWriter(str(path))
+    writer.register_timeseries(
+        "root.case.d1", TimeseriesSchema("temperature", TSDataType.DOUBLE)
+    )
+    writer.register_timeseries(
+        "root.case.d1", TimeseriesSchema("Temperature", TSDataType.DOUBLE)
+    )
+    for t in range(3):
+        writer.write_row_record(
+            RowRecord(
+                "root.case.d1",
+                t,
+                [
+                    Field("temperature", 30.0 + t, TSDataType.DOUBLE),
+                    Field("Temperature", 40.0 + t, TSDataType.DOUBLE),
+                ],
+            )
+        )
+    writer.close()
+
+    with TsFileDataFrame(str(path), show_progress=False) as tsdf:
+        # Two independent tree-model series are discovered (case preserved).
+        assert len(tsdf) == 2
+        assert sorted(tsdf.list_timeseries()) == [
+            "root.case.d1.Temperature",
+            "root.case.d1.temperature",
+        ]
+
+        # Metadata layer keeps both rows distinct with their original casing.
+        meta = tsdf.list_timeseries_metadata()
+        assert sorted(meta.index.tolist()) == [
+            "root.case.d1.Temperature",
+            "root.case.d1.temperature",
+        ]
+        for name in ("root.case.d1.temperature", "root.case.d1.Temperature"):
+            assert meta.loc[name, "_col_1"] == "case"
+            assert meta.loc[name, "_col_2"] == "d1"
+            assert meta.loc[name, "count"] == 3
+        assert set(meta["field"]) == {"temperature", "Temperature"}
+
+        # print(tsdf) renders both case-distinct series verbatim. The timestamp
+        # text is derived from format_timestamp so the whole-string match stays
+        # stable across timezones.
+        t0, t2 = format_timestamp(0), format_timestamp(2)
+        expected_repr = "\n".join(
+            [
+                "TsFileDataFrame(tree model, 2 time series, 1 files)",
+                "   _col_1  _col_2        field           start_time                 end_time  count",
+                f"0    case      d1  Temperature  {t0}  {t2}      3",
+                f"1    case      d1  temperature  {t0}  {t2}      3",
+            ]
+        )
+        assert repr(tsdf) == expected_repr
+        print(tsdf)
+        assert capsys.readouterr().out == expected_repr + "\n"
+
+        # Each series must read back its OWN values -- not empty, not the
+        # other's data. Lower-casing anywhere in the read path breaks this.
+        np.testing.assert_array_equal(
+            tsdf["root.case.d1.temperature"][:],
+            np.array([30.0, 31.0, 32.0]),
+        )
+        np.testing.assert_array_equal(
+            tsdf["root.case.d1.Temperature"][:],
+            np.array([40.0, 41.0, 42.0]),
+        )
+
+        # Aligned read of both case-distinct series keeps them separated.
+        aligned = tsdf.loc[
+            0:2,
+            ["root.case.d1.temperature", "root.case.d1.Temperature"],
+        ]
+        assert aligned.series_names == [
+            "root.case.d1.temperature",
+            "root.case.d1.Temperature",
+        ]
+        np.testing.assert_array_equal(
+            aligned.values,
+            np.array([[30.0, 40.0], [31.0, 41.0], [32.0, 42.0]]),
+        )
+
+
 def test_tree_reader_handles_stale_path_columns_after_reused_queries(tmp_path):
     """Reusing a reader must not leak prefix path state across queries.
 

--- a/python/tests/test_tsfile_dataset.py
+++ b/python/tests/test_tsfile_dataset.py
@@ -1507,12 +1507,85 @@ def test_dataset_tree_model_series_access(tmp_path):
         np.testing.assert_array_equal(aligned.timestamps, np.arange(5, dtype=np.int64))
 
 
+def test_dataset_tree_model_reads_uppercase_measurement_names(tmp_path):
+    """Tree-model series with uppercase measurement names must read data.
+
+    Regression: a measurement like ``Temperature``/``STATUS`` must return its
+    values, not an empty array, when read back through TsFileDataFrame.
+    """
+    from tsfile import Field, RowRecord, TimeseriesSchema, TsFileWriter
+
+    path = tmp_path / "tree_upper.tsfile"
+    writer = TsFileWriter(str(path))
+    writer.register_timeseries(
+        "root.ln.wf01.wt01", TimeseriesSchema("Temperature", TSDataType.DOUBLE)
+    )
+    writer.register_timeseries(
+        "root.ln.wf01.wt01", TimeseriesSchema("STATUS", TSDataType.INT32)
+    )
+    for t in range(5):
+        writer.write_row_record(
+            RowRecord(
+                "root.ln.wf01.wt01",
+                t,
+                [
+                    Field("Temperature", float(t) + 0.5, TSDataType.DOUBLE),
+                    Field("STATUS", t * 2, TSDataType.INT32),
+                ],
+            )
+        )
+    writer.close()
+
+    with TsFileDataFrame(str(path), show_progress=False) as tsdf:
+        assert sorted(tsdf.list_timeseries()) == [
+            "root.ln.wf01.wt01.STATUS",
+            "root.ln.wf01.wt01.Temperature",
+        ]
+        np.testing.assert_array_equal(
+            tsdf["root.ln.wf01.wt01.Temperature"][:],
+            np.array([0.5, 1.5, 2.5, 3.5, 4.5]),
+        )
+        np.testing.assert_array_equal(
+            tsdf["root.ln.wf01.wt01.STATUS"][:],
+            np.array([0.0, 2.0, 4.0, 6.0, 8.0]),
+        )
+
+
+def test_tree_reader_handles_stale_path_columns_after_reused_queries(tmp_path):
+
+    """Reusing a reader must not leak prefix path state across queries.
+
+    Reading one device series then another reuses the cached device id; stale
+    prefix segments used to mismatch the device and return empty data.
+    """
+    path = tmp_path / "tree.tsfile"
+    _write_tree_file(path)
+
+    with TsFileDataFrame(str(path), show_progress=False) as tsdf:
+        # First read establishes query state on the reader.
+        np.testing.assert_array_equal(
+            tsdf["root.ln.wf01.wt01.temperature"][:],
+            np.array([0.5, 1.5, 2.5, 3.5, 4.5]),
+        )
+        # Second read reuses the same reader for another device.
+        np.testing.assert_array_equal(
+            tsdf["root.ln.wf02.wt02.status"][:],
+            np.array([0.0, 2.0, 4.0, 6.0, 8.0]),
+        )
+        # Read back the first series to confirm alternating reads stay stable.
+        np.testing.assert_array_equal(
+            tsdf["root.ln.wf01.wt01.temperature"][:],
+            np.array([0.5, 1.5, 2.5, 3.5, 4.5]),
+        )
+
+
 def test_dataset_tree_model_list_timeseries_metadata(tmp_path):
     path = tmp_path / "tree.tsfile"
     _write_tree_file(path)
 
     with TsFileDataFrame(str(path), show_progress=False) as tsdf:
         meta = tsdf.list_timeseries_metadata()
+
         assert isinstance(meta, pd.DataFrame)
         assert list(meta.columns) == [
             "field",

--- a/python/tsfile/dataset/reader.py
+++ b/python/tsfile/dataset/reader.py
@@ -575,23 +575,16 @@ class TsFileSeriesReader:
         # pushdown (query_tree_by_row) isn't reliable in the cwrapper yet
         # (stale col_i path columns leak across queries on a reused reader);
         # see PR #816. Hot path for profilers.
-        # The native tree query normalizes column names and path segments to
-        # lower case (table model is case-insensitive), so match the field name
-        # and device path case-insensitively to preserve the original casing.
-        target_path_lower = [seg.lower() for seg in target_path_segments]
         with self._reader.query_table_on_tree([field_name]) as result_set:
             md = result_set.get_metadata()
             num_cols = md.get_column_num()
             col_names = [md.get_column_name(i + 1) for i in range(num_cols)]
-            lower_col_names = [name.lower() for name in col_names]
             try:
-                field_idx = lower_col_names.index(field_name.lower()) + 1
+                field_idx = col_names.index(field_name) + 1
             except ValueError:
                 return np.array([], dtype=np.int64), np.array([], dtype=np.float64)
             all_col_indices = [
-                idx + 1
-                for idx, name in enumerate(lower_col_names)
-                if name.startswith("col_")
+                idx + 1 for idx, name in enumerate(col_names) if name.startswith("col_")
             ]
             # Only the trailing expected_path_len col_i cells are genuine; the
             # leading duplicates are stale from prior queries on this reader.
@@ -614,11 +607,7 @@ class TsFileSeriesReader:
                 # Trim trailing Nones for the (possibly-shorter) device path.
                 while row_path_segments and row_path_segments[-1] is None:
                     row_path_segments.pop()
-                row_path_lower = [
-                    seg.lower() if isinstance(seg, str) else seg
-                    for seg in row_path_segments
-                ]
-                if row_path_lower != target_path_lower:
+                if row_path_segments != target_path_segments:
                     continue
                 if skipped < offset:
                     skipped += 1
@@ -774,7 +763,6 @@ class TsFileSeriesReader:
             )
 
         target_path_segments = device_path.split(".")
-        target_path_lower = [seg.lower() for seg in target_path_segments]
         expected_path_len = (
             max(len(t.tag_columns) for t in self._catalog.table_entries) + 1
         )
@@ -785,19 +773,16 @@ class TsFileSeriesReader:
         # client-side; aligned reads over N devices are O(N * total_rows).
         # See _read_series_by_row_tree / PR #816 for the cwrapper limitation
         # that blocks per-device pushdown (query_timeseries). Hot path.
-        # The native tree query lower-cases column names and path segments
-        # (table model is case-insensitive), so match both case-insensitively.
         with self._reader.query_table_on_tree(
             field_columns, start_time, end_time
         ) as result_set:
             md = result_set.get_metadata()
             num_cols = md.get_column_num()
             col_names = [md.get_column_name(i + 1) for i in range(num_cols)]
-            lower_col_names = [name.lower() for name in col_names]
             value_indices = {}
             for col in field_columns:
                 try:
-                    value_indices[col] = lower_col_names.index(col.lower()) + 1
+                    value_indices[col] = col_names.index(col) + 1
                 except ValueError:
                     # Column missing (no device in file owns it). Yield empty.
                     return (
@@ -808,9 +793,7 @@ class TsFileSeriesReader:
                         },
                     )
             all_col_indices = [
-                idx + 1
-                for idx, name in enumerate(lower_col_names)
-                if name.startswith("col_")
+                idx + 1 for idx, name in enumerate(col_names) if name.startswith("col_")
             ]
             col_indices = all_col_indices[-expected_path_len:]
             # Fail fast if the cwrapper col_ leak pattern changes: the trailing
@@ -830,11 +813,7 @@ class TsFileSeriesReader:
                 ]
                 while row_path_segments and row_path_segments[-1] is None:
                     row_path_segments.pop()
-                row_path_lower = [
-                    seg.lower() if isinstance(seg, str) else seg
-                    for seg in row_path_segments
-                ]
-                if row_path_lower != target_path_lower:
+                if row_path_segments != target_path_segments:
                     continue
                 ts = int(result_set.get_value_by_index(1))
                 # The on-tree scan already honors start/end_time at the

--- a/python/tsfile/dataset/reader.py
+++ b/python/tsfile/dataset/reader.py
@@ -575,16 +575,23 @@ class TsFileSeriesReader:
         # pushdown (query_tree_by_row) isn't reliable in the cwrapper yet
         # (stale col_i path columns leak across queries on a reused reader);
         # see PR #816. Hot path for profilers.
+        # The native tree query normalizes column names and path segments to
+        # lower case (table model is case-insensitive), so match the field name
+        # and device path case-insensitively to preserve the original casing.
+        target_path_lower = [seg.lower() for seg in target_path_segments]
         with self._reader.query_table_on_tree([field_name]) as result_set:
             md = result_set.get_metadata()
             num_cols = md.get_column_num()
             col_names = [md.get_column_name(i + 1) for i in range(num_cols)]
+            lower_col_names = [name.lower() for name in col_names]
             try:
-                field_idx = col_names.index(field_name) + 1
+                field_idx = lower_col_names.index(field_name.lower()) + 1
             except ValueError:
                 return np.array([], dtype=np.int64), np.array([], dtype=np.float64)
             all_col_indices = [
-                idx + 1 for idx, name in enumerate(col_names) if name.startswith("col_")
+                idx + 1
+                for idx, name in enumerate(lower_col_names)
+                if name.startswith("col_")
             ]
             # Only the trailing expected_path_len col_i cells are genuine; the
             # leading duplicates are stale from prior queries on this reader.
@@ -607,7 +614,11 @@ class TsFileSeriesReader:
                 # Trim trailing Nones for the (possibly-shorter) device path.
                 while row_path_segments and row_path_segments[-1] is None:
                     row_path_segments.pop()
-                if row_path_segments != target_path_segments:
+                row_path_lower = [
+                    seg.lower() if isinstance(seg, str) else seg
+                    for seg in row_path_segments
+                ]
+                if row_path_lower != target_path_lower:
                     continue
                 if skipped < offset:
                     skipped += 1
@@ -763,6 +774,7 @@ class TsFileSeriesReader:
             )
 
         target_path_segments = device_path.split(".")
+        target_path_lower = [seg.lower() for seg in target_path_segments]
         expected_path_len = (
             max(len(t.tag_columns) for t in self._catalog.table_entries) + 1
         )
@@ -773,16 +785,19 @@ class TsFileSeriesReader:
         # client-side; aligned reads over N devices are O(N * total_rows).
         # See _read_series_by_row_tree / PR #816 for the cwrapper limitation
         # that blocks per-device pushdown (query_timeseries). Hot path.
+        # The native tree query lower-cases column names and path segments
+        # (table model is case-insensitive), so match both case-insensitively.
         with self._reader.query_table_on_tree(
             field_columns, start_time, end_time
         ) as result_set:
             md = result_set.get_metadata()
             num_cols = md.get_column_num()
             col_names = [md.get_column_name(i + 1) for i in range(num_cols)]
+            lower_col_names = [name.lower() for name in col_names]
             value_indices = {}
             for col in field_columns:
                 try:
-                    value_indices[col] = col_names.index(col) + 1
+                    value_indices[col] = lower_col_names.index(col.lower()) + 1
                 except ValueError:
                     # Column missing (no device in file owns it). Yield empty.
                     return (
@@ -793,7 +808,9 @@ class TsFileSeriesReader:
                         },
                     )
             all_col_indices = [
-                idx + 1 for idx, name in enumerate(col_names) if name.startswith("col_")
+                idx + 1
+                for idx, name in enumerate(lower_col_names)
+                if name.startswith("col_")
             ]
             col_indices = all_col_indices[-expected_path_len:]
             # Fail fast if the cwrapper col_ leak pattern changes: the trailing
@@ -813,7 +830,11 @@ class TsFileSeriesReader:
                 ]
                 while row_path_segments and row_path_segments[-1] is None:
                     row_path_segments.pop()
-                if row_path_segments != target_path_segments:
+                row_path_lower = [
+                    seg.lower() if isinstance(seg, str) else seg
+                    for seg in row_path_segments
+                ]
+                if row_path_lower != target_path_lower:
                     continue
                 ts = int(result_set.get_value_by_index(1))
                 # The on-tree scan already honors start/end_time at the


### PR DESCRIPTION
### Summary

When reading tree-model TsFiles through `TsFileDataFrame`, series reads could
return empty arrays in two situations. This PR fixes both, which together were
responsible for "read one series OK, then read another series returns empty" on
a reused reader.

Both fixes go on top of the existing tree-model support (#816).

---

### Fix 1 — C++: make `StringArrayDeviceID::split_table_name()` idempotent

**Problem**
Device IDs are cached and reused across queries. `split_table_name()` /
`init_prefix_segments()` appended to `prefix_segments_` every time it was
called, so on a reused reader the prefix segments accumulated across successive
queries. The stale/duplicated prefix segments corrupted the per-device path
columns, so a second series read on the same reader could match nothing and
return empty (and it also leaked the previously allocated segment pointers).

**Change**
`init_prefix_segments()` now clears and frees the existing `prefix_segments_`
before rebuilding, making `split_table_name()` idempotent. Repeated calls
produce a stable, correct segment vector.

Files: `cpp/src/common/device_id.cc`, test `cpp/test/common/device_id_test.cc`
(`DeviceIdTest.SplitTableNameIsIdempotent`).

---

### Fix 2 — Python: read series with uppercase measurement / path names

**Problem**
Tree TsFiles have no table schema, so the Python dataset layer reads them by
synthesizing a virtual table via `query_table_on_tree`. Because the table model
is case-insensitive, the native layer normalizes the synthesized column names
and path segments to lower case (e.g. `Temperature` -> `temperature`), while
the dataset catalog keeps the original casing from timeseries metadata. The two
tree read paths then looked the field column and device path up
case-sensitively, so an uppercase measurement or path segment failed the lookup
and returned an empty array:

```python
with TsFileDataFrame(path) as tsdf:
    tsdf["root.ln.wf01.wt01.Temperature"][:]
    # -> array([], dtype=float64)   # expected [0.5, 1.5, 2.5, 3.5, 4.5]
```

__Change__ Match field column names and device path segments case-insensitively in `_read_series_by_row_tree` and `_read_arrow_tree`, consistent with the case-insensitive table model. The original casing is still surfaced to users; only the internal lookup against the lower-cased result set is normalized.

Files: `python/tsfile/dataset/reader.py`, regression test in `python/tests/test_tsfile_dataset.py`.

---

### Tests

- New C++ regression test: `DeviceIdTest.SplitTableNameIsIdempotent`.
- New Python regression tests covering reused-reader reads and uppercase measurement/path names.
- No public API change; logical series names keep their original casing.
