### PR TITLE
Fix/relax pyarrow constraint

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -39,9 +39,9 @@ dependencies = [
     "numpy>=1.26.4,<3",
     "pandas>=2.0,<2.3; python_version < '3.13'",
     "pandas>=2.3.3; python_version >= '3.13'",
-    "pyarrow>=16.0,<18; python_version<'3.10'",
-    "pyarrow>=18.0,<20; python_version>='3.10' and python_version<'3.14'",
-    "pyarrow>=22.0,<24; python_version>='3.14'"
+    "pyarrow>=16.0; python_version<'3.13'",
+    "pyarrow>=18.0; python_version>='3.13' and python_version<'3.14'",
+    "pyarrow>=22.0; python_version>='3.14'"
 ]
 
 [project.urls]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,7 +21,9 @@ requires = [
     "setuptools>=69",
     "wheel", 
     "Cython>=3", 
-    "numpy>=1.26.4,<3"
+    "numpy>=1.26.4; python_version<'3.13'",
+    "numpy>=2.1.0; python_version>='3.13' and python_version<'3.14'",
+    "numpy>=2.3.2; python_version>='3.14'"
     ]
 
 build-backend = "setuptools.build_meta"
@@ -36,9 +38,13 @@ maintainers = [
     {name = "Apache TsFile Developers", email = "dev@tsfile.apache.org"}
 ]
 dependencies = [
-    "numpy>=1.26.4,<3",
-    "pandas>=2.0,<2.3; python_version < '3.13'",
-    "pandas>=2.3.3; python_version >= '3.13'",
+    "numpy>=1.26.4; python_version<'3.13'",
+    "numpy>=2.1.0; python_version>='3.13' and python_version<'3.14'",
+    "numpy>=2.3.2; python_version>='3.14'",
+    "pandas>=2.0.0; python_version<'3.12'",
+    "pandas>=2.1.1; python_version>='3.12' and python_version<'3.13'",
+    "pandas>=2.2.3; python_version>='3.13' and python_version<'3.14'",
+    "pandas>=2.3.3; python_version>='3.14'",
     "pyarrow>=16.0; python_version<'3.13'",
     "pyarrow>=18.0; python_version>='3.13' and python_version<'3.14'",
     "pyarrow>=22.0; python_version>='3.14'"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -20,9 +20,13 @@
 cython==3.0.10
 black==25.11.0; python_version < "3.10"
 black==26.3.1; python_version >= "3.10"
-numpy>=1.26.4,<3
-pandas==2.2.2; python_version < "3.13"
-pandas>=2.3.3; python_version >= "3.13"
+numpy>=1.26.4; python_version < "3.13"
+numpy>=2.1.0; python_version >= "3.13" and python_version < "3.14"
+numpy>=2.3.2; python_version >= "3.14"
+pandas>=2.0.0; python_version < "3.12"
+pandas>=2.1.1; python_version >= "3.12" and python_version < "3.13"
+pandas>=2.2.3; python_version >= "3.13" and python_version < "3.14"
+pandas>=2.3.3; python_version >= "3.14"
 setuptools==78.1.1
 wheel==0.46.2
 pyarrow>=16.0; python_version < "3.13"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -25,4 +25,6 @@ pandas==2.2.2; python_version < "3.13"
 pandas>=2.3.3; python_version >= "3.13"
 setuptools==78.1.1
 wheel==0.46.2
-pyarrow>=8.0.0
+pyarrow>=16.0; python_version < "3.13"
+pyarrow>=18.0; python_version >= "3.13" and python_version < "3.14"
+pyarrow>=22.0; python_version >= "3.14"

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -285,8 +285,14 @@ def test_write_dataframe_all_datatypes():
         assert df_read["bool_col"].equals(df_sorted["bool_col"])
         assert df_read["int32_col"].equals(df_sorted["int32_col"])
         assert df_read["int64_col"].equals(df_sorted["int64_col"])
-        assert np.allclose(df_read["float_col"], df_sorted["float_col"])
-        assert np.allclose(df_read["double_col"], df_sorted["double_col"])
+        assert np.allclose(
+            df_read["float_col"].to_numpy(dtype=np.float32, na_value=np.nan),
+            df_sorted["float_col"].to_numpy(dtype=np.float32, na_value=np.nan),
+        )
+        assert np.allclose(
+            df_read["double_col"].to_numpy(dtype=np.float64, na_value=np.nan),
+            df_sorted["double_col"].to_numpy(dtype=np.float64, na_value=np.nan),
+        )
         assert df_read["string_col"].equals(df_sorted["string_col"])
         assert df_read["blob_col"].equals(df_sorted["blob_col"])
         assert df_read["text_col"].equals(df_sorted["text_col"])

--- a/python/tests/test_to_tsfile.py
+++ b/python/tests/test_to_tsfile.py
@@ -299,8 +299,14 @@ def test_dataframe_to_tsfile_all_datatypes():
         assert df_read["bool_col"].equals(df_sorted["bool_col"])
         assert df_read["int32_col"].equals(df_sorted["int32_col"])
         assert df_read["int64_col"].equals(df_sorted["int64_col"])
-        assert np.allclose(df_read["float_col"], df_sorted["float_col"])
-        assert np.allclose(df_read["double_col"], df_sorted["double_col"])
+        assert np.allclose(
+            df_read["float_col"].to_numpy(dtype=np.float32, na_value=np.nan),
+            df_sorted["float_col"].to_numpy(dtype=np.float32, na_value=np.nan),
+        )
+        assert np.allclose(
+            df_read["double_col"].to_numpy(dtype=np.float64, na_value=np.nan),
+            df_sorted["double_col"].to_numpy(dtype=np.float64, na_value=np.nan),
+        )
         assert df_read["string_col"].equals(df_sorted["string_col"])
         assert df_read["text_col"].equals(df_sorted["text_col"])
         assert df_read["date_col"].equals(df_sorted["date_col"])


### PR DESCRIPTION
## Description

This PR relaxes and aligns the Python dependency constraints for NumPy, pandas, and PyArrow.

The previous PyArrow upper-bound constraint appears to be a historical restriction rather than a requirement imposed by the current implementation. We verified the Python bindings with newer PyArrow versions, including the Arrow C Data Interface calls used by TsFile, and found no compatibility issues.

Instead of setting upper bounds, this PR defines the minimum supported dependency versions according to the Python version. If a future dependency release introduces an actual incompatibility, we will address it in the implementation or adjust the constraints based on the concrete issue.

Closes #921.

## Changes

- Remove the PyArrow upper-bound constraints.
- Define the minimum PyArrow version by Python version:
  - Python < 3.13: `pyarrow>=16`
  - Python 3.13: `pyarrow>=18`
  - Python >= 3.14: `pyarrow>=22`
- Align the minimum NumPy and pandas versions with their Python-version support.
- Keep the build-system and runtime dependency constraints consistent.
- Adjust DataFrame tests to remain compatible with NumPy 1.26 and pandas nullable floating-point types.

## Verification

The following dependency combinations were tested locally:

- Minimum supported dependency versions on Python 3.12, 3.13, and 3.14
- Latest available NumPy, pandas, and PyArrow versions

All DataFrame-related tests passed (`27/27`) for every tested combination.

The complete GitHub Actions validation also passed:

- [Python unit-test matrix](https://github.com/ColinLeeo/tsfile/actions/runs/32955466173): `9/9` passed
  - Linux, macOS, and Windows
  - Python 3.9, 3.11, and 3.14
- [Python wheel build matrix](https://github.com/ColinLeeo/tsfile/actions/runs/32955469256): `11/11` passed
  - Linux x86_64 and aarch64
  - macOS x86_64 and arm64
  - Windows with Python 3.9–3.14