### PR TITLE
Add configurable TsFileInput reader constructor

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/read/TsFileSequenceReader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/TsFileSequenceReader.java
@@ -388,6 +388,30 @@ public class TsFileSequenceReader implements AutoCloseable {
   }
 
   public TsFileSequenceReader(
+      TsFileInput input,
+      boolean loadMetadataSize,
+      boolean cacheDeviceMetadata,
+      LongConsumer ioSizeRecorder)
+      throws IOException {
+    this.tsFileInput = input;
+    this.file = input.getFilePath();
+    this.cacheDeviceMetadata = cacheDeviceMetadata;
+    if (resourceLogger.isDebugEnabled()) {
+      resourceLogger.debug("{} reader is opened. {}", file, getClass().getName());
+    }
+
+    try {
+      loadFileVersion(ioSizeRecorder);
+      if (loadMetadataSize) {
+        loadMetadataSize(ioSizeRecorder);
+      }
+    } catch (Throwable e) {
+      tsFileInput.close();
+      throw e;
+    }
+  }
+
+  public TsFileSequenceReader(
       TsFileInput input, boolean loadMetadataSize, EncryptParameter firstEncryptParam)
       throws IOException {
     this(input, loadMetadataSize);


### PR DESCRIPTION
## Summary

- add a `TsFileSequenceReader` constructor that accepts `TsFileInput`, metadata loading and device metadata cache flags, and an I/O size recorder
- load the file version and optional metadata size during initialization
- close the supplied input when initialization fails

## Testing

- `./mvnw test -P with-java -pl java/tsfile -am -Dtest=TsFileSequenceReaderTest -Dsurefire.failIfNoSpecifiedTests=false`