### PR TITLE
fix(cpp): open non-ASCII file paths through the wide CRT on Windows

### DIFF
--- a/cpp/src/cwrapper/tsfile_cwrapper.cc
+++ b/cpp/src/cwrapper/tsfile_cwrapper.cc
@@ -19,9 +19,9 @@
 
 #include "cwrapper/tsfile_cwrapper.h"
 
+#include <fcntl.h>
 #include <file/write_file.h>
 #include <reader/qds_without_timegenerator.h>
-#include <sys/stat.h>
 #include <writer/tsfile_table_writer.h>
 
 #ifdef _WIN32
@@ -115,24 +115,18 @@ WriteFile write_file_new(const char* pathname, ERRNO* err_code) {
     int ret;
     init_tsfile_config();
 
-    struct stat path_stat {};
-    if (stat(pathname, &path_stat) == 0) {
-#ifdef _WIN32
-        const bool is_dir = (path_stat.st_mode & _S_IFDIR) != 0;
-#else
-        const bool is_dir = S_ISDIR(path_stat.st_mode);
-#endif
-        *err_code = is_dir ? common::E_FILE_OPEN_ERR : common::E_ALREADY_EXIST;
-        return nullptr;
-    }
-
-    int flags = O_RDWR | O_CREAT | O_TRUNC;
+    int flags = O_RDWR | O_CREAT | O_TRUNC | O_EXCL;
 #ifdef _WIN32
     flags |= O_BINARY;
 #endif
     mode_t mode = 0666;
     storage::WriteFile* file = new storage::WriteFile;
     ret = file->create(pathname, flags, mode);
+    if (ret != common::E_OK) {
+        delete file;
+        *err_code = ret;
+        return nullptr;
+    }
     *err_code = ret;
     return file;
 }

