### PR TITLE
Fix simd disabled case by typo.

### DIFF
--- a/cpp/CLAUDE.md
+++ b/cpp/CLAUDE.md
@@ -64,7 +64,7 @@ All `ON` by default unless noted:
 | `ENABLE_SNAPPY` / `ENABLE_LZ4` / `ENABLE_LZOKAY` / `ENABLE_ZLIB` | Compression libraries |
 | `ENABLE_THREADS` | Multi-threaded read/write via pthreads |
 | `ENABLE_ASAN` | AddressSanitizer (`OFF` by default) |
-| `ENABLE_SIMDE` | SIMD Everywhere (`OFF` by default) |
+| `ENABLE_SIMD` | SIMD acceleration |
 
 ## Source Structure
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -256,7 +256,7 @@ if (ENABLE_THREADS)
     link_libraries(Threads::Threads)
 endif()
 
-option(ENABLE_SIMD "Enable SIMDe (SIMD Everywhere)" OFF)
+option(ENABLE_SIMD "Enable SIMD acceleration" ON)
 message("cmake using: ENABLE_SIMD=${ENABLE_SIMD}")
 
 if (ENABLE_SIMD)

--- a/cpp/pom.xml
+++ b/cpp/pom.xml
@@ -40,7 +40,7 @@
         <enable.lzokay>ON</enable.lzokay>
         <enable.zlib>ON</enable.zlib>
         <enable.antlr4>ON</enable.antlr4>
-        <enable.simde>OFF</enable.simde>
+        <enable.simd>ON</enable.simd>
     </properties>
     <build>
         <sourceDirectory>${project.basedir}</sourceDirectory>
@@ -87,7 +87,7 @@
                                 <option>-DENABLE_LZ4=${enable.lz4}</option>
                                 <option>-DENABLE_LZOKAY=${enable.lzokay}</option>
                                 <option>-DENABLE_ZLIB=${enable.zlib}</option>
-                                <option>-DENABLE_SIMDE=${enable.simde}</option>
+                                <option>-DENABLE_SIMD=${enable.simd}</option>
                                 <!--
                                     The Visual Studio generator additionally
                                     needs -DCMAKE_GENERATOR_PLATFORM (and


### PR DESCRIPTION
Previously, due to a typo, SIMD was not enabled for the C++ build produced by Maven. This PR fixes the configuration.