### PR TITLE
Fix Python wheel test skipping and dependencies

### DIFF
--- a/python/pom.xml
+++ b/python/pom.xml
@@ -142,7 +142,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipTests:-false}</skip>
+                            <skip>${skipTests}</skip>
                             <executable>${python.venv.bin}${python.exe.bin}</executable>
                             <arguments>
                                 <argument>-m</argument>
@@ -159,7 +159,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipTests:-false}</skip>
+                            <skip>${skipTests}</skip>
                             <executable>${python.venv.bin}pytest</executable>
                             <arguments>
                                 <argument>${project.basedir}/tests</argument>

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -37,8 +37,8 @@ maintainers = [
 ]
 dependencies = [
     "numpy>=1.26.4,<3",
-    "pandas>=2.0,<2.3; python_full_version < '3.14.0'",
-    "pandas>=2.3.3; python_full_version >= '3.14.0'",
+    "pandas>=2.0,<2.3; python_version < '3.13'",
+    "pandas>=2.3.3; python_version >= '3.13'",
     "pyarrow>=16.0,<18; python_version<'3.10'",
     "pyarrow>=18.0,<20; python_version>='3.10' and python_version<'3.14'",
     "pyarrow>=22.0,<24; python_version>='3.14'"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -21,8 +21,8 @@ cython==3.0.10
 black==25.11.0; python_version < "3.10"
 black==26.3.1; python_version >= "3.10"
 numpy>=1.26.4,<3
-pandas==2.2.2; python_full_version < "3.14.0"
-pandas>=2.3.3; python_full_version >= "3.14.0"
+pandas==2.2.2; python_version < "3.13"
+pandas>=2.3.3; python_version >= "3.13"
 setuptools==78.1.1
 wheel==0.46.2
 pyarrow>=8.0.0


### PR DESCRIPTION
## Summary

This PR fixes two issues in the Python wheel build:

- Make Maven's `-DskipTests` option correctly skip Python test setup and execution.
- Use a newer pandas version for Python 3.13 and 3.14 while preserving the existing dependency range for Python 3.9–3.12.

## Root Cause

`${skipTests:-false}` uses shell-style default-value syntax, which is not supported by Maven property interpolation. As a result, `-DskipTests` was not correctly propagated to the Python test executions.

Additionally, Python 3.13 was still selecting pandas 2.2.2. That version does not provide a compatible Windows CPython 3.13 wheel, causing pip to attempt a source build and fail during the wheel workflow.

## Changes

- Replace `${skipTests:-false}` with `${skipTests}` in the Python Maven configuration.
- Select pandas 2.2.2 / `<2.3` for Python 3.9–3.12.
- Select pandas 2.3.3 or newer for Python 3.13 and 3.14.
- Keep `requirements.txt` and wheel package metadata consistent.

## Validation

- Verified that the XML and TOML files parse successfully.
- Verified dependency marker selection for Python 3.9, 3.12, 3.13, and 3.14.
- Verified through Maven's effective POM that `-DskipTests` sets both Python test executions to `skip=true`.
- Ran `git diff --check`.