### PR TITLE
Document dev mailing list subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+# Apache TsFile Website
+
+This branch contains the source files used to build the
+[Apache TsFile website](https://tsfile.apache.org/).
+
+## Website Contributions
+
+For changes to the Apache TsFile website, open a pull request with the
+[`docs/dev`](https://github.com/apache/tsfile/tree/docs/dev) branch as the base branch.

--- a/src/Community/Feedback.md
+++ b/src/Community/Feedback.md
@@ -19,4 +19,22 @@
 
 -->
 
-Coming Soon
+# Communication and Feedback
+
+## Apache Mailing List
+
+The dev mailing list is the primary public communication channel for the Apache TsFile
+community. Project-wide plans, roadmaps, announcements, and development discussions take
+place there.
+
+### Subscribe to the dev mailing list
+
+1. From the email address you want to subscribe, send a plain-text email to
+   [`dev-subscribe@tsfile.apache.org`](mailto:dev-subscribe@tsfile.apache.org?subject=subscribe).
+   Use `subscribe` as the subject; the message body can be empty.
+2. You will receive a confirmation request from the `tsfile.apache.org` domain. Reply to
+   that message as instructed to confirm your subscription.
+
+After confirming, you will receive every message sent to
+[`dev@tsfile.apache.org`](mailto:dev@tsfile.apache.org) and can participate in discussions
+by emailing that address.


### PR DESCRIPTION
## Summary

- replace the placeholder on the English Communication and Feedback page with instructions for subscribing to the dev mailing list
- add a branch README that identifies `docs/dev` as the base branch for website pull requests

## Motivation

The English website did not explain how to subscribe to `dev@tsfile.apache.org`, although the Chinese page did. The repository also did not document which base branch contributors should use for website changes.

## Impact

English-speaking contributors can now join the project mailing list, and documentation contributors can identify the correct PR target before opening a change.

## Root cause

The English feedback page still contained only a `Coming Soon` placeholder, and the website-only branch had no root README describing its contribution workflow.

## Validation

- `git diff --check`
- built all 130 VuePress pages with Node.js 20
- verified the generated `/Community/Feedback.html` contains the subscription instructions and mail links
