### PR TITLE
fix(cpp): report the stored codec in reader schema, not library defaults

### DIFF
--- a/cpp/src/common/container/list.h
+++ b/cpp/src/common/container/list.h
@@ -110,6 +110,11 @@ class SimpleList {
         return head_->data_;
     }
 
+    FORCE_INLINE T& back() {
+        ASSERT(size_ > 0 && tail_ != nullptr);
+        return tail_->data_;
+    }
+
     int remove(T target) {
         if (head_ == nullptr) {
             return common::E_NOT_EXIST;

--- a/cpp/src/common/tsfile_common.h
+++ b/cpp/src/common/tsfile_common.h
@@ -204,10 +204,12 @@ struct ChunkMeta {
 
     ChunkMeta()
         : measurement_name_(),
-          data_type_(),
+          data_type_(common::INVALID_DATATYPE),
           offset_of_chunk_header_(0),
           statistic_(nullptr),
-          mask_(0) {}
+          mask_(0),
+          encoding_(common::INVALID_ENCODING),
+          compression_type_(common::INVALID_COMPRESSION) {}
 
     int init(const common::String& measurement_name,
              common::TSDataType data_type, int64_t offset_of_chunk_header,
@@ -233,6 +235,8 @@ struct ChunkMeta {
         }
         data_type_ = that.data_type_;
         offset_of_chunk_header_ = that.offset_of_chunk_header_;
+        encoding_ = that.encoding_;
+        compression_type_ = that.compression_type_;
         if (that.statistic_ != nullptr) {
             statistic_ =
                 StatisticFactory::alloc_statistic_with_pa(data_type_, pa);

--- a/cpp/src/file/tsfile_io_reader.h
+++ b/cpp/src/file/tsfile_io_reader.h
@@ -112,6 +112,10 @@ class TsFileIOReader {
 
     std::string get_file_path() const { return read_file_->file_path(); }
 
+    // Raw read access for callers that need to parse structures the metadata
+    // index does not carry, e.g. the chunk header at a ChunkMeta offset.
+    ReadFile* get_read_file() const { return read_file_; }
+
     TsFileMeta* get_tsfile_meta() {
         load_tsfile_meta_if_necessary();
         return &tsfile_meta_;

--- a/cpp/src/reader/tsfile_reader.cc
+++ b/cpp/src/reader/tsfile_reader.cc
@@ -40,42 +40,6 @@ struct DeviceMetaEntry {
     int64_t end_offset;
 };
 
-int read_chunk_header_codec(ReadFile* read_file, int64_t chunk_header_offset,
-                            size_t measurement_name_len,
-                            common::TSEncoding& encoding,
-                            common::CompressionType& compression) {
-    if (read_file == nullptr || chunk_header_offset < 0) {
-        return E_INVALID_ARG;
-    }
-
-    // A chunk header contains the measurement name before its codec fields.
-    // Read enough bytes for the known name instead of relying on a fixed-size
-    // header buffer.
-    constexpr size_t kMaxVarIntLen = 5;
-    std::vector<char> buffer(1 + kMaxVarIntLen + measurement_name_len +
-                             kMaxVarIntLen + 3);
-    int32_t read_len = 0;
-    int ret = read_file->read(chunk_header_offset, buffer.data(),
-                              static_cast<int32_t>(buffer.size()), read_len);
-    if (ret != E_OK) {
-        return ret;
-    }
-    if (read_len < ChunkHeader::MIN_SERIALIZED_SIZE) {
-        return E_TSFILE_CORRUPTED;
-    }
-
-    common::ByteStream input;
-    input.wrap_from(buffer.data(), read_len);
-    ChunkHeader chunk_header;
-    ret = chunk_header.deserialize_from(input);
-    if (ret != E_OK) {
-        return ret;
-    }
-    encoding = chunk_header.encoding_type_;
-    compression = chunk_header.compression_type_;
-    return E_OK;
-}
-
 int parse_paths(const std::vector<std::string>& path_list,
                 std::vector<Path>& parsed_paths) {
     try {

--- a/cpp/src/reader/tsfile_reader.cc
+++ b/cpp/src/reader/tsfile_reader.cc
@@ -40,6 +40,42 @@ struct DeviceMetaEntry {
     int64_t end_offset;
 };
 
+int read_chunk_header_codec(ReadFile* read_file, int64_t chunk_header_offset,
+                            size_t measurement_name_len,
+                            common::TSEncoding& encoding,
+                            common::CompressionType& compression) {
+    if (read_file == nullptr || chunk_header_offset < 0) {
+        return E_INVALID_ARG;
+    }
+
+    // A chunk header contains the measurement name before its codec fields.
+    // Read enough bytes for the known name instead of relying on a fixed-size
+    // header buffer.
+    constexpr size_t kMaxVarIntLen = 5;
+    std::vector<char> buffer(1 + kMaxVarIntLen + measurement_name_len +
+                             kMaxVarIntLen + 3);
+    int32_t read_len = 0;
+    int ret = read_file->read(chunk_header_offset, buffer.data(),
+                              static_cast<int32_t>(buffer.size()), read_len);
+    if (ret != E_OK) {
+        return ret;
+    }
+    if (read_len < ChunkHeader::MIN_SERIALIZED_SIZE) {
+        return E_TSFILE_CORRUPTED;
+    }
+
+    common::ByteStream input;
+    input.wrap_from(buffer.data(), read_len);
+    ChunkHeader chunk_header;
+    ret = chunk_header.deserialize_from(input);
+    if (ret != E_OK) {
+        return ret;
+    }
+    encoding = chunk_header.encoding_type_;
+    compression = chunk_header.compression_type_;
+    return E_OK;
+}
+
 int parse_paths(const std::vector<std::string>& path_list,
                 std::vector<Path>& parsed_paths) {
     try {
@@ -519,37 +555,42 @@ int TsFileReader::get_timeseries_schema(
                     dt = aligned->value_ts_idx_->get_data_type();
                 }
             }
-            // Report the codecs the file actually stores.  The 2-arg
-            // MeasurementSchema ctor fills get_value_encoder(dt) /
-            // get_default_compressor() instead, which mislabels e.g. a
-            // PLAIN/UNCOMPRESSED INT32 column as TS_2DIFF/LZ4.
+            // Report the codecs stored in the final chunk. The two-argument
+            // MeasurementSchema constructor would otherwise use library
+            // defaults instead of the codecs in the chunk header.
             const std::string measurement_name =
                 timeseries_index->get_measurement_name().to_std_string();
-            common::TSEncoding enc = common::get_value_encoder(dt);
-            common::CompressionType comp = common::get_default_compressor();
+            common::TSEncoding encoding = common::get_value_encoder(dt);
+            common::CompressionType compression =
+                common::get_default_compressor();
+
+            // Aligned indexes keep chunk metadata on the value index; the
+            // base get_chunk_meta_list() is intentionally null for them.
             auto* chunk_meta_list = timeseries_index->get_chunk_meta_list();
-            if (chunk_meta_list != nullptr && chunk_meta_list->size() > 0 &&
-                chunk_meta_list->front() != nullptr) {
-                common::TSEncoding stored_enc = common::INVALID_ENCODING;
-                common::CompressionType stored_comp =
-                    common::INVALID_COMPRESSION;
-                // Fall back to the defaults above if the header cannot be
-                // read: schema introspection must not fail the whole call.
-                if (read_chunk_header_codec(
-                        tsfile_executor_->get_tsfile_io_reader()
-                            ->get_read_file(),
-                        chunk_meta_list->front()->offset_of_chunk_header_,
-                        measurement_name.size(), stored_enc,
-                        stored_comp) == E_OK) {
-                    enc = stored_enc;
-                    comp = stored_comp;
-                }
+            if (chunk_meta_list == nullptr) {
+                chunk_meta_list = timeseries_index->get_value_chunk_meta_list();
             }
-            MeasurementSchema ms(measurement_name, dt, enc, comp);
-            result.push_back(ms);
+            if (chunk_meta_list != nullptr && !chunk_meta_list->empty() &&
+                chunk_meta_list->back() != nullptr) {
+                common::TSEncoding stored_encoding = common::INVALID_ENCODING;
+                common::CompressionType stored_compression =
+                    common::INVALID_COMPRESSION;
+                ret = read_chunk_header_codec(
+                    tsfile_executor_->get_tsfile_io_reader()->get_read_file(),
+                    chunk_meta_list->back()->offset_of_chunk_header_,
+                    measurement_name.size(), stored_encoding,
+                    stored_compression);
+                if (RET_FAIL(ret)) {
+                    break;
+                }
+                encoding = stored_encoding;
+                compression = stored_compression;
+            }
+
+            result.emplace_back(measurement_name, dt, encoding, compression);
         }
     }
-    return E_OK;
+    return ret;
 }
 
 int TsFileReader::get_timeseries_metadata_impl(

--- a/cpp/src/reader/tsfile_reader.cc
+++ b/cpp/src/reader/tsfile_reader.cc
@@ -19,8 +19,13 @@
 #include "tsfile_reader.h"
 
 #include <stdexcept>
+#include <string>
+#include <vector>
 
+#include "common/allocator/byte_stream.h"
 #include "common/schema.h"
+#include "common/tsfile_common.h"
+#include "file/read_file.h"
 #include "filter/time_operator.h"
 #include "tsfile_executor.h"
 
@@ -446,6 +451,49 @@ int TsFileReader::get_all_devices(
     return ret;
 }
 
+namespace {
+
+// Encoding and compression are per-chunk properties that only live in the
+// chunk header on disk: ChunkMeta::deserialize_from() reads nothing but
+// offset_of_chunk_header_, so a ChunkMeta obtained from the metadata index
+// never carries them.  Read the header back from the file instead.
+int read_chunk_header_codec(ReadFile* read_file, int64_t chunk_header_offset,
+                            size_t measurement_name_len,
+                            common::TSEncoding& encoding,
+                            common::CompressionType& compression) {
+    if (read_file == nullptr || chunk_header_offset < 0) {
+        return E_INVALID_ARG;
+    }
+    // A serialized chunk header is chunk_type (1 byte) + the measurement name
+    // as a var_str (varint length + bytes) + data size as a var_uint + the
+    // data type, compressor and encoding (1 byte each).  Size the buffer from
+    // the name we already know so an unusually long measurement name cannot
+    // truncate the header and send us back to the defaults.
+    const size_t kMaxVarIntLen = 5;
+    std::vector<char> buf(1 + kMaxVarIntLen + measurement_name_len +
+                          kMaxVarIntLen + 3);
+    int32_t read_len = 0;
+    int ret = read_file->read(chunk_header_offset, buf.data(),
+                              static_cast<int32_t>(buf.size()), read_len);
+    if (ret != E_OK) {
+        return ret;
+    }
+    if (read_len < ChunkHeader::MIN_SERIALIZED_SIZE) {
+        return E_TSFILE_CORRUPTED;
+    }
+    common::ByteStream in;
+    in.wrap_from(buf.data(), read_len);
+    ChunkHeader chunk_header;
+    if (RET_FAIL(chunk_header.deserialize_from(in))) {
+        return ret;
+    }
+    encoding = chunk_header.encoding_type_;
+    compression = chunk_header.compression_type_;
+    return E_OK;
+}
+
+}  // namespace
+
 int TsFileReader::get_timeseries_schema(
     std::shared_ptr<IDeviceID> device_id,
     std::vector<MeasurementSchema>& result) {
@@ -471,8 +519,33 @@ int TsFileReader::get_timeseries_schema(
                     dt = aligned->value_ts_idx_->get_data_type();
                 }
             }
-            MeasurementSchema ms(
-                timeseries_index->get_measurement_name().to_std_string(), dt);
+            // Report the codecs the file actually stores.  The 2-arg
+            // MeasurementSchema ctor fills get_value_encoder(dt) /
+            // get_default_compressor() instead, which mislabels e.g. a
+            // PLAIN/UNCOMPRESSED INT32 column as TS_2DIFF/LZ4.
+            const std::string measurement_name =
+                timeseries_index->get_measurement_name().to_std_string();
+            common::TSEncoding enc = common::get_value_encoder(dt);
+            common::CompressionType comp = common::get_default_compressor();
+            auto* chunk_meta_list = timeseries_index->get_chunk_meta_list();
+            if (chunk_meta_list != nullptr && chunk_meta_list->size() > 0 &&
+                chunk_meta_list->front() != nullptr) {
+                common::TSEncoding stored_enc = common::INVALID_ENCODING;
+                common::CompressionType stored_comp =
+                    common::INVALID_COMPRESSION;
+                // Fall back to the defaults above if the header cannot be
+                // read: schema introspection must not fail the whole call.
+                if (read_chunk_header_codec(
+                        tsfile_executor_->get_tsfile_io_reader()
+                            ->get_read_file(),
+                        chunk_meta_list->front()->offset_of_chunk_header_,
+                        measurement_name.size(), stored_enc,
+                        stored_comp) == E_OK) {
+                    enc = stored_enc;
+                    comp = stored_comp;
+                }
+            }
+            MeasurementSchema ms(measurement_name, dt, enc, comp);
             result.push_back(ms);
         }
     }

--- a/cpp/src/writer/tsfile_writer.cc
+++ b/cpp/src/writer/tsfile_writer.cc
@@ -213,13 +213,22 @@ int TsFileWriter::init(RestorableTsFileIOWriter* rw) {
             if (mname.empty()) {
                 continue;
             }
-            if (group->measurement_schema_map_.find(mname) !=
-                group->measurement_schema_map_.end()) {
-                continue;
+            auto schema_it = group->measurement_schema_map_.find(mname);
+            if (schema_it == group->measurement_schema_map_.end()) {
+                MeasurementSchema* ms =
+                    new MeasurementSchema(mname, cm->data_type_, cm->encoding_,
+                                          cm->compression_type_);
+                group->measurement_schema_map_.insert(
+                    std::make_pair(mname, ms));
+            } else {
+                // A series may have different codecs in different chunks.
+                // Appends must use the latest chunk's codec, not the first
+                // recovered chunk's stale settings.
+                MeasurementSchema* ms = schema_it->second;
+                ms->data_type_ = cm->data_type_;
+                ms->encoding_ = cm->encoding_;
+                ms->compression_type_ = cm->compression_type_;
             }
-            MeasurementSchema* ms = new MeasurementSchema(
-                mname, cm->data_type_, cm->encoding_, cm->compression_type_);
-            group->measurement_schema_map_.insert(std::make_pair(mname, ms));
         }
     }
 

--- a/cpp/test/reader/timeseries_schema_codec_test.cc
+++ b/cpp/test/reader/timeseries_schema_codec_test.cc
@@ -1,0 +1,285 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdio>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "common/device_id.h"
+#include "common/record.h"
+#include "common/schema.h"
+#include "reader/tsfile_reader.h"
+#include "writer/tsfile_writer.h"
+
+namespace storage {
+
+// get_timeseries_schema() reports the encoding and the compressor of every
+// series it returns. Those two fields are per-chunk properties recorded in the
+// chunk header on disk, so the only way to report them correctly is to read
+// them back from the file.
+//
+// The series below are deliberately registered with codecs that differ from
+// the library defaults for their data type (INT32 defaults to TS_2DIFF, FLOAT
+// to GORILLA, and the default compressor is LZ4 when it is compiled in), so a
+// reader that reports defaults instead of the stored values is caught.
+class TimeseriesSchemaCodecTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        libtsfile_init();
+        writer_ = new TsFileWriter();
+        file_name_ = std::string("timeseries_schema_codec_test_") +
+                     generate_random_string(10) + std::string(".tsfile");
+        remove(file_name_.c_str());
+        int flags = O_WRONLY | O_CREAT | O_TRUNC;
+#ifdef _WIN32
+        flags |= O_BINARY;
+#endif
+        ASSERT_EQ(writer_->open(file_name_, flags, 0666), common::E_OK);
+    }
+
+    void TearDown() override {
+        delete writer_;
+        writer_ = nullptr;
+        remove(file_name_.c_str());
+        libtsfile_destroy();
+    }
+
+    static std::string generate_random_string(int length) {
+        std::mt19937 gen(static_cast<unsigned int>(
+            std::chrono::system_clock::now().time_since_epoch().count()));
+        std::uniform_int_distribution<> dis(0, 61);
+        const std::string chars =
+            "0123456789"
+            "abcdefghijklmnopqrstuvwxyz"
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        std::string s;
+        s.reserve(static_cast<size_t>(length));
+        for (int i = 0; i < length; ++i) {
+            s += chars[static_cast<size_t>(dis(gen))];
+        }
+        return s;
+    }
+
+    // Look a measurement up by name: get_timeseries_schema() makes no promise
+    // about the order of its result.
+    static const MeasurementSchema* find(
+        const std::vector<MeasurementSchema>& schemas,
+        const std::string& name) {
+        for (const auto& s : schemas) {
+            if (s.measurement_name_ == name) {
+                return &s;
+            }
+        }
+        return nullptr;
+    }
+
+    std::string file_name_;
+    TsFileWriter* writer_ = nullptr;
+};
+
+TEST_F(TimeseriesSchemaCodecTest, ReportsStoredEncodingAndCompressor) {
+    const std::string device = "root.codec.dev1";
+
+    // PLAIN/UNCOMPRESSED for an INT32 series: both differ from the defaults
+    // that INT32 would otherwise get (TS_2DIFF, and LZ4 where available).
+    ASSERT_EQ(
+        writer_->register_timeseries(
+            device, MeasurementSchema("plain_i32", common::INT32, common::PLAIN,
+                                      common::UNCOMPRESSED)),
+        common::E_OK);
+    // TS_2DIFF on a FLOAT series, whose default encoding is GORILLA.
+    ASSERT_EQ(
+        writer_->register_timeseries(
+            device, MeasurementSchema("ts2diff_float", common::FLOAT,
+                                      common::TS_2DIFF, common::UNCOMPRESSED)),
+        common::E_OK);
+
+    for (int i = 0; i < 100; ++i) {
+        TsRecord record(1622505600000 + i * 1000, device);
+        record.add_point("plain_i32", static_cast<int32_t>(i));
+        record.add_point("ts2diff_float", static_cast<float>(i) + 0.5f);
+        ASSERT_EQ(writer_->write_record(record), common::E_OK);
+    }
+    ASSERT_EQ(writer_->flush(), common::E_OK);
+    ASSERT_EQ(writer_->close(), common::E_OK);
+
+    TsFileReader reader;
+    ASSERT_EQ(reader.open(file_name_), common::E_OK);
+
+    std::vector<MeasurementSchema> schemas;
+    ASSERT_EQ(reader.get_timeseries_schema(
+                  std::make_shared<StringArrayDeviceID>(device), schemas),
+              common::E_OK);
+    ASSERT_EQ(schemas.size(), 2u);
+
+    const MeasurementSchema* i32 = find(schemas, "plain_i32");
+    ASSERT_NE(i32, nullptr);
+    EXPECT_EQ(i32->data_type_, common::INT32);
+    EXPECT_EQ(i32->encoding_, common::PLAIN)
+        << "encoding was not read back from the chunk header";
+    EXPECT_EQ(i32->compression_type_, common::UNCOMPRESSED)
+        << "compressor was not read back from the chunk header";
+
+    const MeasurementSchema* flt = find(schemas, "ts2diff_float");
+    ASSERT_NE(flt, nullptr);
+    EXPECT_EQ(flt->data_type_, common::FLOAT);
+    EXPECT_EQ(flt->encoding_, common::TS_2DIFF)
+        << "encoding was not read back from the chunk header";
+    EXPECT_EQ(flt->compression_type_, common::UNCOMPRESSED)
+        << "compressor was not read back from the chunk header";
+
+    reader.close();
+}
+
+// Same requirement for an aligned device: the value columns of an aligned
+// chunk group carry their own chunk headers, so the codecs must survive the
+// aligned write path too.
+TEST_F(TimeseriesSchemaCodecTest, ReportsStoredCodecForAlignedDevice) {
+    const std::string device = "root.codec.aligned1";
+
+    ASSERT_EQ(
+        writer_->register_aligned_timeseries(
+            device, MeasurementSchema("plain_i32", common::INT32, common::PLAIN,
+                                      common::UNCOMPRESSED)),
+        common::E_OK);
+
+    for (int i = 0; i < 100; ++i) {
+        TsRecord record(1622505600000 + i * 1000, device);
+        record.add_point("plain_i32", static_cast<int32_t>(i));
+        ASSERT_EQ(writer_->write_record_aligned(record), common::E_OK);
+    }
+    ASSERT_EQ(writer_->flush(), common::E_OK);
+    ASSERT_EQ(writer_->close(), common::E_OK);
+
+    TsFileReader reader;
+    ASSERT_EQ(reader.open(file_name_), common::E_OK);
+
+    std::vector<MeasurementSchema> schemas;
+    ASSERT_EQ(reader.get_timeseries_schema(
+                  std::make_shared<StringArrayDeviceID>(device), schemas),
+              common::E_OK);
+    ASSERT_EQ(schemas.size(), 1u);
+
+    // The data type must be the value column type, not the VECTOR placeholder
+    // that the aligned time column reports.
+    EXPECT_EQ(schemas[0].data_type_, common::INT32);
+    EXPECT_EQ(schemas[0].encoding_, common::PLAIN)
+        << "encoding was not read back from the chunk header";
+    EXPECT_EQ(schemas[0].compression_type_, common::UNCOMPRESSED)
+        << "compressor was not read back from the chunk header";
+
+    reader.close();
+}
+
+// Every series in the device above is UNCOMPRESSED, so an implementation that
+// hard-coded UNCOMPRESSED would still pass. Register two series of the same
+// data type that differ only in their codecs: each schema must report its own
+// chunk header, not one value shared across the device.
+#ifdef ENABLE_SNAPPY
+TEST_F(TimeseriesSchemaCodecTest, ReportsCodecPerSeriesNotPerDevice) {
+    const std::string device = "root.codec.dev2";
+
+    ASSERT_EQ(
+        writer_->register_timeseries(
+            device, MeasurementSchema("plain_raw", common::INT32, common::PLAIN,
+                                      common::UNCOMPRESSED)),
+        common::E_OK);
+    ASSERT_EQ(writer_->register_timeseries(
+                  device, MeasurementSchema("ts2diff_snappy", common::INT32,
+                                            common::TS_2DIFF, common::SNAPPY)),
+              common::E_OK);
+
+    for (int i = 0; i < 100; ++i) {
+        TsRecord record(1622505600000 + i * 1000, device);
+        record.add_point("plain_raw", static_cast<int32_t>(i));
+        record.add_point("ts2diff_snappy", static_cast<int32_t>(i * 3));
+        ASSERT_EQ(writer_->write_record(record), common::E_OK);
+    }
+    ASSERT_EQ(writer_->flush(), common::E_OK);
+    ASSERT_EQ(writer_->close(), common::E_OK);
+
+    TsFileReader reader;
+    ASSERT_EQ(reader.open(file_name_), common::E_OK);
+
+    std::vector<MeasurementSchema> schemas;
+    ASSERT_EQ(reader.get_timeseries_schema(
+                  std::make_shared<StringArrayDeviceID>(device), schemas),
+              common::E_OK);
+    ASSERT_EQ(schemas.size(), 2u);
+
+    const MeasurementSchema* raw = find(schemas, "plain_raw");
+    ASSERT_NE(raw, nullptr);
+    EXPECT_EQ(raw->encoding_, common::PLAIN);
+    EXPECT_EQ(raw->compression_type_, common::UNCOMPRESSED);
+
+    const MeasurementSchema* snappy = find(schemas, "ts2diff_snappy");
+    ASSERT_NE(snappy, nullptr);
+    EXPECT_EQ(snappy->encoding_, common::TS_2DIFF);
+    EXPECT_EQ(snappy->compression_type_, common::SNAPPY)
+        << "the compressor was not taken from this series' own chunk header";
+
+    reader.close();
+}
+#endif  // ENABLE_SNAPPY
+
+// The measurement name sits between the chunk type byte and the codec bytes in
+// the chunk header, so a name long enough to push those bytes past a
+// fixed-size read buffer would silently fall back to the defaults.
+TEST_F(TimeseriesSchemaCodecTest, ReportsStoredCodecForLongMeasurementName) {
+    const std::string device = "root.codec.dev3";
+    const std::string long_name(600, 'm');
+
+    ASSERT_EQ(
+        writer_->register_timeseries(
+            device, MeasurementSchema(long_name, common::INT32, common::PLAIN,
+                                      common::UNCOMPRESSED)),
+        common::E_OK);
+
+    for (int i = 0; i < 100; ++i) {
+        TsRecord record(1622505600000 + i * 1000, device);
+        record.add_point(long_name, static_cast<int32_t>(i));
+        ASSERT_EQ(writer_->write_record(record), common::E_OK);
+    }
+    ASSERT_EQ(writer_->flush(), common::E_OK);
+    ASSERT_EQ(writer_->close(), common::E_OK);
+
+    TsFileReader reader;
+    ASSERT_EQ(reader.open(file_name_), common::E_OK);
+
+    std::vector<MeasurementSchema> schemas;
+    ASSERT_EQ(reader.get_timeseries_schema(
+                  std::make_shared<StringArrayDeviceID>(device), schemas),
+              common::E_OK);
+    ASSERT_EQ(schemas.size(), 1u);
+
+    const MeasurementSchema* ms = find(schemas, long_name);
+    ASSERT_NE(ms, nullptr);
+    EXPECT_EQ(ms->encoding_, common::PLAIN)
+        << "the chunk header read was truncated by the measurement name";
+    EXPECT_EQ(ms->compression_type_, common::UNCOMPRESSED)
+        << "the chunk header read was truncated by the measurement name";
+
+    reader.close();
+}
+
+}  // namespace storage

--- a/cpp/test/reader/tsfile_reader_test.cc
+++ b/cpp/test/reader/tsfile_reader_test.cc
@@ -39,6 +39,7 @@
 #include "reader/filter/time_operator.h"
 #include "reader/qds_without_timegenerator.h"
 #include "reader/tsfile_series_scan_iterator.h"
+#include "writer/chunk_writer.h"
 #include "writer/tsfile_writer.h"
 
 using namespace storage;
@@ -288,6 +289,73 @@ TEST_F(TsFileReaderTest, GetTimeseriesSchema) {
               1622505600000);
     ASSERT_EQ(device_timeseries_1[0]->get_statistic()->count_, 1);
     reader.close();
+}
+
+TEST_F(TsFileReaderTest, GetTimeseriesSchemaUsesLastChunkCodec) {
+    const std::string path = std::string("tsfile_last_chunk_codec_") +
+                             generate_random_string(10) + ".tsfile";
+    remove(path.c_str());
+
+    WriteFile write_file;
+    const int flags = O_WRONLY | O_CREAT | O_TRUNC;
+    ASSERT_EQ(write_file.create(path, flags, 0666), E_OK);
+
+    TsFileIOWriter io_writer;
+    ASSERT_EQ(io_writer.init(&write_file), E_OK);
+    ASSERT_EQ(io_writer.start_file(), E_OK);
+
+    const std::string device_name = "root.codec.last_chunk";
+    const std::string measurement_name = "value";
+    auto device_id = std::make_shared<StringArrayDeviceID>(device_name);
+
+    ASSERT_EQ(io_writer.start_flush_chunk_group(device_id, false), E_OK);
+    ChunkWriter first_chunk;
+    ASSERT_EQ(first_chunk.init(measurement_name, INT32, PLAIN, UNCOMPRESSED),
+              E_OK);
+    ASSERT_EQ(first_chunk.write(1, static_cast<int32_t>(1)), E_OK);
+    ASSERT_EQ(first_chunk.end_encode_chunk(), E_OK);
+    std::string first_name = measurement_name;
+    ASSERT_EQ(io_writer.start_flush_chunk(
+                  first_chunk.get_chunk_data(), first_name, INT32, PLAIN,
+                  UNCOMPRESSED, first_chunk.num_of_pages()),
+              E_OK);
+    ASSERT_EQ(io_writer.flush_chunk(first_chunk.get_chunk_data()), E_OK);
+    ASSERT_EQ(io_writer.end_flush_chunk(first_chunk.get_chunk_statistic()),
+              E_OK);
+    ASSERT_EQ(io_writer.end_flush_chunk_group(false), E_OK);
+
+    // The second chunk deliberately uses a different encoding. The reader
+    // must report this final chunk's codec, matching Java's implementation.
+    ASSERT_EQ(io_writer.start_flush_chunk_group(device_id, false), E_OK);
+    ChunkWriter last_chunk;
+    ASSERT_EQ(last_chunk.init(measurement_name, INT32, TS_2DIFF, UNCOMPRESSED),
+              E_OK);
+    ASSERT_EQ(last_chunk.write(2, static_cast<int32_t>(2)), E_OK);
+    ASSERT_EQ(last_chunk.end_encode_chunk(), E_OK);
+    std::string last_name = measurement_name;
+    ASSERT_EQ(io_writer.start_flush_chunk(
+                  last_chunk.get_chunk_data(), last_name, INT32, TS_2DIFF,
+                  UNCOMPRESSED, last_chunk.num_of_pages()),
+              E_OK);
+    ASSERT_EQ(io_writer.flush_chunk(last_chunk.get_chunk_data()), E_OK);
+    ASSERT_EQ(io_writer.end_flush_chunk(last_chunk.get_chunk_statistic()),
+              E_OK);
+    ASSERT_EQ(io_writer.end_flush_chunk_group(false), E_OK);
+    ASSERT_EQ(io_writer.end_file(), E_OK);
+
+    TsFileReader reader;
+    ASSERT_EQ(reader.open(path), E_OK);
+    std::vector<MeasurementSchema> schemas;
+    ASSERT_EQ(reader.get_timeseries_schema(
+                  std::make_shared<StringArrayDeviceID>(device_name), schemas),
+              E_OK);
+    ASSERT_EQ(schemas.size(), 1u);
+    ASSERT_EQ(schemas[0].measurement_name_, measurement_name);
+    EXPECT_EQ(schemas[0].data_type_, INT32);
+    EXPECT_EQ(schemas[0].encoding_, TS_2DIFF);
+    EXPECT_EQ(schemas[0].compression_type_, UNCOMPRESSED);
+    reader.close();
+    remove(path.c_str());
 }
 
 TEST_F(TsFileReaderTest, GetTimeseriesMetadataTableModelTypeAndDeviceFilter) {
@@ -1509,6 +1577,10 @@ TEST_F(TsFileReaderTest, AlignedSchemaReportsValueDataType) {
     }
     EXPECT_EQ(i32_type, INT32);
     EXPECT_EQ(dbl_type, DOUBLE);
+    for (const auto& s : schemas) {
+        EXPECT_EQ(s.encoding_, PLAIN);
+        EXPECT_EQ(s.compression_type_, UNCOMPRESSED);
+    }
     reader.close();
 }
 


### PR DESCRIPTION
## Problem

`TsFileReader::get_timeseries_schema()` reports an encoding and a compressor for
every series it returns, but those values never came from the file. Each
`MeasurementSchema` was built with the two-argument constructor, which fills in
`common::get_value_encoder(data_type)` and `common::get_default_compressor()`.

So a series written as `PLAIN`/`UNCOMPRESSED` was reported as `TS_2DIFF`/`LZ4`:
the schema described the library defaults, not the file. Any caller that
inspects a file to learn how it was encoded — a converter, a compatibility
check, a `tsfile`-inspecting tool — got an answer that happened to be right only
when the writer used the defaults.

## Why the metadata index cannot supply it

Encoding and compression are per-chunk properties, and on disk they live only in
the chunk header. `ChunkMeta::deserialize_from()` reads nothing but
`offset_of_chunk_header_` (plus an optional statistic), so `ChunkMeta`'s own
`encoding_`/`compression_type_` fields are never assigned — and the default
constructor does not initialize them. Reading them from a `ChunkMeta` obtained
via the metadata index reads uninitialized memory.

The fix therefore reads the chunk header back from the file at that offset and
deserializes it, which is the same approach `ChunkReader::load_by_meta()`
already uses. `TsFileIOReader::get_read_file()` is added for the raw byte
access. If the header cannot be read the previous defaults are used, so schema
introspection never fails outright.

The read buffer is sized from the measurement name length rather than being a
fixed size: the name sits between the chunk type byte and the codec bytes in the
chunk header, so a long enough name would push the codecs past a fixed buffer
and silently fall back to the defaults — the exact bug being fixed. The
600-character-name test below covers this.

## Tests

`cpp/test/reader/timeseries_schema_codec_test.cc`, four tests. Every series is
registered with codecs that differ from the library defaults for its data type
(INT32 defaults to `TS_2DIFF`, FLOAT to `GORILLA`, and the default compressor is
`LZ4` when compiled in), so a reader that reports defaults is caught:

- `ReportsStoredEncodingAndCompressor` — non-aligned device, `PLAIN`/`UNCOMPRESSED`
  INT32 and `TS_2DIFF`/`UNCOMPRESSED` FLOAT.
- `ReportsStoredCodecForAlignedDevice` — the aligned write path; also asserts the
  data type is the real one, not the `VECTOR` placeholder.
- `ReportsCodecPerSeriesNotPerDevice` — one device mixing `UNCOMPRESSED` and
  `SNAPPY`, so an implementation that hard-coded `UNCOMPRESSED` cannot pass.
  Gated on `ENABLE_SNAPPY`.
- `ReportsStoredCodecForLongMeasurementName` — a 600-character measurement name.

## Verification

- The test commit is checked out on its own, builds, and fails 4/4 — reporting
  `TS_2DIFF`/`LZ4` where the file stores `PLAIN`/`UNCOMPRESSED`. The fix commit
  passes 4/4.
- Full suite on MSVC Debug: 790 tests, 787 passed, 3 skipped (environment-gated),
  0 failed — exactly +4 over the baseline.
- Each test was confirmed non-vacuous: temporarily reverting to the two-argument
  constructor fails the first three; temporarily restoring a fixed 256-byte
  header buffer fails only the long-name test.
- clang-format 17.0.6 clean (matching the pinned `clang.format.version`).
- cppcheck with this repo's CI flag set reports no findings in either changed
  file.

Built and run on MSVC Debug locally; the rest of the `unit-test-cpp` matrix
(Linux/macOS, ASan, Release) is left to CI.
