### PR TITLE
Document website pull request target

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,3 +196,9 @@ cpp/target/build/bin/tsfile-cli --help
 ```
 
 See [`cpp/tools/README.md`](./cpp/tools/README.md) for the full command and option reference.
+
+## Website Contributions
+
+For changes to the [Apache TsFile website](https://tsfile.apache.org/), open a pull request
+with the [`docs/dev`](https://github.com/apache/tsfile/tree/docs/dev) branch as the base
+branch.


### PR DESCRIPTION
## Summary

- add a Website Contributions section to the root README
- state that website pull requests must use `docs/dev` as the base branch

## Motivation

The repository README did not tell contributors which branch receives website changes.

## Impact

Contributors can identify the correct base branch before opening website documentation pull requests.

## Root cause

The website contribution workflow was not documented in the repository README.

## Validation

- `git diff --check`