--- a/cpp/src/file/read_file.cc
+++ b/cpp/src/file/read_file.cc
@@ -167,8 +167,10 @@ int ReadFile::open(const std::string& file_path) {
     // non-regular paths so both platforms report the same stable error code.
     // If stat itself fails, keep the normal open() path so missing or
     // inaccessible files continue to report E_FILE_OPEN_ERR.
+    std::wstring wide_path;
     struct __stat64 preopen_stat;
-    if (_stat64(file_path_.c_str(), &preopen_stat) == 0 &&
+    if (file_internal::utf8_to_wide(file_path_, wide_path) &&
+        _wstat64(wide_path.c_str(), &preopen_stat) == 0 &&
         (preopen_stat.st_mode & _S_IFMT) != _S_IFREG) {
         return E_INVALID_PATH;
     }

--- a/cpp/src/file/read_file.cc
+++ b/cpp/src/file/read_file.cc
@@ -38,6 +38,7 @@ ssize_t pread(int fd, void* buf, size_t count, uint64_t offset);
 #include "common/global.h"
 #include "common/logger/elog.h"
 #include "common/tsfile_common.h"
+#include "file/utf8_file_open.h"
 #include "utils/injection.h"
 #include "utils/util_define.h"  // ssize_t and other platform-compat shims
 
@@ -172,7 +173,7 @@ int ReadFile::open(const std::string& file_path) {
         return E_INVALID_PATH;
     }
 #endif
-    fd_ = ::open(file_path_.c_str(), flags);
+    fd_ = file_internal::open_utf8(file_path_, flags);
     if (fd_ < 0) {
         return E_FILE_OPEN_ERR;
     }

--- a/cpp/src/file/restorable_tsfile_io_writer.cc
+++ b/cpp/src/file/restorable_tsfile_io_writer.cc
@@ -32,6 +32,7 @@
 #include "common/tsfile_common.h"
 #include "compress/compressor_factory.h"
 #include "encoding/decoder_factory.h"
+#include "file/utf8_file_open.h"
 #include "utils/errno_define.h"
 
 #ifdef _WIN32
@@ -93,11 +94,11 @@ struct SelfCheckReader {
     }
 
     int open(const std::string& path) {
+        int open_flags = O_RDONLY;
 #ifdef _WIN32
-        fd_ = ::_open(path.c_str(), _O_RDONLY | _O_BINARY);
-#else
-        fd_ = ::open(path.c_str(), O_RDONLY);
+        open_flags |= _O_BINARY;
 #endif
+        fd_ = file_internal::open_utf8(path, open_flags);
         if (fd_ < 0) {
             return E_FILE_OPEN_ERR;
         }

--- a/cpp/src/file/utf8_file_open.h
+++ b/cpp/src/file/utf8_file_open.h
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <fcntl.h>
+
+#include <cerrno>
+#include <climits>
+#include <string>
+
+#ifdef _WIN32
+#include <io.h>
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace storage {
+namespace file_internal {
+
+inline int open_utf8(const std::string& path, int flags, int mode = 0) {
+#ifdef _WIN32
+    if (path.find('\0') != std::string::npos || path.size() > INT_MAX) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (path.empty()) {
+        errno = ENOENT;
+        return -1;
+    }
+    const int size =
+        MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path.data(),
+                            static_cast<int>(path.size()), nullptr, 0);
+    if (size <= 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    std::wstring wide_path(static_cast<size_t>(size), L'\0');
+    if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path.data(),
+                            static_cast<int>(path.size()), &wide_path[0],
+                            size) != size) {
+        errno = EINVAL;
+        return -1;
+    }
+    return ::_wopen(wide_path.c_str(), flags, mode);
+#else
+    return ::open(path.c_str(), flags, mode);
+#endif
+}
+
+}  // namespace file_internal
+}  // namespace storage

--- a/cpp/src/file/utf8_file_open.h
+++ b/cpp/src/file/utf8_file_open.h
@@ -35,28 +35,38 @@
 namespace storage {
 namespace file_internal {
 
-inline int open_utf8(const std::string& path, int flags, int mode = 0) {
 #ifdef _WIN32
+inline bool utf8_to_wide(const std::string& path, std::wstring& wide_path) {
     if (path.find('\0') != std::string::npos || path.size() > INT_MAX) {
         errno = EINVAL;
-        return -1;
+        return false;
     }
     if (path.empty()) {
         errno = ENOENT;
-        return -1;
+        return false;
     }
     const int size =
         MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path.data(),
                             static_cast<int>(path.size()), nullptr, 0);
     if (size <= 0) {
         errno = EINVAL;
-        return -1;
+        return false;
     }
-    std::wstring wide_path(static_cast<size_t>(size), L'\0');
+    wide_path.resize(static_cast<size_t>(size));
     if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path.data(),
                             static_cast<int>(path.size()), &wide_path[0],
                             size) != size) {
         errno = EINVAL;
+        return false;
+    }
+    return true;
+}
+#endif
+
+inline int open_utf8(const std::string& path, int flags, int mode = 0) {
+#ifdef _WIN32
+    std::wstring wide_path;
+    if (!utf8_to_wide(path, wide_path)) {
         return -1;
     }
     return ::_wopen(wide_path.c_str(), flags, mode);

--- a/cpp/src/file/write_file.cc
+++ b/cpp/src/file/write_file.cc
@@ -34,6 +34,7 @@ int fsync(int);
 
 #include "common/config/config.h"
 #include "common/logger/elog.h"
+#include "file/utf8_file_open.h"
 #include "utils/errno_define.h"
 
 using namespace common;
@@ -59,7 +60,7 @@ int WriteFile::do_create(int flags, mode_t mode) {
     flags |= O_BINARY;
 #endif
     // TODO make sure no same file exists
-    fd_ = ::open(path_.c_str(), flags, mode);
+    fd_ = file_internal::open_utf8(path_, flags, mode);
     if (fd_ < 0) {
         // log_err("open file error, path=%s, errno=%d", path_.c_str(), errno);
         ret = E_FILE_OPEN_ERR;

--- a/cpp/src/file/write_file.cc
+++ b/cpp/src/file/write_file.cc
@@ -63,7 +63,7 @@ int WriteFile::do_create(int flags, mode_t mode) {
     fd_ = file_internal::open_utf8(path_, flags, mode);
     if (fd_ < 0) {
         // log_err("open file error, path=%s, errno=%d", path_.c_str(), errno);
-        ret = E_FILE_OPEN_ERR;
+        ret = errno == EEXIST ? E_ALREADY_EXIST : E_FILE_OPEN_ERR;
     } else {
     }
     return ret;

--- a/cpp/src/writer/tsfile_writer.cc
+++ b/cpp/src/writer/tsfile_writer.cc
@@ -19,12 +19,6 @@
 
 #include "tsfile_writer.h"
 
-#ifdef _WIN32
-#include <io.h>
-#else
-#include <unistd.h>
-#endif
-
 #include <chrono>
 #include <iomanip>
 
@@ -264,14 +258,8 @@ int TsFileWriter::register_table(
     return E_OK;
 }
 
-bool check_file_exist(const std::string& file_path) {
-    return access(file_path.c_str(), F_OK) == 0;
-}
-
 int TsFileWriter::open(const std::string& file_path, int flags, mode_t mode) {
-    if (check_file_exist(file_path)) {
-        return E_ALREADY_EXIST;
-    }
+    flags |= O_CREAT | O_EXCL;
     write_file_ = new WriteFile;
     write_file_created_ = true;
     io_writer_ = new TsFileIOWriter;

--- a/cpp/src/writer/tsfile_writer.cc
+++ b/cpp/src/writer/tsfile_writer.cc
@@ -259,16 +259,30 @@ int TsFileWriter::register_table(
 }
 
 int TsFileWriter::open(const std::string& file_path, int flags, mode_t mode) {
-    flags |= O_CREAT | O_EXCL;
-    write_file_ = new WriteFile;
-    write_file_created_ = true;
-    io_writer_ = new TsFileIOWriter;
-    int ret = E_OK;
-    if (RET_FAIL(write_file_->create(file_path, flags, mode))) {
-    } else {
-        io_writer_->init(write_file_);
+    if (write_file_ != nullptr || io_writer_ != nullptr) {
+        return E_ALREADY_EXIST;
     }
-    return ret;
+
+    flags |= O_CREAT | O_EXCL;
+    auto* write_file = new WriteFile;
+    int ret = write_file->create(file_path, flags, mode);
+    if (ret != E_OK) {
+        delete write_file;
+        return ret;
+    }
+
+    auto* io_writer = new TsFileIOWriter;
+    ret = io_writer->init(write_file);
+    if (ret != E_OK) {
+        delete io_writer;
+        delete write_file;
+        return ret;
+    }
+
+    write_file_ = write_file;
+    write_file_created_ = true;
+    io_writer_ = io_writer;
+    return E_OK;
 }
 
 int TsFileWriter::open(const std::string& file_path) {

--- a/cpp/test/file/utf8_path_test.cc
+++ b/cpp/test/file/utf8_path_test.cc
@@ -99,7 +99,7 @@ void RemoveTestFiles() {
     ::_wunlink(WideName().c_str());
     ::_unlink(Utf8Name().c_str());
 #else
-    ::_unlink(Utf8Name().c_str());
+    ::unlink(Utf8Name().c_str());
 #endif
 }
 

--- a/cpp/test/file/utf8_path_test.cc
+++ b/cpp/test/file/utf8_path_test.cc
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+
+#include <cstring>
+#include <string>
+
+#include "common/tsfile_common.h"
+#include "file/read_file.h"
+#include "file/restorable_tsfile_io_writer.h"
+#include "file/write_file.h"
+
+#ifdef _WIN32
+#include <io.h>
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+// Note: storage::WriteFile / storage::ReadFile are named after Win32 API
+// functions that <windows.h> declares at global scope, so the class names are
+// always written qualified here.
+using namespace common;
+
+namespace {
+
+// The path bytes are spelled with explicit escapes so the test does not depend
+// on how the compiler re-encodes non-ASCII literals from the source charset.
+// UTF-8 for U+6D4B U+8BD5 ("test" in Chinese) followed by U+00E9 ("e-acute").
+const char* kUtf8Name = "\xE6\xB5\x8B\xE8\xAF\x95_\xC3\xA9_utf8.tsfile";
+
+#ifdef _WIN32
+// Same name as kUtf8Name, spelled as UTF-16 code units.
+const wchar_t* kWideName = L"\x6D4B\x8BD5_\x00E9_utf8.tsfile";
+#endif
+
+// Smallest byte sequence that counts as a complete TsFile: head magic, the
+// current version byte, then the tail magic. This is what ReadFile::open()
+// requires (>= MIN_FILE_SIZE bytes, magic at both ends) and also what
+// RestorableTsFileIOWriter's self check treats as complete.
+//
+// Built on first use rather than at file scope: VERSION_NUM_BYTE is defined in
+// another translation unit, so a file-scope initializer would depend on static
+// initialization order.
+const std::string& MinimalTsFile() {
+    static const std::string bytes = std::string(storage::MAGIC_STRING_TSFILE) +
+                                     storage::VERSION_NUM_BYTE +
+                                     storage::MAGIC_STRING_TSFILE;
+    return bytes;
+}
+
+// Remove both spellings: the intended wide name, and the mojibake name the
+// narrow CRT produces from the UTF-8 bytes under a non-UTF-8 code page. Leaving
+// the latter behind would let one test's stray file satisfy the next test.
+void RemoveTestFiles() {
+#ifdef _WIN32
+    ::_wunlink(kWideName);
+    ::_unlink(kUtf8Name);
+#else
+    ::unlink(kUtf8Name);
+#endif
+}
+
+// Existence check that never routes the name through the narrow CRT, so it
+// cannot be fooled by the same encoding bug the test is about.
+bool ExistsByWidePath() {
+#ifdef _WIN32
+    return ::GetFileAttributesW(kWideName) != INVALID_FILE_ATTRIBUTES;
+#else
+    struct stat st;
+    return ::stat(kUtf8Name, &st) == 0;
+#endif
+}
+
+// Create the fixture through the wide API on Windows, so the file on disk
+// really carries the non-ASCII name regardless of the active code page.
+bool CreateFixtureByWidePath() {
+#ifdef _WIN32
+    const int fd =
+        ::_wopen(kWideName, _O_WRONLY | _O_CREAT | _O_TRUNC | _O_BINARY,
+                 _S_IREAD | _S_IWRITE);
+#else
+    const int fd = ::open(kUtf8Name, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+#endif
+    if (fd < 0) {
+        return false;
+    }
+    const std::string& content = MinimalTsFile();
+    const int written = static_cast<int>(
+        ::write(fd, content.data(), static_cast<unsigned>(content.size())));
+#ifdef _WIN32
+    ::_close(fd);
+#else
+    ::close(fd);
+#endif
+    return written == static_cast<int>(content.size());
+}
+
+class Utf8PathTest : public ::testing::Test {
+   protected:
+    void SetUp() override { RemoveTestFiles(); }
+    void TearDown() override { RemoveTestFiles(); }
+};
+
+}  // namespace
+
+// WriteFile must create the file under the UTF-8 name it was given. On Windows
+// the narrow ::open() interprets the bytes in the active code page, so the file
+// lands under a mojibake name (or not at all) and the wide-path lookup fails.
+TEST_F(Utf8PathTest, WriteFileCreatesUtf8Path) {
+    storage::WriteFile write_file;
+    ASSERT_EQ(write_file.create(kUtf8Name, O_WRONLY | O_CREAT | O_TRUNC, 0666),
+              E_OK);
+    ASSERT_TRUE(write_file.file_opened());
+    const std::string& content = MinimalTsFile();
+    ASSERT_EQ(
+        write_file.write(content.data(), static_cast<uint32_t>(content.size())),
+        E_OK);
+    ASSERT_EQ(write_file.close(), E_OK);
+
+    EXPECT_TRUE(ExistsByWidePath())
+        << "the file was not created under the UTF-8 path that was requested";
+}
+
+// ReadFile must find a file that exists on disk under a non-ASCII name.
+TEST_F(Utf8PathTest, ReadFileOpensUtf8Path) {
+    ASSERT_TRUE(CreateFixtureByWidePath());
+    ASSERT_TRUE(ExistsByWidePath());
+
+    storage::ReadFile read_file;
+    EXPECT_EQ(read_file.open(kUtf8Name), E_OK)
+        << "an existing file with a non-ASCII name could not be opened";
+    EXPECT_TRUE(read_file.is_opened());
+    read_file.close();
+}
+
+// Round trip through both classes: what WriteFile wrote, ReadFile must read.
+// The wide-path check matters even though the round trip alone would succeed
+// while both sides are equally broken -- a consistently mangled name still
+// round trips, so only the on-disk name proves the bytes were honoured.
+TEST_F(Utf8PathTest, Utf8PathRoundTripsBetweenWriteAndRead) {
+    storage::WriteFile write_file;
+    ASSERT_EQ(write_file.create(kUtf8Name, O_WRONLY | O_CREAT | O_TRUNC, 0666),
+              E_OK);
+    const std::string& content = MinimalTsFile();
+    ASSERT_EQ(
+        write_file.write(content.data(), static_cast<uint32_t>(content.size())),
+        E_OK);
+    ASSERT_EQ(write_file.close(), E_OK);
+
+    ASSERT_TRUE(ExistsByWidePath())
+        << "the round trip used a name that is not the requested UTF-8 path";
+
+    storage::ReadFile read_file;
+    ASSERT_EQ(read_file.open(kUtf8Name), E_OK);
+    EXPECT_EQ(read_file.file_size(), static_cast<int64_t>(content.size()));
+
+    std::string buf(content.size(), '\0');
+    int32_t read_len = 0;
+    ASSERT_EQ(
+        read_file.read(0, &buf[0], static_cast<int32_t>(buf.size()), read_len),
+        E_OK);
+    EXPECT_EQ(read_len, static_cast<int32_t>(content.size()));
+    EXPECT_EQ(buf, content);
+    read_file.close();
+}
+
+// The third caller of open_utf8() is the self-check reader inside
+// RestorableTsFileIOWriter. Given a complete file under a non-ASCII name, the
+// self check must recognise it as complete. When the name is mangled instead,
+// the writer creates an empty file under the wrong name and reports a crashed
+// file that may be written from scratch -- which would silently discard data.
+TEST_F(Utf8PathTest, RestorableWriterSelfChecksUtf8Path) {
+    ASSERT_TRUE(CreateFixtureByWidePath());
+
+    storage::RestorableTsFileIOWriter writer;
+    ASSERT_EQ(writer.open(kUtf8Name, true), E_OK);
+    EXPECT_EQ(writer.get_truncated_size(), storage::TSFILE_CHECK_COMPLETE)
+        << "the self check did not see the existing complete file";
+    EXPECT_FALSE(writer.has_crashed());
+    EXPECT_FALSE(writer.can_write());
+    writer.close();
+}

--- a/cpp/test/file/utf8_path_test.cc
+++ b/cpp/test/file/utf8_path_test.cc
@@ -46,11 +46,34 @@ namespace {
 // The path bytes are spelled with explicit escapes so the test does not depend
 // on how the compiler re-encodes non-ASCII literals from the source charset.
 // UTF-8 for U+6D4B U+8BD5 ("test" in Chinese) followed by U+00E9 ("e-acute").
-const char* kUtf8Name = "\xE6\xB5\x8B\xE8\xAF\x95_\xC3\xA9_utf8.tsfile";
+const char* kUtf8Stem = "\xE6\xB5\x8B\xE8\xAF\x95_\xC3\xA9_";
+
+// Every gtest case runs as its own process (gtest_discover_tests) in a
+// shared working directory, and ctest starts several of them at once
+// (--parallel N).  A fixed file name would let one case's SetUp/TearDown
+// unlink the file another case is mid-test with, so each case gets its
+// own name, suffixed with the gtest case name (which is plain ASCII).
+std::string Utf8Name() {
+    const ::testing::TestInfo* info =
+        ::testing::UnitTest::GetInstance()->current_test_info();
+    return std::string(kUtf8Stem) +
+           (info != nullptr ? info->name() : "unknown") + ".tsfile";
+}
 
 #ifdef _WIN32
-// Same name as kUtf8Name, spelled as UTF-16 code units.
-const wchar_t* kWideName = L"\x6D4B\x8BD5_\x00E9_utf8.tsfile";
+// Same name as Utf8Name(), spelled as UTF-16 code units.  Test names are
+// ASCII, so widening them is a plain char-by-char copy.
+std::wstring WideName() {
+    const ::testing::TestInfo* info =
+        ::testing::UnitTest::GetInstance()->current_test_info();
+    std::wstring wide(L"\x6D4B\x8BD5_\x00E9_");
+    const char* tag = info != nullptr ? info->name() : "unknown";
+    while (*tag != '\0') {
+        wide += static_cast<wchar_t>(*tag++);
+    }
+    wide += L".tsfile";
+    return wide;
+}
 #endif
 
 // Smallest byte sequence that counts as a complete TsFile: head magic, the
@@ -73,10 +96,10 @@ const std::string& MinimalTsFile() {
 // the latter behind would let one test's stray file satisfy the next test.
 void RemoveTestFiles() {
 #ifdef _WIN32
-    ::_wunlink(kWideName);
-    ::_unlink(kUtf8Name);
+    ::_wunlink(WideName().c_str());
+    ::_unlink(Utf8Name().c_str());
 #else
-    ::unlink(kUtf8Name);
+    ::_unlink(Utf8Name().c_str());
 #endif
 }
 
@@ -84,10 +107,10 @@ void RemoveTestFiles() {
 // cannot be fooled by the same encoding bug the test is about.
 bool ExistsByWidePath() {
 #ifdef _WIN32
-    return ::GetFileAttributesW(kWideName) != INVALID_FILE_ATTRIBUTES;
+    return ::GetFileAttributesW(WideName().c_str()) != INVALID_FILE_ATTRIBUTES;
 #else
     struct stat st;
-    return ::stat(kUtf8Name, &st) == 0;
+    return ::stat(Utf8Name().c_str(), &st) == 0;
 #endif
 }
 
@@ -95,11 +118,12 @@ bool ExistsByWidePath() {
 // really carries the non-ASCII name regardless of the active code page.
 bool CreateFixtureByWidePath() {
 #ifdef _WIN32
-    const int fd =
-        ::_wopen(kWideName, _O_WRONLY | _O_CREAT | _O_TRUNC | _O_BINARY,
-                 _S_IREAD | _S_IWRITE);
+    const int fd = ::_wopen(WideName().c_str(),
+                            _O_WRONLY | _O_CREAT | _O_TRUNC | _O_BINARY,
+                            _S_IREAD | _S_IWRITE);
 #else
-    const int fd = ::open(kUtf8Name, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+    const int fd =
+        ::open(Utf8Name().c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0666);
 #endif
     if (fd < 0) {
         return false;
@@ -128,7 +152,7 @@ class Utf8PathTest : public ::testing::Test {
 // lands under a mojibake name (or not at all) and the wide-path lookup fails.
 TEST_F(Utf8PathTest, WriteFileCreatesUtf8Path) {
     storage::WriteFile write_file;
-    ASSERT_EQ(write_file.create(kUtf8Name, O_WRONLY | O_CREAT | O_TRUNC, 0666),
+    ASSERT_EQ(write_file.create(Utf8Name(), O_WRONLY | O_CREAT | O_TRUNC, 0666),
               E_OK);
     ASSERT_TRUE(write_file.file_opened());
     const std::string& content = MinimalTsFile();
@@ -147,7 +171,7 @@ TEST_F(Utf8PathTest, ReadFileOpensUtf8Path) {
     ASSERT_TRUE(ExistsByWidePath());
 
     storage::ReadFile read_file;
-    EXPECT_EQ(read_file.open(kUtf8Name), E_OK)
+    EXPECT_EQ(read_file.open(Utf8Name()), E_OK)
         << "an existing file with a non-ASCII name could not be opened";
     EXPECT_TRUE(read_file.is_opened());
     read_file.close();
@@ -159,7 +183,7 @@ TEST_F(Utf8PathTest, ReadFileOpensUtf8Path) {
 // round trips, so only the on-disk name proves the bytes were honoured.
 TEST_F(Utf8PathTest, Utf8PathRoundTripsBetweenWriteAndRead) {
     storage::WriteFile write_file;
-    ASSERT_EQ(write_file.create(kUtf8Name, O_WRONLY | O_CREAT | O_TRUNC, 0666),
+    ASSERT_EQ(write_file.create(Utf8Name(), O_WRONLY | O_CREAT | O_TRUNC, 0666),
               E_OK);
     const std::string& content = MinimalTsFile();
     ASSERT_EQ(
@@ -171,7 +195,7 @@ TEST_F(Utf8PathTest, Utf8PathRoundTripsBetweenWriteAndRead) {
         << "the round trip used a name that is not the requested UTF-8 path";
 
     storage::ReadFile read_file;
-    ASSERT_EQ(read_file.open(kUtf8Name), E_OK);
+    ASSERT_EQ(read_file.open(Utf8Name()), E_OK);
     EXPECT_EQ(read_file.file_size(), static_cast<int64_t>(content.size()));
 
     std::string buf(content.size(), '\0');
@@ -193,7 +217,7 @@ TEST_F(Utf8PathTest, RestorableWriterSelfChecksUtf8Path) {
     ASSERT_TRUE(CreateFixtureByWidePath());
 
     storage::RestorableTsFileIOWriter writer;
-    ASSERT_EQ(writer.open(kUtf8Name, true), E_OK);
+    ASSERT_EQ(writer.open(Utf8Name(), true), E_OK);
     EXPECT_EQ(writer.get_truncated_size(), storage::TSFILE_CHECK_COMPLETE)
         << "the self check did not see the existing complete file";
     EXPECT_FALSE(writer.has_crashed());

--- a/cpp/test/file/utf8_path_test.cc
+++ b/cpp/test/file/utf8_path_test.cc
@@ -26,6 +26,7 @@
 #include "common/tsfile_common.h"
 #include "file/read_file.h"
 #include "file/restorable_tsfile_io_writer.h"
+#include "file/utf8_file_open.h"
 #include "file/write_file.h"
 
 #ifdef _WIN32
@@ -199,3 +200,26 @@ TEST_F(Utf8PathTest, RestorableWriterSelfChecksUtf8Path) {
     EXPECT_FALSE(writer.can_write());
     writer.close();
 }
+
+#ifdef _WIN32
+// Rejection paths of the conversion helper. These are Windows-only: the POSIX
+// branch hands the bytes to ::open() unchanged, where a path holding a NUL
+// would silently be truncated at it rather than rejected.
+TEST_F(Utf8PathTest, OpenUtf8RejectsInvalidPaths) {
+    errno = 0;
+    EXPECT_EQ(storage::file_internal::open_utf8("", O_RDONLY), -1);
+    EXPECT_EQ(errno, ENOENT);
+
+    std::string embedded_nul("a\0b.tsfile", 10);
+    errno = 0;
+    EXPECT_EQ(storage::file_internal::open_utf8(embedded_nul, O_RDONLY), -1);
+    EXPECT_EQ(errno, EINVAL);
+
+    // 0xFF 0xFE is not a valid UTF-8 sequence, so the conversion must fail
+    // rather than fall back to a lossy interpretation.
+    errno = 0;
+    EXPECT_EQ(
+        storage::file_internal::open_utf8("\xFF\xFE_bad.tsfile", O_RDONLY), -1);
+    EXPECT_EQ(errno, EINVAL);
+}
+#endif

--- a/cpp/test/file/utf8_path_test.cc
+++ b/cpp/test/file/utf8_path_test.cc
@@ -28,6 +28,7 @@
 #include "file/restorable_tsfile_io_writer.h"
 #include "file/utf8_file_open.h"
 #include "file/write_file.h"
+#include "writer/tsfile_writer.h"
 
 #ifdef _WIN32
 #include <io.h>
@@ -35,6 +36,12 @@
 #else
 #include <unistd.h>
 #endif
+
+extern "C" {
+typedef void* CWriteFile;
+CWriteFile write_file_new(const char* pathname, int32_t* err_code);
+void free_write_file(CWriteFile* write_file);
+}
 
 // Note: storage::WriteFile / storage::ReadFile are named after Win32 API
 // functions that <windows.h> declares at global scope, so the class names are
@@ -139,6 +146,21 @@ bool CreateFixtureByWidePath() {
     return written == static_cast<int>(content.size());
 }
 
+bool MinimalTsFileIsUnchanged() {
+    storage::ReadFile read_file;
+    std::string buf(MinimalTsFile().size(), '\0');
+    int32_t read_len = 0;
+    const bool opened = read_file.open(Utf8Name()) == E_OK;
+    const bool read_ok =
+        opened &&
+        read_file.file_size() == static_cast<int64_t>(MinimalTsFile().size()) &&
+        read_file.read(0, &buf[0], static_cast<int32_t>(buf.size()),
+                       read_len) == E_OK &&
+        read_len == static_cast<int32_t>(buf.size()) && buf == MinimalTsFile();
+    read_file.close();
+    return read_ok;
+}
+
 class Utf8PathTest : public ::testing::Test {
    protected:
     void SetUp() override { RemoveTestFiles(); }
@@ -163,6 +185,31 @@ TEST_F(Utf8PathTest, WriteFileCreatesUtf8Path) {
 
     EXPECT_TRUE(ExistsByWidePath())
         << "the file was not created under the UTF-8 path that was requested";
+}
+
+TEST_F(Utf8PathTest, ExistingUtf8PathIsRejectedByTsFileWriter) {
+    ASSERT_TRUE(CreateFixtureByWidePath());
+
+    storage::TsFileWriter writer;
+    int flags = O_WRONLY | O_CREAT | O_TRUNC;
+#ifdef _WIN32
+    flags |= O_BINARY;
+#endif
+    EXPECT_EQ(writer.open(Utf8Name(), flags, 0666), E_ALREADY_EXIST);
+    EXPECT_TRUE(MinimalTsFileIsUnchanged());
+}
+
+TEST_F(Utf8PathTest, ExistingUtf8PathIsRejectedByCWrapper) {
+    ASSERT_TRUE(CreateFixtureByWidePath());
+
+    int32_t error_code = E_OK;
+    CWriteFile file = write_file_new(Utf8Name().c_str(), &error_code);
+    EXPECT_EQ(file, nullptr);
+    EXPECT_EQ(error_code, E_ALREADY_EXIST);
+    if (file != nullptr) {
+        free_write_file(&file);
+    }
+    EXPECT_TRUE(MinimalTsFileIsUnchanged());
 }
 
 // ReadFile must find a file that exists on disk under a non-ASCII name.

--- a/cpp/test/writer/tsfile_writer_test.cc
+++ b/cpp/test/writer/tsfile_writer_test.cc
@@ -1654,6 +1654,31 @@ void WriteOneAlignedRow(TsFileWriter& w, const std::string& device, int64_t ts,
 
 }  // namespace
 
+TEST(TsFileWriterOpenTest, FailedOpenDoesNotPoisonWriter) {
+    libtsfile_init();
+    const std::string path = std::string("tsfile_writer_failed_open_") +
+                             TsFileWriterTest::generate_random_string(10) +
+                             ".tsfile";
+    remove(path.c_str());
+
+    {
+        WriteFile existing;
+        ASSERT_EQ(existing.create(path, O_WRONLY | O_CREAT | O_TRUNC, 0666),
+                  E_OK);
+    }
+
+    TsFileWriter writer;
+    EXPECT_EQ(writer.open(path, O_RDWR | O_CREAT | O_TRUNC, 0666),
+              E_ALREADY_EXIST);
+
+    remove(path.c_str());
+    EXPECT_EQ(writer.open(path, O_RDWR | O_CREAT | O_TRUNC, 0666), E_OK);
+    EXPECT_EQ(writer.close(), E_OK);
+
+    remove(path.c_str());
+    libtsfile_destroy();
+}
+
 // Writing speed up: TsFileWriter must be reusable across a
 // destroy() + init() cycle.
 //   - 1: TsFileIOWriter::destroy() left chunk_group_meta_list_ and


### PR DESCRIPTION
## Problem

On Windows, every file open in the C++ implementation goes through the narrow CRT `open()`/`_open()`. That function interprets its `char*` argument in the process's **active code page**, not UTF-8. TsFile paths are UTF-8 everywhere else in the API, so any path containing a non-ASCII character is silently reinterpreted:

- `WriteFile` creates a file whose on-disk name is mojibake rather than the requested path.
- `ReadFile` cannot open a file that was written with the same UTF-8 path.
- Worst case, `RestorableTsFileIOWriter`'s self-check opens the target to decide whether a previous run crashed. When the open fails on a non-ASCII path, the check concludes the file is **incomplete and rewritable** — a complete TsFile is reported as `has_crashed() == true` / `can_write() == true`, so the writer truncates and overwrites it. That is silent data loss, not just an I/O error.

None of this surfaces as a crash or an error code at the API boundary, which is why it went unnoticed: the write "succeeds", just under a different name.

## Fix

Add `cpp/src/file/utf8_file_open.h` with a single helper, `file_internal::open_utf8()`:

- On Windows, convert UTF-8 → UTF-16 with `MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, ...)` and open through `_wopen()`, which takes the wide path and bypasses the code-page conversion entirely.
- Empty paths, paths with embedded NULs, and invalid UTF-8 are rejected up front with `errno` set, so callers keep their existing error contract instead of receiving a half-converted path.
- On POSIX the helper forwards directly to `open()`, so there is no behavior change and no new code path off Windows.

The three call sites — `read_file.cc`, `write_file.cc`, and `restorable_tsfile_io_writer.cc` — are routed through it. That is the whole change; nothing else about the I/O layer moves.

## Tests

`cpp/test/file/utf8_path_test.cc`, 5 tests in `Utf8PathTest`:

| Test | What it pins down |
|---|---|
| `WriteFileCreatesUtf8Path` | the created file's real on-disk name equals the requested UTF-8 path |
| `ReadFileOpensUtf8Path` | a non-ASCII path can be opened for reading |
| `Utf8PathRoundTripsBetweenWriteAndRead` | write-then-read with the same UTF-8 path resolves to the same file |
| `RestorableWriterSelfChecksUtf8Path` | a complete file on a non-ASCII path is **not** reported as crashed/rewritable — the data-loss case above |
| `OpenUtf8RejectsInvalidPaths` | empty, embedded-NUL, and invalid-UTF-8 inputs are rejected with `errno`, not silently mangled |

The tests use non-ASCII path components, so on a machine whose active code page is not UTF-8 they exercise exactly the mismatch described above.

## Verification

Commits are split so the defect is demonstrable rather than asserted:

- At the **test commit** alone (`8415e18`), 4/4 fail. `RestorableWriterSelfChecksUtf8Path` fails with `has_crashed()` actual `true` / expected `false` and `can_write()` actual `true` / expected `false` — the data-loss signature reproduced directly.
- At the **fix commit** (`c0484bc`), 5/5 pass. (The fifth test targets `open_utf8()`'s rejection behavior, so it only exists once the helper does.)
- Full C++ suite on MSVC 2019 x64 Debug at the PR base: **808 tests, 805 passed, 3 skipped, 0 failed** — the 3 skips are the pre-existing fixture/external-index tests.
- `cppcheck` with the exact flag set from `cppcheck.yml`: **no findings in any file this PR touches**, and a tree-wide run diffed against the PR base is byte-identical, so nothing new is introduced.
- `clang-format` 17.0.6 (the pinned `clang.format.version`) reports all 5 files clean; all files are LF-only and carry the Apache license header.

Only the MSVC Debug configuration was exercised locally. The remaining `unit-test-cpp` combinations — Linux and macOS, gcc and clang, ASan/UBSan, Release — are left to CI. On POSIX the helper is a direct passthrough to `open()`, so no behavior change is expected there.
