### PR TITLE
fix(cpp): fix memory leaks and null dereference crashes

### DIFF
--- a/cpp/src/compress/lz4_compressor.cc
+++ b/cpp/src/compress/lz4_compressor.cc
@@ -56,12 +56,16 @@ int LZ4Compressor::compress(char* uncompressed_buf,
                                  uncompressed_buf_len, max_dst_size);
 
         if (compressed_data_size <= 0) {
+            mem_free(compressed_buf_);
+            compressed_buf_ = nullptr;
             ret = E_COMPRESS_ERR;
         } else {
             char* compressed_data = (char*)mem_realloc(
                 compressed_buf_, (size_t)compressed_data_size);
 
             if (compressed_data == nullptr) {
+                mem_free(compressed_buf_);
+                compressed_buf_ = nullptr;
                 ret = E_OOM;
             } else {
                 compressed_buf_ = compressed_data;

--- a/cpp/src/cwrapper/tsfile_cwrapper.cc
+++ b/cpp/src/cwrapper/tsfile_cwrapper.cc
@@ -555,6 +555,9 @@ char* tsfile_result_set_get_value_by_name_string(ResultSet result_set,
     auto* r = static_cast<storage::ResultSet*>(result_set);
     std::string column_name_(column_name);
     common::String* ret = r->get_value<common::String*>(column_name_);
+    if (ret == nullptr) {
+        return nullptr;
+    }
     // Caller should free return's char* 's space.
     char* dup = (char*)malloc(ret->len_ + 1);
     if (dup) {
@@ -581,6 +584,9 @@ char* tsfile_result_set_get_value_by_index_string(ResultSet result_set,
                                                   uint32_t column_index) {
     auto* r = static_cast<storage::ResultSet*>(result_set);
     common::String* ret = r->get_value<common::String*>(column_index);
+    if (ret == nullptr) {
+        return nullptr;
+    }
     // Caller should free return's char* 's space.
     char* dup = (char*)malloc(ret->len_ + 1);
     if (dup) {

--- a/cpp/src/reader/chunk_reader.cc
+++ b/cpp/src/reader/chunk_reader.cc
@@ -57,6 +57,7 @@ void ChunkReader::reset() {
     char* file_data_buf = in_stream_.get_wrapped_buf();
     if (file_data_buf != nullptr) {
         mem_free(file_data_buf);
+        in_stream_.clear_wrapped_buf();
     }
     in_stream_.reset();
     file_data_buf_size_ = 0;
@@ -113,7 +114,11 @@ int ChunkReader::load_by_meta(ChunkMeta* meta) {
     }
     ret = read_file_->read(chunk_meta_->offset_of_chunk_header_, file_data_buf,
                            file_data_buf_size_, ret_read_len);
-    if (IS_SUCC(ret) && ret_read_len < ChunkHeader::MIN_SERIALIZED_SIZE) {
+    if (!IS_SUCC(ret)) {
+        mem_free(file_data_buf);
+        return ret;
+    }
+    if (ret_read_len < ChunkHeader::MIN_SERIALIZED_SIZE) {
         ret = E_TSFILE_CORRUPTED;
         LOGE("file corrupted, ret=" << ret << ", offset="
                                     << chunk_meta_->offset_of_chunk_header_


### PR DESCRIPTION
## Summary

Fix 4 classes of memory/crash bugs discovered during a systematic scan of the C++ codebase.

## Changes

### 1. ChunkReader double-free (`src/reader/chunk_reader.cc`)

`reset()` frees the wrapped buffer via `mem_free(file_data_buf)` but does not clear the wrapped pointer in `ByteStream`. When `destroy()` is subsequently called, `get_wrapped_buf()` returns the already-freed pointer and `mem_free(buf)` is called again → **double-free crash**.

**Fix**: Call `in_stream_.clear_wrapped_buf()` immediately after `mem_free()` to null out the stale pointer. `destroy()` already has its own null-guard, so this prevents the double-free.

### 2. ChunkReader read-failure memory leak (`src/reader/chunk_reader.cc`)

`load_by_meta()` allocates `file_data_buf` via `mem_alloc()`, then calls `read_file_->read()`. The original code only freed the buffer on the partial-success path (`IS_SUCC(ret) && ret_read_len < MIN_SERIALIZED_SIZE`). If `read()` itself returns an error, the buffer is never freed and never passed to `wrap_from()` → **memory leak** for every failed chunk load.

**Fix**: Add an early-exit path after `read()`: if `!IS_SUCC(ret)`, free the buffer and return immediately.

### 3. LZ4Compressor error-path leaks (`src/compress/lz4_compressor.cc`)

`compress()` allocates `compressed_buf_` via `mem_alloc()`, then has two error paths that do not free it:
- `LZ4_compress_default` returns ≤ 0 → `compressed_buf_` leaked
- `mem_realloc` returns nullptr → `compressed_buf_` leaked

**Fix**: Add `mem_free(compressed_buf_); compressed_buf_ = nullptr;` on both error paths.

### 4. C wrapper string getter null dereference (`src/cwrapper/tsfile_cwrapper.cc`)

Both `tsfile_result_set_get_value_by_{name,index}_string()` call `r->get_value<common::String*>()` which delegates to `Field::get_string_value()`. For non-STRING/TEXT/BLOB column types, this returns `nullptr`. The code then unconditionally dereferences `ret->len_` → **SIGSEGV**.

**Fix**: Add a null check before the dereference, returning `nullptr` (which the Python caller already handles correctly, returning `None`).

## Verification

- All 721 C++ tests pass (`TsFile_Test` with ASan/Debug)
- clang-format applied via `spotless:apply`

## Files Changed

| File | +/− |
|------|-----|
| `cpp/src/reader/chunk_reader.cc` | +7/−1 |
| `cpp/src/compress/lz4_compressor.cc` | +4/−0 |
| `cpp/src/cwrapper/tsfile_cwrapper.cc` | +6/−0 |