### PR TITLE
fix(tsfile): propagate IOException on writer close instead of swallowing it

### DIFF
--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages.properties
@@ -202,9 +202,6 @@ log.write.flush_chunk_groups = start to flush chunk groups, memory space occupy:
 # TsFileWriter / AbstractTableModelTsFileWriter — close file (2 files, 1 key)
 log.write.close_file = start close file
 
-# AbstractTableModelTsFileWriter — close file exception (1 site)
-log.write.close_file_exception = Meet exception when close file writer.
-
 # TsFileWriter / AbstractTableModelTsFileWriter — page size vs chunk group size warn (2 files, 1 key)
 log.write.page_size_warn = TsFile's page size {} is greater than chunk group size {}, please enlarge the chunk group size or decrease page size.
 

--- a/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
+++ b/java/common/src/main/resources/org/apache/tsfile/i18n/messages_zh.properties
@@ -202,9 +202,6 @@ log.write.flush_chunk_groups = 开始刷新 chunk groups，占用内存空间: {
 # TsFileWriter / AbstractTableModelTsFileWriter — close file (2 files, 1 key)
 log.write.close_file = 开始关闭文件
 
-# AbstractTableModelTsFileWriter — close file exception (1 site)
-log.write.close_file_exception = 关闭文件 writer 时发生异常。
-
 # TsFileWriter / AbstractTableModelTsFileWriter — page size vs chunk group size warn (2 files, 1 key)
 log.write.page_size_warn = TsFile 的 page size {} 大于 chunk group size {}，请增大 chunk group size 或减小 page size。
 

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/v4/AbstractTableModelTsFileWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/v4/AbstractTableModelTsFileWriter.java
@@ -271,13 +271,9 @@ abstract class AbstractTableModelTsFileWriter implements ITsFileWriter {
    */
   @Override
   @TsFileApi
-  public void close() {
+  public void close() throws IOException {
     LOG.info(Messages.get("log.write.close_file"));
-    try {
-      flush();
-      fileWriter.endFile();
-    } catch (IOException e) {
-      LOG.warn(Messages.get("log.write.close_file_exception"), e);
-    }
+    flush();
+    fileWriter.endFile();
   }
 }

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/v4/ITsFileWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/v4/ITsFileWriter.java
@@ -32,7 +32,7 @@ public interface ITsFileWriter extends AutoCloseable {
   void write(Tablet tablet) throws IOException, WriteProcessException;
 
   @TsFileApi
-  void close();
+  void close() throws IOException;
 
   @TsFileApi
   void write(TSRecord record) throws IOException, WriteProcessException;


### PR DESCRIPTION
The `close()` method of `AbstractTableModelTsFileWriter` catches `IOException` and only logs a warning, silently swallowing the failure so callers cannot detect that closing the file failed.

Changes:
- `ITsFileWriter.close()` now declares `throws IOException`
- `AbstractTableModelTsFileWriter.close()` lets the exception propagate instead of logging and dropping it