### PR TITLE
Add initial Go API bindings

### DIFF
--- a/.github/workflows/unit-test-go.yml
+++ b/.github/workflows/unit-test-go.yml
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Go unit tests
+
+on:
+  pull_request:
+    paths:
+      - "go/**"
+      - "cpp/src/cwrapper/**"
+      - ".github/workflows/unit-test-go.yml"
+  push:
+    branches: [develop]
+    paths:
+      - "go/**"
+      - "cpp/src/cwrapper/**"
+
+jobs:
+  test:
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-14]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "11"
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22.x"
+          cache-dependency-path: go/go.mod
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y uuid-dev
+      - name: Build native library
+        run: ./mvnw -P with-cpp -DskipTests -Dspotless.skip=true package
+      - name: Test Go API
+        working-directory: go
+        run: |
+          go vet ./...
+          go test ./...
+          go test -race ./...

--- a/cpp/src/cwrapper/tsfile_cwrapper.cc
+++ b/cpp/src/cwrapper/tsfile_cwrapper.cc
@@ -580,6 +580,36 @@ ResultSet tsfile_query_table_on_tree(TsFileReader reader, char** columns,
     return table_result_set;
 }
 
+ResultSet tsfile_reader_query_tree(TsFileReader reader, char** paths,
+                                   uint32_t path_num, Timestamp start_time,
+                                   Timestamp end_time, ERRNO* err_code) {
+    if (err_code == nullptr) {
+        return nullptr;
+    }
+    *err_code = common::E_INVALID_ARG;
+    if (reader == nullptr || paths == nullptr || path_num == 0 ||
+        end_time < start_time) {
+        return nullptr;
+    }
+    try {
+        std::vector<std::string> selected_paths;
+        selected_paths.reserve(path_num);
+        for (uint32_t i = 0; i < path_num; i++) {
+            if (paths[i] == nullptr) {
+                return nullptr;
+            }
+            selected_paths.emplace_back(paths[i]);
+        }
+        storage::ResultSet* result_set = nullptr;
+        *err_code = static_cast<storage::TsFileReader*>(reader)->query(
+            selected_paths, start_time, end_time, result_set);
+        return result_set;
+    } catch (const std::bad_alloc&) {
+        *err_code = common::E_OOM;
+        return nullptr;
+    }
+}
+
 ResultSet tsfile_reader_query_tree_by_row(TsFileReader reader,
                                           char** device_ids, int device_ids_len,
                                           char** measurement_names,
@@ -1954,6 +1984,165 @@ ERRNO _tsfile_writer_add_tsfile_property(TsFileWriter writer, const char* key,
         auto* w = static_cast<storage::TsFileWriter*>(writer);
         return w->add_tsfile_property(std::string(key, key_len), value,
                                       value_len);
+    } catch (const std::bad_alloc&) {
+        return common::E_OOM;
+    }
+}
+
+TsFileGenericWriter tsfile_generic_writer_new(const char* pathname,
+                                              uint64_t memory_threshold,
+                                              ERRNO* err_code) {
+    // Public C entry point: guard null arguments before the private delegate
+    // dereferences them, and keep std::bad_alloc from crossing the C ABI.
+    // See tsfile_writer_new() above for the null-guard rationale.
+    if (err_code == nullptr) {
+        return nullptr;
+    }
+    *err_code = common::E_OK;
+    if (pathname == nullptr) {
+        *err_code = common::E_INVALID_ARG;
+        return nullptr;
+    }
+    try {
+        return _tsfile_writer_new(pathname, memory_threshold, err_code);
+    } catch (const std::bad_alloc&) {
+        *err_code = common::E_OOM;
+        return nullptr;
+    }
+}
+
+Tablet tablet_new_with_target_name(const char* target_name,
+                                   char** column_name_list,
+                                   TSDataType* data_types, int column_num,
+                                   int max_rows) {
+    // Public C entry point: reject arguments that would make the private
+    // delegate read out-of-bounds memory (negative column_num, null lists or
+    // null column names) before touching caller buffers. The native Tablet
+    // constructor asserts 0 < max_rows < (1 << 30); reject values outside
+    // that domain here instead of letting an assertion abort the host
+    // process. Returns NULL on invalid arguments or allocation failure.
+    if (column_num < 0 || max_rows <= 0 || max_rows >= (1 << 30)) {
+        return nullptr;
+    }
+    if (column_num > 0) {
+        if (column_name_list == nullptr || data_types == nullptr) {
+            return nullptr;
+        }
+        for (int i = 0; i < column_num; i++) {
+            if (column_name_list[i] == nullptr) {
+                return nullptr;
+            }
+        }
+    }
+    try {
+        return _tablet_new_with_target_name(target_name, column_name_list,
+                                            data_types, column_num, max_rows);
+    } catch (const std::bad_alloc&) {
+        return nullptr;
+    }
+}
+
+ERRNO tsfile_generic_writer_register_table(TsFileGenericWriter writer,
+                                           TableSchema* schema) {
+    if (writer == nullptr) {
+        return common::E_INVALID_ARG;
+    }
+    try {
+        return _tsfile_writer_register_table(writer, schema);
+    } catch (const std::bad_alloc&) {
+        return common::E_OOM;
+    }
+}
+
+ERRNO tsfile_generic_writer_register_timeseries(
+    TsFileGenericWriter writer, const char* device_id,
+    const TimeseriesSchema* schema) {
+    if (writer == nullptr || device_id == nullptr || schema == nullptr ||
+        schema->timeseries_name == nullptr) {
+        return common::E_INVALID_ARG;
+    }
+    try {
+        return _tsfile_writer_register_timeseries(writer, device_id, schema);
+    } catch (const std::bad_alloc&) {
+        return common::E_OOM;
+    }
+}
+
+ERRNO tsfile_generic_writer_register_device(TsFileGenericWriter writer,
+                                            const DeviceSchema* device_schema) {
+    if (writer == nullptr || device_schema == nullptr ||
+        device_schema->device_name == nullptr ||
+        device_schema->timeseries_num < 0) {
+        return common::E_INVALID_ARG;
+    }
+    if (device_schema->timeseries_num > 0 &&
+        device_schema->timeseries_schema == nullptr) {
+        return common::E_INVALID_ARG;
+    }
+    for (int i = 0; i < device_schema->timeseries_num; i++) {
+        if (device_schema->timeseries_schema[i].timeseries_name == nullptr) {
+            return common::E_INVALID_ARG;
+        }
+    }
+    try {
+        return _tsfile_writer_register_device(writer, device_schema);
+    } catch (const std::bad_alloc&) {
+        return common::E_OOM;
+    }
+}
+
+ERRNO tsfile_generic_writer_write_tree_tablet(TsFileGenericWriter writer,
+                                              Tablet tablet) {
+    if (writer == nullptr || tablet == nullptr) {
+        return common::E_INVALID_ARG;
+    }
+    try {
+        return _tsfile_writer_write_tablet(writer, tablet);
+    } catch (const std::bad_alloc&) {
+        return common::E_OOM;
+    }
+}
+
+ERRNO tsfile_generic_writer_write_table_tablet(TsFileGenericWriter writer,
+                                               Tablet tablet) {
+    if (writer == nullptr || tablet == nullptr) {
+        return common::E_INVALID_ARG;
+    }
+    try {
+        return _tsfile_writer_write_table(writer, tablet);
+    } catch (const std::bad_alloc&) {
+        return common::E_OOM;
+    }
+}
+
+ERRNO tsfile_generic_writer_flush(TsFileGenericWriter writer) {
+    if (writer == nullptr) {
+        return common::E_INVALID_ARG;
+    }
+    try {
+        return _tsfile_writer_flush(writer);
+    } catch (const std::bad_alloc&) {
+        return common::E_OOM;
+    }
+}
+
+ERRNO tsfile_generic_writer_add_tsfile_property(TsFileGenericWriter writer,
+                                                const char* key,
+                                                uint32_t key_len,
+                                                const uint8_t* value,
+                                                uint32_t value_len) {
+    return _tsfile_writer_add_tsfile_property(writer, key, key_len, value,
+                                              value_len);
+}
+
+ERRNO tsfile_generic_writer_close(TsFileGenericWriter writer) {
+    // Matches the public tsfile_writer_close(): a null handle is treated as
+    // already closed.
+    if (writer == nullptr) {
+        return common::E_OK;
+    }
+    try {
+        return _tsfile_writer_close(writer);
     } catch (const std::bad_alloc&) {
         return common::E_OOM;
     }

--- a/cpp/src/cwrapper/tsfile_cwrapper.h
+++ b/cpp/src/cwrapper/tsfile_cwrapper.h
@@ -274,6 +274,7 @@ typedef void* WriteFile;
 
 typedef void* TsFileReader;
 typedef void* TsFileWriter;
+typedef void* TsFileGenericWriter;
 
 // just reuse Tablet from c++
 typedef void* Tablet;
@@ -732,6 +733,22 @@ ResultSet tsfile_query_table(TsFileReader reader, const char* table_name,
 ResultSet tsfile_query_table_on_tree(TsFileReader reader, char** columns,
                                      uint32_t column_num, Timestamp start_time,
                                      Timestamp end_time, ERRNO* err_code);
+
+/**
+ * @brief Query exact tree-model full paths within a time range.
+ *
+ * @param reader [in] Valid reader handle.
+ * @param paths [in] Array of full paths such as root.device.measurement.
+ * @param path_num [in] Number of paths; must be greater than zero.
+ * @param start_time [in] Inclusive start timestamp.
+ * @param end_time [in] Inclusive end timestamp.
+ * @param err_code [out] Error code; must not be NULL.
+ * @return ResultSet handle on success, or NULL on failure.
+ */
+ResultSet tsfile_reader_query_tree(TsFileReader reader, char** paths,
+                                   uint32_t path_num, Timestamp start_time,
+                                   Timestamp end_time, ERRNO* err_code);
+
 /**
  * @brief Query time series (tree model) by row with offset/limit.
  *
@@ -841,11 +858,10 @@ char* tsfile_result_set_get_value_by_name_string(ResultSet result_set,
                                                  const char* column_name);
 
 /**
- * @brief Gets value from current row by column_index[0 <= column_index <<
- * column_num] (generic types).
+ * @brief Gets a value from the current row by 1-based column index.
  *
  * @param result_set [in] Valid ResultSet with active row (after next()=true).
- * @param column_name [in] Existing column index in result schema.
+ * @param column_index [in] Existing column index in [1, column_num].
  * @return type-value, return type-specific value.
  * @note Generated for: bool, int32_t, int64_t, float, double
  */
@@ -881,7 +897,7 @@ bool tsfile_result_set_is_null_by_name(ResultSet result_set,
 /**
  * @brief Checks if the current row's column value is NULL by column index.
  *
- * @param column_index [in] Column position (0 ≤ index < result_column_count).
+ * @param column_index [in] Column position in [1, result_column_count].
  * @return bool - true: Value is NULL or index out of range, false: Valid value.
  */
 bool tsfile_result_set_is_null_by_index(ResultSet result_set,
@@ -903,7 +919,7 @@ ResultSetMetaData tsfile_result_set_get_metadata(ResultSet result_set);
 /**
  * @brief Gets column name by index from metadata.
  *
- * @param column_index [in] Column position (0 ≤ index < column_num).
+ * @param column_index [in] Column position in [1, column_num].
  * @return const char* Read-only string. NULL if index invalid.
  */
 char* tsfile_result_set_metadata_get_column_name(ResultSetMetaData result_set,
@@ -1078,6 +1094,117 @@ void free_timeseries_schema(TimeseriesSchema schema);
 void free_table_schema(TableSchema schema);
 void free_column_schema(ColumnSchema schema);
 void free_write_file(WriteFile* write_file);
+
+// ---------- Generic Writer API ----------
+//
+// Safety rules:
+// - No C++ exception (e.g. std::bad_alloc) is allowed to cross this API:
+//   allocation failures are reported as RET_OOM, and null/invalid
+//   arguments as RET_INVALID_ARG (handle constructors additionally return
+//   NULL).
+// - tsfile_generic_writer_close(NULL) is a no-op returning RET_OK.
+//
+// Ownership and lifetime rules:
+// - tsfile_generic_writer_new returns an owning handle. The caller owns the
+//   returned handle until it is passed to tsfile_generic_writer_close, which
+//   flushes, closes and deletes it.
+// - Input schemas (TableSchema, TimeseriesSchema, DeviceSchema) and strings
+//   (pathname, target_name, device_id, keys) are borrowed for the duration of
+//   the call only; the writer does not retain them after the call returns.
+// - Tablets are not consumed by the writer: after
+//   tsfile_generic_writer_write_tree_tablet or
+//   tsfile_generic_writer_write_table_tablet the tablet remains caller-owned
+//   and must be freed by the caller (e.g. via free_tablet).
+
+/**
+ * @brief Create a new generic writer.
+ * @param pathname file path of the TsFile to write; must not be NULL
+ * @param memory_threshold in-memory buffer threshold in bytes
+ * @param err_code out parameter receiving the error code; may be NULL, in
+ *        which case the call fails silently with a NULL return
+ * @return an owning handle to the new writer, or NULL on failure with
+ *         *err_code set (unless err_code was NULL)
+ */
+TsFileGenericWriter tsfile_generic_writer_new(const char* pathname,
+                                              uint64_t memory_threshold,
+                                              ERRNO* err_code);
+
+/**
+ * @brief Create a tablet whose rows target the named table.
+ * @param target_name name of the target table (borrowed); NULL selects the
+ *        table-less constructor
+ * @param column_name_list column names (borrowed); must not be NULL when
+ *        column_num > 0, and no entry may be NULL
+ * @param data_types data types of the columns (borrowed); must not be NULL
+ *        when column_num > 0
+ * @param column_num number of columns; must be >= 0
+ * @param max_rows maximum number of rows the tablet can hold; must satisfy
+ *        0 < max_rows < 2^30
+ * @return a caller-owned tablet, or NULL if the arguments are invalid or
+ *         memory allocation fails
+ */
+Tablet tablet_new_with_target_name(const char* target_name,
+                                   char** column_name_list,
+                                   TSDataType* data_types, int column_num,
+                                   int max_rows);
+
+/**
+ * @brief Register a table schema with the writer. The schema is borrowed for
+ *        the duration of the call.
+ */
+ERRNO tsfile_generic_writer_register_table(TsFileGenericWriter writer,
+                                           TableSchema* schema);
+
+/**
+ * @brief Register a timeseries schema for a device with the writer. The
+ *        device_id string and schema are borrowed for the duration of the
+ *        call.
+ */
+ERRNO tsfile_generic_writer_register_timeseries(TsFileGenericWriter writer,
+                                                const char* device_id,
+                                                const TimeseriesSchema* schema);
+
+/**
+ * @brief Register a device schema with the writer. The device schema is
+ *        borrowed for the duration of the call.
+ */
+ERRNO tsfile_generic_writer_register_device(TsFileGenericWriter writer,
+                                            const DeviceSchema* device_schema);
+
+/**
+ * @brief Write a tree-model tablet. The tablet remains caller-owned after the
+ *        call returns.
+ */
+ERRNO tsfile_generic_writer_write_tree_tablet(TsFileGenericWriter writer,
+                                              Tablet tablet);
+
+/**
+ * @brief Write a table-model tablet. The tablet remains caller-owned after
+ *        the call returns.
+ */
+ERRNO tsfile_generic_writer_write_table_tablet(TsFileGenericWriter writer,
+                                               Tablet tablet);
+
+/**
+ * @brief Flush pending data to the file.
+ */
+ERRNO tsfile_generic_writer_flush(TsFileGenericWriter writer);
+
+/**
+ * @brief Add a key/value TsFile property to the writer. The key and value
+ *        buffers are borrowed for the duration of the call.
+ */
+ERRNO tsfile_generic_writer_add_tsfile_property(TsFileGenericWriter writer,
+                                                const char* key,
+                                                uint32_t key_len,
+                                                const uint8_t* value,
+                                                uint32_t value_len);
+
+/**
+ * @brief Flush, close and delete the writer. After this call the handle must
+ *        not be used.
+ */
+ERRNO tsfile_generic_writer_close(TsFileGenericWriter writer);
 
 // ---------- !For Python API! ----------
 

--- a/cpp/test/cwrapper/cwrapper_public_writer_test.cc
+++ b/cpp/test/cwrapper/cwrapper_public_writer_test.cc
@@ -1,0 +1,301 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+extern "C" {
+#include "cwrapper/errno_define_c.h"
+#include "cwrapper/tsfile_cwrapper.h"
+}
+
+namespace cwrapper_public_writer {
+
+class CWrapperPublicWriterTest : public testing::Test {};
+
+// Every public generic writer entry point must reject a null writer handle
+// without dereferencing it: ERRNO-returning calls report RET_INVALID_ARG,
+// and tsfile_generic_writer_close follows the public tsfile_writer_close
+// convention of treating a null handle as already closed.
+TEST_F(CWrapperPublicWriterTest, NullWriterHandlesReturnInvalidArg) {
+    ColumnSchema column = {const_cast<char*>("s1"), TS_DATATYPE_INT64, FIELD};
+    TableSchema schema = {const_cast<char*>("table1"), &column, 1};
+
+    TimeseriesSchema ts_schema;
+    ts_schema.timeseries_name = const_cast<char*>("s1");
+    ts_schema.data_type = TS_DATATYPE_INT64;
+    ts_schema.encoding = TS_ENCODING_PLAIN;
+    ts_schema.compression = TS_COMPRESSION_UNCOMPRESSED;
+
+    DeviceSchema device_schema;
+    device_schema.device_name = const_cast<char*>("root.d1");
+    device_schema.timeseries_schema = &ts_schema;
+    device_schema.timeseries_num = 1;
+
+    EXPECT_EQ(tsfile_generic_writer_register_table(nullptr, &schema),
+              RET_INVALID_ARG);
+    EXPECT_EQ(tsfile_generic_writer_register_timeseries(nullptr, "root.d1",
+                                                        &ts_schema),
+              RET_INVALID_ARG);
+    EXPECT_EQ(tsfile_generic_writer_register_device(nullptr, &device_schema),
+              RET_INVALID_ARG);
+    EXPECT_EQ(tsfile_generic_writer_write_tree_tablet(nullptr, nullptr),
+              RET_INVALID_ARG);
+    EXPECT_EQ(tsfile_generic_writer_write_table_tablet(nullptr, nullptr),
+              RET_INVALID_ARG);
+    EXPECT_EQ(tsfile_generic_writer_flush(nullptr), RET_INVALID_ARG);
+    EXPECT_EQ(tsfile_generic_writer_close(nullptr), RET_OK);
+
+    char key[] = "test_key";
+    const uint8_t value = 0;
+    EXPECT_EQ(
+        tsfile_generic_writer_add_tsfile_property(
+            nullptr, key, static_cast<uint32_t>(std::strlen(key)), &value, 1),
+        RET_INVALID_ARG);
+}
+
+// tsfile_generic_writer_new must never dereference a null pathname or a null
+// err_code, and it must surface open() failures through *err_code with a
+// NULL handle instead of leaking a half-open writer.
+TEST_F(CWrapperPublicWriterTest, WriterNewInvalidArgs) {
+    ERRNO err = RET_OK;
+
+    EXPECT_EQ(tsfile_generic_writer_new(nullptr, 1 << 20, &err), nullptr);
+    EXPECT_EQ(err, RET_INVALID_ARG);
+
+    // A null err_code is accepted: the call reports failure only through
+    // the NULL return and must not crash.
+    const char* filename = "cwrapper_public_writer_test.tsfile";
+    EXPECT_EQ(tsfile_generic_writer_new(filename, 1 << 20, nullptr), nullptr);
+    remove(filename);
+
+    // A path under a non-existent directory fails to open; the error code
+    // must be reported and the handle must be NULL.
+    const char* bad_path = "cwrapper_public_writer_nonexistent_dir/x.tsfile";
+    err = RET_OK;
+    EXPECT_EQ(tsfile_generic_writer_new(bad_path, 1 << 20, &err), nullptr);
+    EXPECT_NE(err, RET_OK);
+}
+
+TEST_F(CWrapperPublicWriterTest, QueryTreeInvalidArgs) {
+    ERRNO err = RET_OK;
+    char path[] = "root.d1.s1";
+    char* paths[] = {path};
+
+    EXPECT_EQ(tsfile_reader_query_tree(nullptr, paths, 1, 0, 1, &err), nullptr);
+    EXPECT_EQ(err, RET_INVALID_ARG);
+    EXPECT_EQ(tsfile_reader_query_tree(nullptr, paths, 1, 0, 1, nullptr),
+              nullptr);
+}
+
+// tablet_new_with_target_name must reject arguments that would make the
+// private delegate read out-of-bounds memory or hit the native Tablet
+// max_rows assertion, returning NULL instead.
+TEST_F(CWrapperPublicWriterTest, TabletNewWithTargetNameInvalidArgs) {
+    char column_names[] = "s1";
+    char* column_name_list[] = {column_names};
+    TSDataType data_types[] = {TS_DATATYPE_INT64};
+
+    // Null element inside an otherwise valid list.
+    char* null_entry[] = {nullptr};
+
+    // Lists present, but element counts/limits invalid.
+    EXPECT_EQ(
+        tablet_new_with_target_name("t1", column_name_list, data_types, 1, 0),
+        nullptr);
+    EXPECT_EQ(
+        tablet_new_with_target_name("t1", column_name_list, data_types, 1, -1),
+        nullptr);
+    EXPECT_EQ(
+        tablet_new_with_target_name("t1", column_name_list, data_types, -1, 2),
+        nullptr);
+
+    // column_num > 0 requires both lists and every element.
+    EXPECT_EQ(tablet_new_with_target_name("t1", nullptr, data_types, 1, 2),
+              nullptr);
+    EXPECT_EQ(
+        tablet_new_with_target_name("t1", column_name_list, nullptr, 1, 2),
+        nullptr);
+    EXPECT_EQ(tablet_new_with_target_name("t1", null_entry, data_types, 1, 2),
+              nullptr);
+
+    // Zero columns with null lists and a null target is a valid tablet.
+    Tablet zero_columns =
+        tablet_new_with_target_name(nullptr, nullptr, nullptr, 0, 16);
+    ASSERT_NE(nullptr, zero_columns);
+    free_tablet(&zero_columns);
+    EXPECT_EQ(nullptr, zero_columns);
+
+    // The nominal one-column construction still succeeds.
+    Tablet tablet =
+        tablet_new_with_target_name("t1", column_name_list, data_types, 1, 2);
+    ASSERT_NE(nullptr, tablet);
+    free_tablet(&tablet);
+    EXPECT_EQ(nullptr, tablet);
+}
+
+// Invalid arguments on a live writer handle must be reported, not crashed
+// on, and must not close the writer.
+TEST_F(CWrapperPublicWriterTest, InvalidArgsOnLiveWriter) {
+    const char* filename = "cwrapper_public_writer_test.tsfile";
+    remove(filename);
+
+    ERRNO err = RET_OK;
+    TsFileGenericWriter writer =
+        tsfile_generic_writer_new(filename, 128 * 1024 * 1024, &err);
+    ASSERT_EQ(RET_OK, err);
+    ASSERT_NE(nullptr, writer);
+
+    TimeseriesSchema ts_schema;
+    ts_schema.timeseries_name = const_cast<char*>("s1");
+    ts_schema.data_type = TS_DATATYPE_INT64;
+    ts_schema.encoding = TS_ENCODING_PLAIN;
+    ts_schema.compression = TS_COMPRESSION_UNCOMPRESSED;
+
+    TimeseriesSchema null_name_schema = ts_schema;
+    null_name_schema.timeseries_name = nullptr;
+
+    EXPECT_EQ(tsfile_generic_writer_register_table(writer, nullptr),
+              RET_INVALID_ARG);
+    EXPECT_EQ(
+        tsfile_generic_writer_register_timeseries(writer, nullptr, &ts_schema),
+        RET_INVALID_ARG);
+    EXPECT_EQ(
+        tsfile_generic_writer_register_timeseries(writer, "root.d1", nullptr),
+        RET_INVALID_ARG);
+    EXPECT_EQ(tsfile_generic_writer_register_timeseries(writer, "root.d1",
+                                                        &null_name_schema),
+              RET_INVALID_ARG);
+    EXPECT_EQ(tsfile_generic_writer_write_tree_tablet(writer, nullptr),
+              RET_INVALID_ARG);
+    EXPECT_EQ(tsfile_generic_writer_write_table_tablet(writer, nullptr),
+              RET_INVALID_ARG);
+
+    DeviceSchema no_name;
+    no_name.device_name = nullptr;
+    no_name.timeseries_schema = &ts_schema;
+    no_name.timeseries_num = 1;
+    EXPECT_EQ(tsfile_generic_writer_register_device(writer, &no_name),
+              RET_INVALID_ARG);
+
+    DeviceSchema no_array;
+    no_array.device_name = const_cast<char*>("root.d1");
+    no_array.timeseries_schema = nullptr;
+    no_array.timeseries_num = 1;
+    EXPECT_EQ(tsfile_generic_writer_register_device(writer, &no_array),
+              RET_INVALID_ARG);
+
+    DeviceSchema negative_count;
+    negative_count.device_name = const_cast<char*>("root.d1");
+    negative_count.timeseries_schema = &ts_schema;
+    negative_count.timeseries_num = -1;
+    EXPECT_EQ(tsfile_generic_writer_register_device(writer, &negative_count),
+              RET_INVALID_ARG);
+
+    // The writer must still be usable: a valid registration and close
+    // succeed.
+    EXPECT_EQ(tsfile_generic_writer_register_timeseries(writer, "root.d1",
+                                                        &ts_schema),
+              RET_OK);
+    EXPECT_EQ(tsfile_generic_writer_close(writer), RET_OK);
+    remove(filename);
+}
+
+TEST_F(CWrapperPublicWriterTest, WriteAndQueryTreeTablet) {
+    const char* filename = "cwrapper_public_writer_test.tsfile";
+    remove(filename);
+
+    const char* device_id = "root.d1";
+    const char* measurement = "s1";
+
+    // Write one INT64/PLAIN/UNCOMPRESSED timeseries with the public API.
+    ERRNO err = RET_OK;
+    TsFileGenericWriter writer =
+        tsfile_generic_writer_new(filename, 128 * 1024 * 1024, &err);
+    ASSERT_EQ(RET_OK, err);
+    ASSERT_NE(nullptr, writer);
+
+    TimeseriesSchema schema;
+    schema.timeseries_name = const_cast<char*>(measurement);
+    schema.data_type = TS_DATATYPE_INT64;
+    schema.encoding = TS_ENCODING_PLAIN;
+    schema.compression = TS_COMPRESSION_UNCOMPRESSED;
+    ASSERT_EQ(
+        tsfile_generic_writer_register_timeseries(writer, device_id, &schema),
+        RET_OK);
+
+    char* column_names[] = {const_cast<char*>(measurement)};
+    TSDataType data_types[] = {TS_DATATYPE_INT64};
+    Tablet tablet =
+        tablet_new_with_target_name(device_id, column_names, data_types, 1, 2);
+    ASSERT_NE(nullptr, tablet);
+
+    ASSERT_EQ(tablet_add_timestamp(tablet, 0, 1), RET_OK);
+    ASSERT_EQ(tablet_add_timestamp(tablet, 1, 2), RET_OK);
+    ASSERT_EQ(tablet_add_value_by_name_int64_t(tablet, 0, measurement, 11),
+              RET_OK);
+    ASSERT_EQ(tablet_add_value_by_name_int64_t(tablet, 1, measurement, 22),
+              RET_OK);
+
+    ASSERT_EQ(tsfile_generic_writer_write_tree_tablet(writer, tablet), RET_OK);
+    ASSERT_EQ(tsfile_generic_writer_flush(writer), RET_OK);
+    ASSERT_EQ(tsfile_generic_writer_close(writer), RET_OK);
+
+    free_tablet(&tablet);
+    EXPECT_EQ(nullptr, tablet);
+
+    // Read the file back with the public reader/query-by-row API.
+    ERRNO code = RET_OK;
+    TsFileReader reader = tsfile_reader_new(filename, &code);
+    ASSERT_EQ(RET_OK, code);
+    ASSERT_NE(nullptr, reader);
+
+    char device_ids[] = "root.d1";
+    char measurement_names[] = "s1";
+    char* device_id_list[] = {device_ids};
+    char* measurement_name_list[] = {measurement_names};
+
+    ResultSet result_set = tsfile_reader_query_tree_by_row(
+        reader, device_id_list, 1, measurement_name_list, 1, 0, -1, &code);
+    ASSERT_EQ(RET_OK, code);
+    ASSERT_NE(nullptr, result_set);
+
+    const int64_t expected_values[] = {11, 22};
+    int row = 0;
+    while (tsfile_result_set_next(result_set, &code)) {
+        ASSERT_EQ(RET_OK, code);
+        ASSERT_LT(row, 2);
+        EXPECT_EQ(static_cast<int64_t>(row + 1),
+                  tsfile_result_set_get_value_by_index_int64_t(result_set, 1));
+        EXPECT_EQ(expected_values[row],
+                  tsfile_result_set_get_value_by_index_int64_t(result_set, 2));
+        row++;
+    }
+    ASSERT_EQ(RET_OK, code);
+    ASSERT_EQ(2, row);
+
+    free_tsfile_result_set(&result_set);
+    ASSERT_EQ(tsfile_reader_close(reader), RET_OK);
+    remove(filename);
+}
+
+}  // namespace cwrapper_public_writer

--- a/docs/superpowers/specs/2026-08-27-go-api-design.md
+++ b/docs/superpowers/specs/2026-08-27-go-api-design.md
@@ -1,0 +1,313 @@
+# TsFile Go API Design
+
+## Status
+
+Proposed design for an initial Go binding over the TsFile C++ implementation.
+This document covers the API and implementation boundary only; it is not an
+implementation plan.
+
+## Goals and scope
+
+Add a Go module at `go/` with module path `github.com/apache/tsfile/go` and a
+public package imported as `github.com/apache/tsfile/go/tsfile`.
+
+The first release supports:
+
+- Linux and macOS with cgo enabled;
+- single-file tree-model and table-model read, write, and query operations;
+- schemas, tablets, readers, writers, and result sets;
+- the same C++ core and C wrapper used by the Python binding; and
+- deterministic ownership, error handling, and cross-language tests.
+
+The first release does not include Arrow, pandas/dataframe-style APIs, dataset
+or multi-file merging, Windows, automatic native dependency installation, or a
+pure-Go TsFile implementation.
+
+## Architecture
+
+```text
+Go public API (go/tsfile)
+        |
+internal cgo bridge and ownership helpers
+        |
+stable, public cpp/src/cwrapper C ABI
+        |
+TsFile C++ core
+```
+
+Only bridge files import `C`. Public Go types do not expose C pointers or C
+types. Every value crossing the boundary is validated and either copied or
+owned by one explicitly documented handle.
+
+Suggested layout:
+
+```text
+go/
+  go.mod
+  tsfile/
+    constants.go
+    errors.go
+    schema.go
+    tablet.go
+    writer.go
+    reader.go
+    result_set.go
+    cgo_bridge.go
+  examples/
+    tree_read_write/
+    table_read_write/
+  testdata/
+  README.md
+```
+
+The cgo bridge remains in the public package because Go's `internal` import
+rules do not improve the C boundary by themselves. It is kept in narrowly
+scoped files with unexported functions, so all C allocation and release sites
+remain easy to audit.
+
+## Stable C ABI prerequisite
+
+The public C ABI already provides reader construction and close, table and
+tree queries, result-set iteration and typed accessors, schema structs, tablet
+allocation and typed insertion, and resource release functions.
+
+Several writer operations needed for Python parity are currently available
+only as underscore-prefixed functions under a section explicitly marked as a
+temporary Python API. The Go binding must not depend on those private symbols.
+Before implementing the corresponding Go methods, add public, non-underscore
+thin delegates for the existing behavior:
+
+- pathname-based writer construction;
+- target-named tablet construction;
+- table, timeseries, and device registration;
+- tree-tablet and table-tablet writes; and
+- writer flush.
+
+The wrappers are additive and mirror existing arguments and `ERRNO` return
+semantics. Existing public functions remain unchanged. Python may migrate to
+the public delegates, but its private symbols need not be removed as part of
+this change. Public writer close and property functions are reused when their
+existing lifetime semantics match the pathname writer; otherwise an additive
+delegate is supplied rather than changing an existing signature.
+
+No generic configuration ABI, error-string ABI, or Go-specific C ABI is
+introduced.
+
+## Public Go API
+
+Enums use distinct Go integer types whose constant values match
+`TSDataType`, `TSEncoding`, `CompressionType`, and `ColumnCategory`. Tests pin
+every value to the C header.
+
+Representative schema and writer API:
+
+```go
+type TimeseriesSchema struct {
+    Name        string
+    DataType    DataType
+    Encoding    Encoding
+    Compression Compression
+}
+
+type DeviceSchema struct {
+    Device     string
+    TimeSeries []TimeseriesSchema
+}
+
+type ColumnSchema struct {
+    Name     string
+    DataType DataType
+    Category ColumnCategory
+}
+
+type TableSchema struct {
+    Table   string
+    Columns []ColumnSchema
+}
+
+func NewWriter(path string, options ...WriterOption) (*Writer, error)
+func (w *Writer) RegisterTable(TableSchema) error
+func (w *Writer) RegisterTimeseries(device string, schema TimeseriesSchema) error
+func (w *Writer) RegisterDevice(DeviceSchema) error
+func (w *Writer) WriteTreeTablet(*Tablet) error
+func (w *Writer) WriteTableTablet(*Tablet) error
+func (w *Writer) AddProperty(key string, value []byte) error
+func (w *Writer) Flush() error
+func (w *Writer) Close() error
+```
+
+A tablet represents one target device for tree data or one target table for
+table data. Its column definitions are fixed at construction:
+
+```go
+type TabletColumn struct {
+    Name     string
+    DataType DataType
+}
+
+func NewTablet(target string, columns []TabletColumn, maxRows int) (*Tablet, error)
+func (t *Tablet) AddTimestamp(row int, timestamp int64) error
+func (t *Tablet) SetBool(row, column int, value bool) error
+func (t *Tablet) SetInt32(row, column int, value int32) error
+func (t *Tablet) SetInt64(row, column int, value int64) error
+func (t *Tablet) SetFloat32(row, column int, value float32) error
+func (t *Tablet) SetFloat64(row, column int, value float64) error
+func (t *Tablet) SetString(row, column int, value string) error
+func (t *Tablet) Rows() int
+func (t *Tablet) Close() error
+```
+
+All constructors and mutations return errors. The API does not use reflection
+or `any` in the write path. A successful write does not consume the tablet;
+the caller remains responsible for closing it.
+
+The reader exposes the query shapes already present in the C ABI, not SQL:
+
+```go
+type TableQuery struct {
+    Table      string
+    Columns    []string
+    Start, End int64
+}
+
+type TreeQuery struct {
+    Paths      []string
+    Start, End int64
+}
+
+type TreeRowsQuery struct {
+    Devices, Measurements []string
+    Offset, Limit         int
+}
+
+type TableRowsQuery struct {
+    Table         string
+    Columns       []string
+    Offset, Limit int
+    BatchSize     int
+}
+
+func NewReader(path string) (*Reader, error)
+func (r *Reader) QueryTable(TableQuery) (*ResultSet, error)
+func (r *Reader) QueryTree(TreeQuery) (*ResultSet, error)
+func (r *Reader) QueryTreeRows(TreeRowsQuery) (*ResultSet, error)
+func (r *Reader) QueryTableRows(TableRowsQuery) (*ResultSet, error)
+func (r *Reader) Close() error
+```
+
+The MVP passes a null tag-filter handle for table-row queries. A Go tag-filter
+DSL can be added separately after the core reader/writer API is stable.
+
+Result sets retain typed access and make end-of-stream distinct from failure:
+
+```go
+func (rs *ResultSet) Next() (bool, error)
+func (rs *ResultSet) Metadata() []ColumnMetadata
+func (rs *ResultSet) IsNull(column int) (bool, error)
+func (rs *ResultSet) Bool(column int) (bool, error)
+func (rs *ResultSet) Int32(column int) (int32, error)
+func (rs *ResultSet) Int64(column int) (int64, error)
+func (rs *ResultSet) Float32(column int) (float32, error)
+func (rs *ResultSet) Float64(column int) (float64, error)
+func (rs *ResultSet) String(column int) (string, error)
+func (rs *ResultSet) Close() error
+```
+
+`Next` returns `(false, nil)` at a clean end and `(false, err)` on failure.
+
+## Errors
+
+C calls report numeric values defined in `errno_define_c.h`. Go preserves the
+raw value:
+
+```go
+type Error struct {
+    Code int32
+    Op   string
+}
+```
+
+`Error.Error` maps known codes to stable messages and includes the operation.
+Unknown codes remain inspectable and render as `unknown error code N`.
+Exported sentinel errors cover common conditions such as invalid arguments,
+out-of-range access, type mismatch, missing devices/measurements/tables, and
+file I/O. `errors.Is` compares TsFile error codes.
+
+`ErrClosed` and `ErrNullValue` describe Go binding state rather than C error
+codes. No error-string allocation or free function is invented.
+
+## Ownership, lifetime, and concurrency
+
+Each `Reader`, `Writer`, `Tablet`, and `ResultSet` owns exactly one C handle.
+Its `Close` method is the only release site, clears the pointer, and is
+idempotent. Other methods return `ErrClosed` after release. Finalizers are not
+used as the primary ownership mechanism.
+
+Go strings and byte slices are copied into temporary C allocations and freed
+immediately after the call. C strings and metadata returned to Go are copied
+before their documented release function is called. Heap strings returned by
+result-set string accessors are copied and released with the matching C
+allocator (`free`). Go pointers are never retained by C.
+
+A reader owns its result sets because the C API states that closing a reader
+invalidates them. `Reader.Close` first closes registered result sets, then the
+reader. Explicit result-set close unregisters it. Lock ordering is always
+reader before result set.
+
+Handle methods are internally serialized with a small mutex. This prevents a
+method from racing with `Close` and makes concurrent calls memory-safe, but it
+does not promise parallel execution inside one handle. Independent handles may
+run concurrently.
+
+## Build and runtime linking
+
+The repository build is the MVP packaging path. From `go/tsfile`, cgo uses:
+
+```text
+-I${SRCDIR}/../../cpp/target/build/include
+-L${SRCDIR}/../../cpp/target/build/lib -ltsfile
+```
+
+The C++ library is built first with `TSFILE_BUILD_SHARED=ON`, which is already
+the default. Runtime instructions document `LD_LIBRARY_PATH` on Linux and
+`DYLD_LIBRARY_PATH` or a corrected install name on macOS. Static linking is
+deferred until all transitive native dependencies are proven. A future native
+package may expose `libtsfile.pc`; pkg-config is not required for the MVP.
+
+## Testing and acceptance criteria
+
+Unit tests cover validation, enum pinning, error mapping, typed tablet access,
+idempotent close, use-after-close, null values, and clean-end versus iteration
+failure.
+
+Integration tests cover all supported data types and:
+
+- tree and table write/read round trips;
+- multiple devices and columns;
+- empty and bounded time-range queries;
+- offset and limit behavior;
+- flush followed by close; and
+- reader/result-set parent-child lifetime behavior.
+
+Cross-language tests read Python or Java fixtures from Go and read Go-written
+files with an existing Python or C++ reader. C wrapper lifetime tests run under
+ASan on supported CI jobs, with valgrind as an optional Linux supplement.
+`go test -race` exercises concurrent method and close calls to verify internal
+serialization.
+
+Acceptance requires:
+
+- clean builds and tests on Linux amd64 and macOS arm64;
+- no references from Go to underscore-prefixed C symbols;
+- no C leaks or use-after-free in the exercised wrapper paths;
+- value-identical tree and table cross-language round trips;
+- clean `gofmt`, `go vet`, and `go test -race`; and
+- runnable tree and table examples plus reproducible build instructions.
+
+## Implementation sequence
+
+1. Promote and test the minimal stable C writer/tablet delegates.
+2. Add the Go module, enum/error mapping, and cgo bridge.
+3. Implement Reader and ResultSet with fixture-based tests.
+4. Implement schemas, Tablet, and Writer with round-trip tests.
+5. Add cross-language, ASan, race, examples, and documentation gates.

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+GOCACHE ?= /tmp/tsfile-go-build-cache
+
+.PHONY: test race vet fmt
+
+test:
+	GOCACHE=$(GOCACHE) go test ./...
+
+race:
+	GOCACHE=$(GOCACHE) go test -race ./...
+
+vet:
+	GOCACHE=$(GOCACHE) go vet ./...
+
+fmt:
+	gofmt -w tsfile/*.go examples/tree_read_write/main.go examples/table_read_write/main.go

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,61 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# TsFile Go API
+
+This module provides a cgo binding to the Apache TsFile C++ implementation.
+It supports Linux amd64 and macOS arm64 with cgo enabled. The native library
+must be built locally before running Go code; this module does not download or
+install native dependencies.
+
+Prerequisites are Go 1.22 or newer, a C/C++ toolchain, CMake, Maven, a JDK,
+and `CGO_ENABLED=1`.
+
+## Build the native library
+
+From the repository root:
+
+```bash
+./mvnw -P with-cpp -DskipTests package
+```
+
+The Go bridge expects headers under `cpp/target/build/include` and the shared
+library under `cpp/target/build/lib`.
+
+## Test
+
+```bash
+cd go
+make test
+make race
+make vet
+```
+
+The public package is `github.com/apache/tsfile/go/tsfile`. Result-set columns
+use idiomatic Go zero-based indexes; the underlying C ABI remains one-based.
+Readers own their active result sets, so closing a reader also closes every
+result set created from it. All native `Close` methods are idempotent.
+
+Runnable tree and table examples are under `examples/tree_read_write` and
+`examples/table_read_write`:
+
+```bash
+go run ./examples/tree_read_write
+go run ./examples/table_read_write
+```

--- a/go/examples/table_read_write/main.go
+++ b/go/examples/table_read_write/main.go
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/apache/tsfile/go/tsfile"
+)
+
+func main() {
+	path := "table-example.tsfile"
+	_ = os.Remove(path)
+	writer, err := tsfile.NewWriter(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer writer.Close()
+	if err := writer.RegisterTable(tsfile.TableSchema{Table: "metrics", Columns: []tsfile.ColumnSchema{
+		{Name: "device", DataType: tsfile.DataTypeString, Category: tsfile.ColumnCategoryTag},
+		{Name: "value", DataType: tsfile.DataTypeInt64, Category: tsfile.ColumnCategoryField},
+	}}); err != nil {
+		log.Fatal(err)
+	}
+	tablet, err := tsfile.NewTablet("metrics", []tsfile.TabletColumn{
+		{Name: "device", DataType: tsfile.DataTypeString},
+		{Name: "value", DataType: tsfile.DataTypeInt64},
+	}, 1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer tablet.Close()
+	if err := tablet.AddTimestamp(0, 1); err != nil {
+		log.Fatal(err)
+	}
+	if err := tablet.SetString(0, 0, "d1"); err != nil {
+		log.Fatal(err)
+	}
+	if err := tablet.SetInt64(0, 1, 42); err != nil {
+		log.Fatal(err)
+	}
+	if err := writer.WriteTableTablet(tablet); err != nil {
+		log.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		log.Fatal(err)
+	}
+	reader, err := tsfile.NewReader(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer reader.Close()
+	result, err := reader.QueryTable(tsfile.TableQuery{
+		Table: "metrics", Columns: []string{"device", "value"}, Start: 0, End: 10,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer result.Close()
+	for {
+		ok, err := result.Next()
+		if err != nil {
+			log.Fatal(err)
+		}
+		if !ok {
+			break
+		}
+		device, err := result.String(1)
+		if err != nil {
+			log.Fatal(err)
+		}
+		value, err := result.Int64(2)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("%s %d\n", device, value)
+	}
+}

--- a/go/examples/tree_read_write/main.go
+++ b/go/examples/tree_read_write/main.go
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/apache/tsfile/go/tsfile"
+)
+
+func main() {
+	path := "tree-example.tsfile"
+	_ = os.Remove(path)
+	writer, err := tsfile.NewWriter(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer writer.Close()
+	if err := writer.RegisterTimeseries("root.d1", tsfile.TimeseriesSchema{
+		Name: "temperature", DataType: tsfile.DataTypeDouble,
+		Encoding: tsfile.EncodingPlain, Compression: tsfile.CompressionUncompressed,
+	}); err != nil {
+		log.Fatal(err)
+	}
+	tablet, err := tsfile.NewTablet("root.d1", []tsfile.TabletColumn{
+		{Name: "temperature", DataType: tsfile.DataTypeDouble},
+	}, 2)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer tablet.Close()
+	for i, value := range []float64{20.5, 21.25} {
+		if err := tablet.AddTimestamp(i, int64(i)); err != nil {
+			log.Fatal(err)
+		}
+		if err := tablet.SetFloat64(i, 0, value); err != nil {
+			log.Fatal(err)
+		}
+	}
+	if err := writer.WriteTreeTablet(tablet); err != nil {
+		log.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		log.Fatal(err)
+	}
+	reader, err := tsfile.NewReader(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer reader.Close()
+	result, err := reader.QueryTree(tsfile.TreeQuery{
+		Paths: []string{"root.d1.temperature"}, Start: 0, End: 10,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer result.Close()
+	for {
+		ok, err := result.Next()
+		if err != nil {
+			log.Fatal(err)
+		}
+		if !ok {
+			break
+		}
+		timestamp, err := result.Int64(0)
+		if err != nil {
+			log.Fatal(err)
+		}
+		value, err := result.Float64(1)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("%d %.2f\n", timestamp, value)
+	}
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/apache/tsfile/go
+
+go 1.22

--- a/go/tsfile/api_test.go
+++ b/go/tsfile/api_test.go
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tsfile
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestTabletValidationAndClose(t *testing.T) {
+	if _, err := NewTablet("root.d1", nil, 1); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("empty columns: %v", err)
+	}
+	tablet, err := NewTablet("root.d1", []TabletColumn{
+		{Name: "text", DataType: DataTypeString},
+		{Name: "number", DataType: DataTypeInt64},
+	}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tablet.SetInt64(0, 0, 1); !errors.Is(err, ErrTypeMismatch) {
+		t.Fatalf("type mismatch: %v", err)
+	}
+	if err := tablet.SetString(0, 0, "a\x00b"); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("embedded NUL: %v", err)
+	}
+	if err := tablet.AddTimestamp(1, 1); !errors.Is(err, ErrOutOfRange) {
+		t.Fatalf("row out of range: %v", err)
+	}
+	if err := tablet.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tablet.Close(); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+	if err := tablet.AddTimestamp(0, 1); !errors.Is(err, ErrClosed) {
+		t.Fatalf("write after close: %v", err)
+	}
+}
+
+func TestWriterOptionValidation(t *testing.T) {
+	if _, err := NewWriter("unused.tsfile", WithMemoryThreshold(0)); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("zero memory threshold: %v", err)
+	}
+	if _, err := NewWriter("unused.tsfile", nil); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("nil option: %v", err)
+	}
+}

--- a/go/tsfile/cgo_bridge.go
+++ b/go/tsfile/cgo_bridge.go
@@ -1,0 +1,779 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// This file is the only place in the package that imports "C". All cgo
+// traffic goes through the unexported helpers and handle types defined here
+// so that C allocation and release sites stay easy to audit. Go pointers are
+// never retained by C: values crossing the boundary are copied into
+// temporary C allocations (C.CString / C.malloc) that are freed before the
+// helper returns, and C-allocated results are copied back into Go memory
+// before the matching free call.
+//
+// Handle constructors return plain Go values (unsafe.Pointer, int32) rather
+// than _Ctype aliases so that the narrow API surface of the bridge is usable
+// from the package's other files and _test files, which live in separate
+// cgo translation units and cannot reference C types directly.
+package tsfile
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/../../cpp/target/build/include
+#cgo LDFLAGS: -L${SRCDIR}/../../cpp/target/build/lib -ltsfile -Wl,-rpath,${SRCDIR}/../../cpp/target/build/lib
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cwrapper/errno_define_c.h"
+#include "cwrapper/tsfile_cwrapper.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"unsafe"
+)
+
+// errnoOK and errnoFileClose are plain-Go mirrors of the C RET_* constants
+// used by the test stubs: _test files live in a separate cgo translation
+// unit and cannot reference C types or C.RET_* constants directly, so the
+// bridge exposes just the numeric values they need.
+const (
+	errnoOK        = C.RET_OK
+	errnoFileClose = C.RET_FILE_CLOSE_ERR
+)
+
+// cerrno is the Go-side mirror of the C ERRNO type (int32_t). The bridge
+// converts between it and C.ERRNO at the boundary.
+type cerrno = int32
+
+// nativeHandle owns exactly one opaque C handle. release is the single
+// release site for that C memory: it frees the handle and returns a C ERRNO
+// for mapping through newError.
+type nativeHandle struct {
+	ptr     unsafe.Pointer
+	release func(unsafe.Pointer) cerrno
+}
+
+// close releases the C handle through release. It clears the stored pointer
+// only after release reports success (RET_OK): the C ABI does not delete the
+// writer on a failed close (the generic writer returns early without delete
+// when flush or close fails), so on a release error the wrapper keeps
+// ownership and a later retry can release it. On success the handle is
+// irrevocably gone, making a second close an idempotent no-op.
+func (h *nativeHandle) close() error {
+	if h.ptr == nil {
+		return nil
+	}
+	code := h.release(h.ptr)
+	if code == C.RET_OK {
+		h.ptr = nil
+		return nil
+	}
+	return newError("close", code)
+}
+
+// ---------------------------------------------------------------------------
+// String and byte marshaling (Go -> C copies; Go pointers never retained)
+// ---------------------------------------------------------------------------
+
+// cStringPtr returns a freshly allocated NUL-terminated C copy of value. The
+// caller owns the allocation and must release it with freeCString after use.
+// Every value maps to a non-NULL allocation; callers must not pass empty or
+// NUL-containing values without running validateCString first, because the
+// native constructors do not accept NULL and C.CString would truncate at an
+// embedded NUL.
+func cStringPtr(value string) *C.char {
+	return C.CString(value)
+}
+
+// validateCString rejects values that cannot cross the C string boundary
+// safely: an empty value maps to NULL in the C ABI (the native constructors
+// dereference the argument and would crash on NULL), and an embedded NUL
+// would be silently truncated by C.CString, handing C a different name than
+// Go asked for. It returns ErrInvalidArgument without touching C memory.
+func validateCString(op, field, value string) error {
+	if value == "" || strings.IndexByte(value, 0) >= 0 {
+		err := newError(op, C.RET_INVALID_ARG)
+		return fmt.Errorf("%w: %s %q must be a non-empty string without embedded NUL", err, field, value)
+	}
+	return nil
+}
+
+// validateCStrings applies validateCString to every element of values,
+// returning the index of the first invalid element so the caller can name it.
+func validateCStrings(op, field string, values []string) (int, error) {
+	for i, v := range values {
+		if v == "" || strings.IndexByte(v, 0) >= 0 {
+			err := newError(op, C.RET_INVALID_ARG)
+			return i, fmt.Errorf("%w: %s[%d] %q must be a non-empty string without embedded NUL", err, field, i, v)
+		}
+	}
+	return 0, nil
+}
+
+// freeCString releases one C.CString allocation; nil is a no-op.
+func freeCString(s *C.char) {
+	if s != nil {
+		C.free(unsafe.Pointer(s))
+	}
+}
+
+// cgoString copies the NUL-terminated C string at p into Go memory, or ""
+// for a nil pointer. It is the read-back side of cStringPtr.
+func cgoString(p unsafe.Pointer) string {
+	if p == nil {
+		return ""
+	}
+	return C.GoString((*C.char)(p))
+}
+
+// marshalCStrings copies values into a C-allocated array of C strings. The
+// returned Go slice is only a view over that C allocation. Keeping both the
+// pointer array and its elements in C memory is required by the cgo pointer
+// rules when the array is passed to a char** parameter.
+func marshalCStrings(values []string) ([]*C.char, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	mem := C.malloc(C.size_t(len(values)) * C.size_t(unsafe.Sizeof(uintptr(0))))
+	if mem == nil {
+		return nil, newError("marshal strings", C.RET_OOM)
+	}
+	out := unsafe.Slice((**C.char)(mem), len(values))
+	for i, v := range values {
+		cs := C.CString(v)
+		if cs == nil {
+			for _, p := range out[:i] {
+				C.free(unsafe.Pointer(p))
+			}
+			C.free(mem)
+			return nil, newError("marshal strings", C.RET_OOM)
+		}
+		out[i] = cs
+	}
+	return out, nil
+}
+
+// freeCStrings releases every element of a slice produced by
+// marshalCStrings.
+func freeCStrings(ptrs []*C.char) {
+	for _, p := range ptrs {
+		if p != nil {
+			C.free(unsafe.Pointer(p))
+		}
+	}
+	if len(ptrs) > 0 {
+		C.free(unsafe.Pointer(&ptrs[0]))
+	}
+}
+
+// cBytesLen is the Go-side mirror of the byte lengths the C ABI takes
+// (uint32_t length parameters). Values crossing the boundary are capped at
+// cBytesLenMax by validateCBytesLen, so a cBytesLen produced by the bridge
+// always fits the C ABI's effective length domain.
+type cBytesLen uint64
+
+// cBytesLenMax is the largest byte length the bridge accepts for a single C
+// byte buffer. The bound is INT32_MAX, not MaxUint32, because both ends of
+// the byte boundary agree on it: the native property API
+// (tsfile_generic_writer_add_tsfile_property) takes uint32_t lengths but
+// rejects any length above INT32_MAX with E_OUT_OF_RANGE, and the 32-bit
+// signed C.int used by C.GoBytes cannot express a larger count. Admitting
+// MaxUint32 would let values through that C.int(n) in cgoBytes silently
+// truncates (MaxUint32 wraps to -1; MaxInt32+5 wraps to 5), handing C or
+// Go a different length than requested.
+const cBytesLenMax = math.MaxInt32
+
+// validateCBytesLen is a pure integer-length validator for the C ABI's byte
+// length parameters: it reports whether a length of n bytes fits the
+// ABI's effective domain [0, cBytesLenMax]. It performs no allocation and
+// needs no backing buffer, so the boundary can be tested with bare integers
+// like cBytesLenMax+1.
+func validateCBytesLen(op string, n int) error {
+	if n < 0 || n > cBytesLenMax {
+		err := newError(op, C.RET_OVERFLOW)
+		return fmt.Errorf("%w: byte length %d exceeds max C length %d", err, n, int64(cBytesLenMax))
+	}
+	return nil
+}
+
+// copyCBytes copies b into a temporary C allocation (C.malloc + memcpy),
+// returning the C pointer and the length in bytes (an unsigned cBytesLen).
+// Go slice memory is never exposed to C and no Go pointer ever crosses the
+// boundary. Empty input returns (nil, 0) with no allocation, which the C ABI
+// accepts as an empty buffer. The returned pointer is valid only until the
+// caller passes it to freeCBytes.
+func copyCBytes(op string, b []byte) (unsafe.Pointer, cBytesLen, error) {
+	if len(b) == 0 {
+		return nil, 0, nil
+	}
+	if err := validateCBytesLen(op, len(b)); err != nil {
+		return nil, 0, err
+	}
+	p := C.malloc(C.size_t(len(b)))
+	if p == nil {
+		err := newError(op, C.RET_OOM)
+		return nil, 0, fmt.Errorf("%w: allocating %d bytes", err, len(b))
+	}
+	C.memcpy(p, unsafe.Pointer(&b[0]), C.size_t(len(b)))
+	return p, cBytesLen(len(b)), nil
+}
+
+// freeCBytes releases one copyCBytes allocation; nil is a no-op. It must be
+// called exactly once per non-nil pointer returned by copyCBytes so the C
+// allocation is freed immediately after the crossing C call returns.
+func freeCBytes(p unsafe.Pointer) {
+	if p != nil {
+		C.free(p)
+	}
+}
+
+// cgoBytes copies the n bytes at the C buffer p into a fresh Go slice,
+// returning nil for a nil pointer. It is the read-back side of copyCBytes
+// and must be called before freeCBytes. n must be non-negative (a negative
+// length is a caller bug and panics). n may be any value up to
+// math.MaxUint32: lengths above cBytesLenMax cannot be expressed in the
+// 32-bit signed C.int argument of C.GoBytes, so they are copied in
+// cBytesLenMax-sized chunks with 64-bit C.size_t memcpy counts.
+func cgoBytes(p unsafe.Pointer, n int) []byte {
+	if p == nil || n == 0 {
+		return nil
+	}
+	if n < 0 {
+		panic("tsfile: cgoBytes with negative length")
+	}
+	if n <= cBytesLenMax {
+		return C.GoBytes(p, C.int(n))
+	}
+	out := make([]byte, n)
+	for off := 0; off < n; {
+		m := nextCgoBytesChunk(off, n)
+		C.memcpy(unsafe.Pointer(&out[off]), unsafe.Add(p, uintptr(off)), C.size_t(m))
+		off += m
+	}
+	return out
+}
+
+// nextCgoBytesChunk is the pure allocation-free step function of the
+// cgoBytes chunked copy: it returns how many bytes to copy at offset off
+// when copying n bytes total, capped at cBytesLenMax per chunk so each count
+// fits the 32-bit signed C.int domain.
+func nextCgoBytesChunk(off, n int) int {
+	rest := n - off
+	if rest > cBytesLenMax {
+		return cBytesLenMax
+	}
+	return rest
+}
+
+// ---------------------------------------------------------------------------
+// Reader handle
+// ---------------------------------------------------------------------------
+
+// readerHandle is the native half of the public Reader type.
+type readerHandle struct{ nativeHandle }
+
+// resultSetHandle is the native half of ResultSet. It is valid only while
+// its owning reader remains open.
+type resultSetHandle struct{ nativeHandle }
+
+// releaseReader calls tsfile_reader_close, which deletes the native reader.
+// A nil pointer is reported as RET_OK, matching close-on-nil semantics.
+func releaseReader(ptr unsafe.Pointer) cerrno {
+	if ptr == nil {
+		return C.RET_OK
+	}
+	return cerrno(C.tsfile_reader_close(C.TsFileReader(ptr)))
+}
+
+// newReaderHandle opens the TsFile at path. The C ABI returns a NULL
+// handle with the error code (RET_FILE_OPEN_ERR for a missing path) on
+// failure.
+func newReaderHandle(path string) (*readerHandle, error) {
+	if err := validateCString("open reader", "path", path); err != nil {
+		return nil, err
+	}
+	cs := cStringPtr(path)
+	defer freeCString(cs)
+	var code C.ERRNO
+	h := C.tsfile_reader_new(cs, &code)
+	if h == nil {
+		return nil, newError("open reader", cerrno(code))
+	}
+	return &readerHandle{nativeHandle{ptr: unsafe.Pointer(h), release: releaseReader}}, nil
+}
+
+func releaseResultSet(ptr unsafe.Pointer) cerrno {
+	if ptr == nil {
+		return C.RET_OK
+	}
+	p := C.ResultSet(ptr)
+	C.free_tsfile_result_set(&p)
+	return C.RET_OK
+}
+
+// ---------------------------------------------------------------------------
+// Tablet handle
+// ---------------------------------------------------------------------------
+
+// tabletHandle is the native half of the public Tablet type.
+type tabletHandle struct{ nativeHandle }
+
+// releaseTablet calls free_tablet, which deletes the native tablet and nulls
+// the in-place C pointer.
+func releaseTablet(ptr unsafe.Pointer) cerrno {
+	if ptr == nil {
+		return C.RET_OK
+	}
+	var p C.Tablet = C.Tablet(ptr)
+	C.free_tablet(&p)
+	return C.RET_OK
+}
+
+// cTabletMaxRowsMax is the native row-capacity limit: storage::Tablet
+// asserts max_rows > 0 && max_rows < (1 << 30), so the bridge only admits
+// 1 <= maxRows < cTabletMaxRowsMax. Beyond the native assertion, larger
+// capacities would make the native row-buffer index math (int32 offsets of
+// length max_rows + 1) unsafe.
+const cTabletMaxRowsMax = 1 << 30
+
+// validateTabletMaxRows is a pure integer validator for the tablet row
+// capacity: it reports whether maxRows fits the native domain
+// [1, cTabletMaxRowsMax). It performs no allocation, so the boundary can be
+// tested with bare integers like cTabletMaxRowsMax.
+func validateTabletMaxRows(op string, maxRows int) error {
+	if maxRows < 1 {
+		return newError(op, C.RET_INVALID_ARG)
+	}
+	if maxRows >= cTabletMaxRowsMax {
+		err := newError(op, C.RET_OVERFLOW)
+		return fmt.Errorf("%w: maxRows %d exceeds native tablet limit %d", err, maxRows, cTabletMaxRowsMax)
+	}
+	return nil
+}
+
+// validateCInt32 is a pure integer validator for the C ABI's signed int
+// parameters (C int is 32-bit on every host this bridge targets): it reports
+// whether v survives the Go int -> C int conversion without truncation. It
+// performs no allocation, so the boundary can be tested with bare integers
+// like math.MaxInt32+1.
+func validateCInt32(op, field string, v int) error {
+	if v < math.MinInt32 || v > math.MaxInt32 {
+		err := newError(op, C.RET_OVERFLOW)
+		return fmt.Errorf("%w: %s %d exceeds C int range", err, field, int64(v))
+	}
+	return nil
+}
+
+// newTabletHandle creates a tablet whose rows target target (a device path or
+// a table name) with the given column schema and row capacity. maxRows must
+// be in [1, cTabletMaxRowsMax) per the native Tablet contract.
+func newTabletHandle(target string, columnNames []string, dataTypes []DataType, maxRows int) (*tabletHandle, error) {
+	if len(columnNames) == 0 || len(dataTypes) != len(columnNames) || maxRows < 1 {
+		return nil, newError("new tablet", C.RET_INVALID_ARG)
+	}
+	if err := validateTabletMaxRows("new tablet", maxRows); err != nil {
+		return nil, err
+	}
+	if err := validateCInt32("new tablet", "column count", len(columnNames)); err != nil {
+		return nil, err
+	}
+	if err := validateCString("new tablet", "target", target); err != nil {
+		return nil, err
+	}
+	if idx, err := validateCStrings("new tablet", "column", columnNames); err != nil {
+		return nil, fmt.Errorf("%w: column name %d is invalid", err, idx)
+	}
+	targetCs := cStringPtr(target)
+	defer freeCString(targetCs)
+	names, err := marshalCStrings(columnNames)
+	if err != nil {
+		return nil, err
+	}
+	defer freeCStrings(names)
+
+	types := make([]C.TSDataType, len(dataTypes))
+	for i, t := range dataTypes {
+		types[i] = C.TSDataType(t)
+	}
+	h := C.tablet_new_with_target_name(
+		targetCs,
+		&names[0],
+		&types[0],
+		C.int(len(dataTypes)),
+		C.int(maxRows),
+	)
+	if h == nil {
+		return nil, newError("new tablet", C.RET_OOM)
+	}
+	return &tabletHandle{nativeHandle{ptr: unsafe.Pointer(h), release: releaseTablet}}, nil
+}
+
+// rowCount returns the number of rows currently added to the tablet.
+func (h *tabletHandle) rowCount() int {
+	if h.ptr == nil {
+		return 0
+	}
+	return int(C.tablet_get_cur_row_size(C.Tablet(h.ptr)))
+}
+
+func (h *tabletHandle) addTimestamp(row int, timestamp int64) error {
+	return newError("add tablet timestamp", cerrno(C.tablet_add_timestamp(
+		C.Tablet(h.ptr), C.uint32_t(row), C.Timestamp(timestamp))))
+}
+
+func (h *tabletHandle) addBool(row, column int, value bool) error {
+	return newError("set tablet bool", cerrno(C.tablet_add_value_by_index_bool(
+		C.Tablet(h.ptr), C.uint32_t(row), C.uint32_t(column), C.bool(value))))
+}
+
+func (h *tabletHandle) addInt32(row, column int, value int32) error {
+	return newError("set tablet int32", cerrno(C.tablet_add_value_by_index_int32_t(
+		C.Tablet(h.ptr), C.uint32_t(row), C.uint32_t(column), C.int32_t(value))))
+}
+
+func (h *tabletHandle) addInt64(row, column int, value int64) error {
+	return newError("set tablet int64", cerrno(C.tablet_add_value_by_index_int64_t(
+		C.Tablet(h.ptr), C.uint32_t(row), C.uint32_t(column), C.int64_t(value))))
+}
+
+func (h *tabletHandle) addFloat32(row, column int, value float32) error {
+	return newError("set tablet float32", cerrno(C.tablet_add_value_by_index_float(
+		C.Tablet(h.ptr), C.uint32_t(row), C.uint32_t(column), C.float(value))))
+}
+
+func (h *tabletHandle) addFloat64(row, column int, value float64) error {
+	return newError("set tablet float64", cerrno(C.tablet_add_value_by_index_double(
+		C.Tablet(h.ptr), C.uint32_t(row), C.uint32_t(column), C.double(value))))
+}
+
+func (h *tabletHandle) addString(row, column int, value string) error {
+	if err := validateCBytesLen("set tablet string", len(value)); err != nil {
+		return err
+	}
+	cs := C.CString(value)
+	if cs == nil {
+		return newError("set tablet string", C.RET_OOM)
+	}
+	defer freeCString(cs)
+	return newError("set tablet string", cerrno(C.tablet_add_value_by_index_string_with_len(
+		C.Tablet(h.ptr), C.uint32_t(row), C.uint32_t(column), cs, C.int(len(value)))))
+}
+
+// ---------------------------------------------------------------------------
+// Writer handle
+// ---------------------------------------------------------------------------
+
+// writerHandle is the native half of the public Writer type. It uses the
+// public generic writer API; tsfile_generic_writer_close flushes, closes, and
+// deletes the native writer.
+type writerHandle struct{ nativeHandle }
+
+// releaseWriter closes and deletes the native writer; nil is RET_OK.
+func releaseWriter(ptr unsafe.Pointer) cerrno {
+	if ptr == nil {
+		return C.RET_OK
+	}
+	return cerrno(C.tsfile_generic_writer_close(C.TsFileGenericWriter(ptr)))
+}
+
+// newWriterHandle opens (or creates) the TsFile at path for writing.
+// memoryThresholdBytes bounds the in-memory write buffer.
+func newWriterHandle(path string, memoryThresholdBytes uint64) (*writerHandle, error) {
+	if err := validateCString("open writer", "path", path); err != nil {
+		return nil, err
+	}
+	cs := cStringPtr(path)
+	defer freeCString(cs)
+	var code C.ERRNO
+	h := C.tsfile_generic_writer_new(cs, C.uint64_t(memoryThresholdBytes), &code)
+	if h == nil {
+		return nil, newError("open writer", cerrno(code))
+	}
+	return &writerHandle{nativeHandle{ptr: unsafe.Pointer(h), release: releaseWriter}}, nil
+}
+
+func allocTimeseriesSchema(schema TimeseriesSchema) (*C.TimeseriesSchema, func(), error) {
+	name := cStringPtr(schema.Name)
+	if name == nil {
+		return nil, func() {}, newError("marshal timeseries schema", C.RET_OOM)
+	}
+	p := (*C.TimeseriesSchema)(C.malloc(C.size_t(C.sizeof_TimeseriesSchema)))
+	if p == nil {
+		freeCString(name)
+		return nil, func() {}, newError("marshal timeseries schema", C.RET_OOM)
+	}
+	p.timeseries_name = name
+	p.data_type = C.TSDataType(schema.DataType)
+	p.encoding = C.TSEncoding(schema.Encoding)
+	p.compression = C.CompressionType(schema.Compression)
+	return p, func() {
+		freeCString(name)
+		C.free(unsafe.Pointer(p))
+	}, nil
+}
+
+func (h *writerHandle) registerTimeseries(device string, schema TimeseriesSchema) error {
+	deviceName := cStringPtr(device)
+	defer freeCString(deviceName)
+	native, freeSchema, err := allocTimeseriesSchema(schema)
+	if err != nil {
+		return err
+	}
+	defer freeSchema()
+	return newError("register timeseries", cerrno(C.tsfile_generic_writer_register_timeseries(
+		C.TsFileGenericWriter(h.ptr), deviceName, native)))
+}
+
+func (h *writerHandle) registerDevice(schema DeviceSchema) error {
+	deviceName := cStringPtr(schema.Device)
+	defer freeCString(deviceName)
+	names, err := marshalCStrings(timeseriesNames(schema.TimeSeries))
+	if err != nil {
+		return err
+	}
+	defer freeCStrings(names)
+
+	var series *C.TimeseriesSchema
+	if len(schema.TimeSeries) > 0 {
+		mem := C.malloc(C.size_t(len(schema.TimeSeries)) * C.size_t(C.sizeof_TimeseriesSchema))
+		if mem == nil {
+			return newError("marshal device schema", C.RET_OOM)
+		}
+		defer C.free(mem)
+		items := unsafe.Slice((*C.TimeseriesSchema)(mem), len(schema.TimeSeries))
+		for i, item := range schema.TimeSeries {
+			items[i].timeseries_name = names[i]
+			items[i].data_type = C.TSDataType(item.DataType)
+			items[i].encoding = C.TSEncoding(item.Encoding)
+			items[i].compression = C.CompressionType(item.Compression)
+		}
+		series = (*C.TimeseriesSchema)(mem)
+	}
+	native := (*C.DeviceSchema)(C.malloc(C.size_t(C.sizeof_DeviceSchema)))
+	if native == nil {
+		return newError("marshal device schema", C.RET_OOM)
+	}
+	defer C.free(unsafe.Pointer(native))
+	native.device_name = deviceName
+	native.timeseries_schema = series
+	native.timeseries_num = C.int(len(schema.TimeSeries))
+	return newError("register device", cerrno(C.tsfile_generic_writer_register_device(
+		C.TsFileGenericWriter(h.ptr), native)))
+}
+
+func (h *writerHandle) registerTable(schema TableSchema) error {
+	tableName := cStringPtr(schema.Table)
+	defer freeCString(tableName)
+	names, err := marshalCStrings(columnNames(schema.Columns))
+	if err != nil {
+		return err
+	}
+	defer freeCStrings(names)
+
+	mem := C.malloc(C.size_t(len(schema.Columns)) * C.size_t(C.sizeof_ColumnSchema))
+	if mem == nil {
+		return newError("marshal table schema", C.RET_OOM)
+	}
+	defer C.free(mem)
+	columns := unsafe.Slice((*C.ColumnSchema)(mem), len(schema.Columns))
+	for i, item := range schema.Columns {
+		columns[i].column_name = names[i]
+		columns[i].data_type = C.TSDataType(item.DataType)
+		columns[i].column_category = C.ColumnCategory(item.Category)
+	}
+	native := (*C.TableSchema)(C.malloc(C.size_t(C.sizeof_TableSchema)))
+	if native == nil {
+		return newError("marshal table schema", C.RET_OOM)
+	}
+	defer C.free(unsafe.Pointer(native))
+	native.table_name = tableName
+	native.column_schemas = (*C.ColumnSchema)(mem)
+	native.column_num = C.int(len(schema.Columns))
+	return newError("register table", cerrno(C.tsfile_generic_writer_register_table(
+		C.TsFileGenericWriter(h.ptr), native)))
+}
+
+func (h *writerHandle) writeTreeTablet(tablet *tabletHandle) error {
+	return newError("write tree tablet", cerrno(C.tsfile_generic_writer_write_tree_tablet(
+		C.TsFileGenericWriter(h.ptr), C.Tablet(tablet.ptr))))
+}
+
+func (h *writerHandle) writeTableTablet(tablet *tabletHandle) error {
+	return newError("write table tablet", cerrno(C.tsfile_generic_writer_write_table_tablet(
+		C.TsFileGenericWriter(h.ptr), C.Tablet(tablet.ptr))))
+}
+
+func (h *writerHandle) flush() error {
+	return newError("flush writer", cerrno(C.tsfile_generic_writer_flush(C.TsFileGenericWriter(h.ptr))))
+}
+
+func (h *writerHandle) addProperty(key string, value []byte) error {
+	keyPtr, keyLen, err := copyCBytes("add property", []byte(key))
+	if err != nil {
+		return err
+	}
+	defer freeCBytes(keyPtr)
+	valuePtr, valueLen, err := copyCBytes("add property", value)
+	if err != nil {
+		return err
+	}
+	defer freeCBytes(valuePtr)
+	return newError("add property", cerrno(C.tsfile_generic_writer_add_tsfile_property(
+		C.TsFileGenericWriter(h.ptr), (*C.char)(keyPtr), C.uint32_t(keyLen),
+		(*C.uint8_t)(valuePtr), C.uint32_t(valueLen))))
+}
+
+func newResultSetHandle(ptr C.ResultSet, code C.ERRNO, op string) (*resultSetHandle, error) {
+	if code != C.RET_OK {
+		if ptr != nil {
+			p := ptr
+			C.free_tsfile_result_set(&p)
+		}
+		return nil, newError(op, cerrno(code))
+	}
+	if ptr == nil {
+		return nil, fmt.Errorf("%s: native query returned a nil result", op)
+	}
+	return &resultSetHandle{nativeHandle{ptr: unsafe.Pointer(ptr), release: releaseResultSet}}, nil
+}
+
+func (h *readerHandle) queryTable(query TableQuery) (*resultSetHandle, error) {
+	table := cStringPtr(query.Table)
+	defer freeCString(table)
+	columns, err := marshalCStrings(query.Columns)
+	if err != nil {
+		return nil, err
+	}
+	defer freeCStrings(columns)
+	var code C.ERRNO
+	result := C.tsfile_query_table(C.TsFileReader(h.ptr), table, &columns[0],
+		C.uint32_t(len(columns)), C.Timestamp(query.Start), C.Timestamp(query.End), &code)
+	return newResultSetHandle(result, code, "query table")
+}
+
+func (h *readerHandle) queryTree(query TreeQuery) (*resultSetHandle, error) {
+	paths, err := marshalCStrings(query.Paths)
+	if err != nil {
+		return nil, err
+	}
+	defer freeCStrings(paths)
+	var code C.ERRNO
+	result := C.tsfile_reader_query_tree(C.TsFileReader(h.ptr), &paths[0],
+		C.uint32_t(len(paths)), C.Timestamp(query.Start), C.Timestamp(query.End), &code)
+	return newResultSetHandle(result, code, "query tree")
+}
+
+func (h *readerHandle) queryTreeRows(query TreeRowsQuery) (*resultSetHandle, error) {
+	devices, err := marshalCStrings(query.Devices)
+	if err != nil {
+		return nil, err
+	}
+	defer freeCStrings(devices)
+	measurements, err := marshalCStrings(query.Measurements)
+	if err != nil {
+		return nil, err
+	}
+	defer freeCStrings(measurements)
+	var code C.ERRNO
+	result := C.tsfile_reader_query_tree_by_row(C.TsFileReader(h.ptr), &devices[0], C.int(len(devices)),
+		&measurements[0], C.int(len(measurements)), C.int(query.Offset), C.int(query.Limit), &code)
+	return newResultSetHandle(result, code, "query tree rows")
+}
+
+func (h *readerHandle) queryTableRows(query TableRowsQuery) (*resultSetHandle, error) {
+	table := cStringPtr(query.Table)
+	defer freeCString(table)
+	columns, err := marshalCStrings(query.Columns)
+	if err != nil {
+		return nil, err
+	}
+	defer freeCStrings(columns)
+	var code C.ERRNO
+	result := C.tsfile_reader_query_table_by_row(C.TsFileReader(h.ptr), table, &columns[0],
+		C.int(len(columns)), C.int(query.Offset), C.int(query.Limit), nil, C.int(query.BatchSize), &code)
+	return newResultSetHandle(result, code, "query table rows")
+}
+
+func (h *resultSetHandle) next() (bool, error) {
+	var code C.ERRNO
+	ok := bool(C.tsfile_result_set_next(C.ResultSet(h.ptr), &code))
+	return ok, newError("advance result set", cerrno(code))
+}
+
+func (h *resultSetHandle) metadata() []ColumnMetadata {
+	meta := C.tsfile_result_set_get_metadata(C.ResultSet(h.ptr))
+	defer C.free_result_set_meta_data(meta)
+	count := int(C.tsfile_result_set_metadata_get_column_num(meta))
+	columns := make([]ColumnMetadata, count)
+	for i := range columns {
+		// The C metadata ABI is 1-based; the public Go API is 0-based.
+		index := C.uint32_t(i + 1)
+		columns[i] = ColumnMetadata{
+			Name:     C.GoString(C.tsfile_result_set_metadata_get_column_name(meta, index)),
+			DataType: DataType(C.tsfile_result_set_metadata_get_data_type(meta, index)),
+		}
+	}
+	return columns
+}
+
+func (h *resultSetHandle) isNull(column int) bool {
+	return bool(C.tsfile_result_set_is_null_by_index(C.ResultSet(h.ptr), C.uint32_t(column+1)))
+}
+
+func (h *resultSetHandle) bool(column int) bool {
+	return bool(C.tsfile_result_set_get_value_by_index_bool(C.ResultSet(h.ptr), C.uint32_t(column+1)))
+}
+
+func (h *resultSetHandle) int32(column int) int32 {
+	return int32(C.tsfile_result_set_get_value_by_index_int32_t(C.ResultSet(h.ptr), C.uint32_t(column+1)))
+}
+
+func (h *resultSetHandle) int64(column int) int64 {
+	return int64(C.tsfile_result_set_get_value_by_index_int64_t(C.ResultSet(h.ptr), C.uint32_t(column+1)))
+}
+
+func (h *resultSetHandle) float32(column int) float32 {
+	return float32(C.tsfile_result_set_get_value_by_index_float(C.ResultSet(h.ptr), C.uint32_t(column+1)))
+}
+
+func (h *resultSetHandle) float64(column int) float64 {
+	return float64(C.tsfile_result_set_get_value_by_index_double(C.ResultSet(h.ptr), C.uint32_t(column+1)))
+}
+
+func (h *resultSetHandle) string(column int) string {
+	p := C.tsfile_result_set_get_value_by_index_string(C.ResultSet(h.ptr), C.uint32_t(column+1))
+	if p == nil {
+		return ""
+	}
+	defer C.free(unsafe.Pointer(p))
+	return C.GoString(p)
+}
+
+// unsafe_NewPointer returns a small, non-nil Go-managed pointer suitable for
+// tests that need to verify nativeHandle bookkeeping (close keeps the stored
+// pointer on failure and clears it on success) without creating a real C
+// handle. The returned pointer is never passed to any release function;
+// callers must only observe and compare it.
+func unsafe_NewPointer() unsafe.Pointer {
+	return unsafe.Pointer(&cgoTestPointer)
+}
+
+// cgoTestPointer is a package-level byte so unsafe_NewPointer has stable
+// non-nil backing memory. It is never freed and never handed to C.
+var cgoTestPointer byte

--- a/go/tsfile/cgo_bridge_test.go
+++ b/go/tsfile/cgo_bridge_test.go
@@ -1,0 +1,451 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tsfile
+
+import (
+	"errors"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+	"unsafe"
+)
+
+// TestBridgeMapsMissingFileError exercises one real C call through the cgo
+// boundary. tsfile_reader_new on a path that cannot possibly exist must
+// return a NULL handle and RET_FILE_OPEN_ERR; the bridge must map that into a
+// *Error carrying the same numeric code, with no retained native handle.
+func TestBridgeMapsMissingFileError(t *testing.T) {
+	missing := filepath.Join(os.TempDir(), "tsfile-go-bridge", "definitely-missing.tsfile")
+	if _, err := os.Stat(missing); err == nil {
+		t.Fatalf("test path unexpectedly exists: %s", missing)
+	}
+
+	h, err := newReaderHandle(missing)
+	if h != nil {
+		// Never expected, but release any created handle to keep C
+		// allocations auditable.
+		_ = h.close()
+		t.Fatalf("expected NULL reader handle, got %v", h.ptr)
+	}
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !errors.Is(err, ErrFileOpen) {
+		t.Fatalf("expected error to match ErrFileOpen, got %v", err)
+	}
+}
+
+// TestBridgeTabletHandleReleases proves a created C handle is released:
+// close must be idempotent (the second close is a no-op, not a
+// use-after-free) and must clear the stored pointer.
+func TestBridgeTabletHandleReleases(t *testing.T) {
+	h, err := newTabletHandle("bridge-dev", []string{"s1"}, []DataType{DataTypeInt64}, 8)
+	if err != nil {
+		t.Fatalf("newTabletHandle: %v", err)
+	}
+	if h.ptr == nil {
+		t.Fatal("expected non-nil native pointer")
+	}
+	if err := h.close(); err != nil {
+		t.Fatalf("first close: %v", err)
+	}
+	if h.ptr != nil {
+		t.Fatal("handle pointer not cleared after close")
+	}
+	if err := h.close(); err != nil {
+		t.Fatalf("second close must be a no-op, got %v", err)
+	}
+}
+
+// TestBridgeWriterHandleLifecycle creates a real writer handle through the
+// public generic writer ABI, verifies the non-NULL pointer, and releases it;
+// the C ABI deletes the writer inside tsfile_generic_writer_close.
+func TestBridgeWriterHandleLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bridge.tsfile")
+	h, err := newWriterHandle(path, 1<<20)
+	if err != nil {
+		t.Fatalf("newWriterHandle: %v", err)
+	}
+	if h.ptr == nil {
+		t.Fatal("expected non-nil native pointer")
+	}
+	if err := h.close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if h.ptr != nil {
+		t.Fatal("handle pointer not cleared after close")
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat written file: %v", err)
+	}
+	if fi.Size() == 0 {
+		t.Fatal("expected a non-empty TsFile after writer close")
+	}
+}
+
+// TestBridgeTabletRowCount checks the tablet handle exposes its row count
+// through the C API before release.
+func TestBridgeTabletRowCount(t *testing.T) {
+	h, err := newTabletHandle("bridge-dev", []string{"s1"}, []DataType{DataTypeInt64}, 4)
+	if err != nil {
+		t.Fatalf("newTabletHandle: %v", err)
+	}
+	defer func() {
+		if err := h.close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+	}()
+	if got := h.rowCount(); got != 0 {
+		t.Fatalf("expected 0 rows, got %d", got)
+	}
+}
+
+// TestBridgeMarshalStrings verifies the C string array helper round-trips
+// values and releases every allocation.
+func TestBridgeMarshalStrings(t *testing.T) {
+	values := []string{"a", "b c", "d"}
+	names, err := marshalCStrings(values)
+	if err != nil {
+		t.Fatalf("marshalCStrings: %v", err)
+	}
+	defer freeCStrings(names)
+	for i, want := range values {
+		got := cgoString(unsafe.Pointer(names[i]))
+		if got != want {
+			t.Fatalf("round-trip[%d] = %q, want %q", i, got, want)
+		}
+	}
+
+	// Empty input must allocate nothing.
+	names, err = marshalCStrings(nil)
+	if err != nil || len(names) != 0 {
+		t.Fatalf("empty marshal = (%v, %v), want (empty, nil)", len(names), err)
+	}
+}
+
+// TestBridgeCStringCopy pins that every non-empty value maps to a non-NULL C
+// copy that round-trips, and that freeCString releases the allocation.
+func TestBridgeCStringCopy(t *testing.T) {
+	for _, want := range []string{"x", "device.1", "a b c"} {
+		p := cStringPtr(want)
+		if p == nil {
+			t.Fatalf("cStringPtr(%q) returned nil", want)
+		}
+		if got := cgoString(unsafe.Pointer(p)); got != want {
+			t.Fatalf("round-trip = %q, want %q", got, want)
+		}
+		freeCString(p)
+	}
+}
+
+// TestBridgeValidateCString pins the pre-C validation: empty and
+// NUL-embedded strings must be rejected with ErrInvalidArgument without any
+// C allocation or call.
+func TestBridgeValidateCString(t *testing.T) {
+	for _, value := range []string{"", "dev\x00ice", "\x00", "a\x00b\x00"} {
+		err := validateCString("op", "field", value)
+		if err == nil {
+			t.Fatalf("validateCString(%q) = nil, want error", value)
+		}
+		if !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("validateCString(%q) = %v, want ErrInvalidArgument", value, err)
+		}
+	}
+	for _, value := range []string{"dev", "device.1", "s-1"} {
+		if err := validateCString("op", "field", value); err != nil {
+			t.Fatalf("validateCString(%q) = %v, want nil", value, err)
+		}
+	}
+}
+
+// TestBridgeReaderRejectsInvalidPath proves the reader constructor validates
+// the path before crossing C: both empty and embedded-NUL paths must fail
+// with ErrInvalidArgument (a NULL path would crash the native reader).
+func TestBridgeReaderRejectsInvalidPath(t *testing.T) {
+	for _, path := range []string{"", "dev\x00.tsfile"} {
+		if _, err := newReaderHandle(path); !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("newReaderHandle(%q) = %v, want ErrInvalidArgument", path, err)
+		}
+	}
+}
+
+// TestBridgeWriterRejectsInvalidPath pins the same validation for the writer
+// constructor.
+func TestBridgeWriterRejectsInvalidPath(t *testing.T) {
+	for _, path := range []string{"", "out\x00.tsfile"} {
+		if _, err := newWriterHandle(path, 1<<20); !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("newWriterHandle(%q) = %v, want ErrInvalidArgument", path, err)
+		}
+	}
+}
+
+// TestBridgeTabletRejectsInvalidNames pins empty/NUL validation for the
+// tablet target and column names: every case must fail with
+// ErrInvalidArgument before any C call, so no native tablet is created.
+func TestBridgeTabletRejectsInvalidNames(t *testing.T) {
+	cases := []struct {
+		name    string
+		target  string
+		columns []string
+	}{
+		{"embedded NUL target", "dev\x00", []string{"s1"}},
+		{"embedded NUL column", "dev", []string{"s1", "s\x002"}},
+		{"empty target", "", []string{"s1"}},
+		{"empty column", "dev", []string{"s1", ""}},
+	}
+	for _, tc := range cases {
+		types := make([]DataType, len(tc.columns))
+		for i := range types {
+			types[i] = DataTypeInt64
+		}
+		h, err := newTabletHandle(tc.target, tc.columns, types, 4)
+		if h != nil {
+			t.Fatalf("%s: expected no handle", tc.name)
+		}
+		if err == nil {
+			t.Fatalf("%s: expected error", tc.name)
+		}
+		if !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("%s: got %v, want ErrInvalidArgument", tc.name, err)
+		}
+	}
+}
+
+// TestBridgeCopyCBytes pins the C-copy semantics: the returned pointer is a
+// C allocation (distinct from the Go slice, so cgocheck2 cannot observe a Go
+// pointer), the contents round-trip through C including embedded NUL bytes,
+// the length is the full byte length, and freeCBytes releases it. Empty and
+// nil inputs map to (nil, 0) with no allocation.
+func TestBridgeCopyCBytes(t *testing.T) {
+	if p, n, err := copyCBytes("copy", nil); p != nil || n != 0 || err != nil {
+		t.Fatalf("copyCBytes(nil) = (%v, %d, %v), want (nil, 0, nil)", p, n, err)
+	}
+	if p, n, err := copyCBytes("copy", []byte{}); p != nil || n != 0 || err != nil {
+		t.Fatalf("copyCBytes(empty) = (%v, %d, %v), want (nil, 0, nil)", p, n, err)
+	}
+	b := []byte{0xde, 0xad, 0x00, 0xbe, 0xef, 0x00, 0x42}
+	p, n, err := copyCBytes("copy", b)
+	if err != nil {
+		t.Fatalf("copyCBytes: %v", err)
+	}
+	defer freeCBytes(p)
+	if n != 7 {
+		t.Fatalf("length = %d, want 7", n)
+	}
+	// Read the C buffer back into Go and compare; this proves the embedded
+	// zero bytes survived the C round trip and that the copy is a true copy
+	// (mutating the Go slice after the copy must not change the C buffer).
+	got := cgoBytes(p, int(n))
+	if string(got) != string(b) {
+		t.Fatalf("round-trip = % x, want % x", got, b)
+	}
+	b[0] = 0xff
+	got2 := cgoBytes(p, int(n))
+	if got2[0] != 0xde {
+		t.Fatalf("C buffer changed after Go slice mutation: % x", got2)
+	}
+}
+
+// TestBridgeCloseIsSafeOnNil ensures closing a zero-valued handle is a no-op,
+// mirroring the idempotent Close contract of the public API.
+func TestBridgeCloseIsSafeOnNil(t *testing.T) {
+	var h readerHandle
+	if err := h.close(); err != nil {
+		t.Fatalf("close on nil handle: %v", err)
+	}
+}
+
+// TestBridgeCloseKeepsOwnershipOnFailure proves the ownership contract of
+// nativeHandle.close: when release fails (a non-RET_OK code) the stored
+// pointer must be preserved so a later retry can release the C handle, and a
+// retry that succeeds must clear it and be idempotent afterwards.
+//
+// The failing release is a pure Go stub (no C memory is involved), so the
+// test cannot leak or double-free a native handle.
+func TestBridgeCloseKeepsOwnershipOnFailure(t *testing.T) {
+	dummy := unsafe_NewPointer()
+
+	var calls int
+	var h nativeHandle
+	h.ptr = dummy
+	h.release = func(ptr unsafe.Pointer) cerrno {
+		calls++
+		if calls == 1 {
+			return errnoFileClose // pinned to RET_FILE_CLOSE_ERR in errno_define_c.h
+		}
+		return errnoOK
+	}
+
+	if err := h.close(); err == nil {
+		t.Fatal("first close: expected error from failing release")
+	} else if !errors.Is(err, ErrFileClose) {
+		t.Fatalf("first close: got %v, want ErrFileClose", err)
+	}
+	if h.ptr == nil {
+		t.Fatal("handle pointer cleared after failed close; ownership lost")
+	}
+	if h.ptr != dummy {
+		t.Fatal("handle pointer changed after failed close")
+	}
+
+	if err := h.close(); err != nil {
+		t.Fatalf("retry close after failure: %v", err)
+	}
+	if h.ptr != nil {
+		t.Fatal("handle pointer not cleared after successful retry")
+	}
+	if err := h.close(); err != nil {
+		t.Fatalf("close after successful retry must be a no-op, got %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("release called %d times, want 2", calls)
+	}
+}
+
+// TestBridgeValidateCBytesLen pins the pure integer-length validator that
+// protects every copyCBytes call. The effective C ABI length domain is
+// [0, MaxInt32]: the native property API rejects uint32 lengths above
+// INT32_MAX, and C.GoBytes takes a 32-bit signed count. All boundary cases
+// use bare integers with no backing slice, so the boundaries are tested
+// without allocating large memory.
+func TestBridgeValidateCBytesLen(t *testing.T) {
+	for _, n := range []int{0, 1, 16, 1 << 20, math.MaxInt32} {
+		if err := validateCBytesLen("op", n); err != nil {
+			t.Fatalf("validateCBytesLen(%d) = %v, want nil", n, err)
+		}
+	}
+	for _, tc := range []struct {
+		name string
+		n    int
+	}{
+		{"maxInt32+1", math.MaxInt32 + 1},
+		{"maxUint32", int(math.MaxUint32)},
+		{"maxUint32+1", int(math.MaxUint32) + 1},
+		{"negative", -1},
+	} {
+		if err := validateCBytesLen("op", tc.n); !errors.Is(err, ErrOverflow) {
+			t.Fatalf("validateCBytesLen(%s) = %v, want ErrOverflow", tc.name, err)
+		}
+	}
+}
+
+// TestBridgeValidateTabletMaxRows pins the pure tablet row-capacity
+// validator against the native domain [1, 1<<30). Every case is a bare
+// integer: no tablet and no C allocation is involved, so the boundary at
+// 1<<30 is tested without reserving row buffers.
+func TestBridgeValidateTabletMaxRows(t *testing.T) {
+	for _, n := range []int{1, 8, 1024, cTabletMaxRowsMax - 1} {
+		if err := validateTabletMaxRows("op", n); err != nil {
+			t.Fatalf("validateTabletMaxRows(%d) = %v, want nil", n, err)
+		}
+	}
+	for _, n := range []int{0, -1, math.MinInt32, math.MinInt64} {
+		if err := validateTabletMaxRows("op", n); !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("validateTabletMaxRows(%d) = %v, want ErrInvalidArgument", n, err)
+		}
+	}
+	for _, n := range []int{cTabletMaxRowsMax, cTabletMaxRowsMax + 1, math.MaxInt32, math.MaxInt64} {
+		if err := validateTabletMaxRows("op", n); !errors.Is(err, ErrOverflow) {
+			t.Fatalf("validateTabletMaxRows(%d) = %v, want ErrOverflow", n, err)
+		}
+	}
+}
+
+// TestBridgeValidateCInt32 pins the pure signed C int validator: values that
+// would truncate in the Go int -> C int conversion must be rejected before
+// the boundary. All cases are bare integers, no allocation.
+func TestBridgeValidateCInt32(t *testing.T) {
+	for _, n := range []int{0, 1, 4096, math.MaxInt32, math.MinInt32} {
+		if err := validateCInt32("op", "field", n); err != nil {
+			t.Fatalf("validateCInt32(%d) = %v, want nil", n, err)
+		}
+	}
+	for _, n := range []int{math.MaxInt32 + 1, math.MaxInt64, math.MinInt32 - 1, math.MinInt64} {
+		if err := validateCInt32("op", "field", n); !errors.Is(err, ErrOverflow) {
+			t.Fatalf("validateCInt32(%d) = %v, want ErrOverflow", n, err)
+		}
+	}
+}
+
+// TestBridgeTabletRejectsOversizedMaxRows proves newTabletHandle rejects
+// row capacities outside the native domain before any C call: the truncated
+// C.int path (values >= 1<<32 wrap to small or negative ints on a 64-bit
+// host) must be unreachable. No handle is returned and no native tablet is
+// created, so no row buffers are allocated.
+func TestBridgeTabletRejectsOversizedMaxRows(t *testing.T) {
+	for _, maxRows := range []int{cTabletMaxRowsMax, 1 << 31, 1 << 32, math.MaxInt32, math.MaxInt64} {
+		h, err := newTabletHandle("dev", []string{"s1"}, []DataType{DataTypeInt64}, maxRows)
+		if h != nil {
+			t.Fatalf("maxRows %d: expected no handle", maxRows)
+		}
+		if !errors.Is(err, ErrOverflow) {
+			t.Fatalf("maxRows %d: got %v, want ErrOverflow", maxRows, err)
+		}
+	}
+}
+
+// TestBridgeNextCgoBytesChunk pins the pure step function of the cgoBytes
+// chunked copy: the last chunk is capped at cBytesLenMax so every per-chunk
+// count fits the 32-bit signed C.int domain, and the walk covers exactly n
+// bytes. Pure integers only, no buffer is allocated.
+func TestBridgeNextCgoBytesChunk(t *testing.T) {
+	if got := nextCgoBytesChunk(0, 7); got != 7 {
+		t.Fatalf("nextCgoBytesChunk(0, 7) = %d, want 7", got)
+	}
+	if got := nextCgoBytesChunk(0, math.MaxInt32); got != math.MaxInt32 {
+		t.Fatalf("nextCgoBytesChunk(0, MaxInt32) = %d, want MaxInt32", got)
+	}
+	if got := nextCgoBytesChunk(0, cBytesLenMax+1); got != cBytesLenMax {
+		t.Fatalf("nextCgoBytesChunk(0, MaxInt32+1) = %d, want MaxInt32", got)
+	}
+	// Walk representative multi-chunk ranges and check exact coverage.
+	for _, n := range []int{math.MaxInt32 + 1, math.MaxInt32 + 2, int(math.MaxUint32) - 1, int(math.MaxUint32)} {
+		off := 0
+		covered := 0
+		for off < n {
+			m := nextCgoBytesChunk(off, n)
+			if m <= 0 || m > cBytesLenMax {
+				t.Fatalf("nextCgoBytesChunk(%d, %d) = %d, want (0, MaxInt32]", off, n, m)
+			}
+			off += m
+			covered++
+			if covered > 3 {
+				t.Fatalf("walk of n=%d did not finish in 3 chunks", n)
+			}
+		}
+	}
+}
+
+// TestBridgeCgoBytesNilAndZero pins the allocation-free edges of cgoBytes:
+// a nil pointer or zero length returns nil without touching C memory.
+func TestBridgeCgoBytesNilAndZero(t *testing.T) {
+	if got := cgoBytes(nil, 0); got != nil {
+		t.Fatalf("cgoBytes(nil, 0) = %v, want nil", got)
+	}
+	if got := cgoBytes(nil, 8); got != nil {
+		t.Fatalf("cgoBytes(nil, 8) = %v, want nil", got)
+	}
+	p := cStringPtr("x")
+	defer freeCString(p)
+	if got := cgoBytes(unsafe.Pointer(p), 0); got != nil {
+		t.Fatalf("cgoBytes(p, 0) = %v, want nil", got)
+	}
+}

--- a/go/tsfile/constants.go
+++ b/go/tsfile/constants.go
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tsfile
+
+// DataType identifies the data type of a time series measurement.
+type DataType int32
+
+const (
+	DataTypeBoolean   DataType = 0
+	DataTypeInt32     DataType = 1
+	DataTypeInt64     DataType = 2
+	DataTypeFloat     DataType = 3
+	DataTypeDouble    DataType = 4
+	DataTypeText      DataType = 5
+	DataTypeVector    DataType = 6
+	DataTypeTimestamp DataType = 8
+	DataTypeDate      DataType = 9
+	DataTypeBlob      DataType = 10
+	DataTypeString    DataType = 11
+	DataTypeNull      DataType = 254
+	DataTypeInvalid   DataType = 255
+)
+
+// Encoding identifies the encoding scheme of a chunk.
+type Encoding int32
+
+const (
+	EncodingPlain      Encoding = 0
+	EncodingDictionary Encoding = 1
+	EncodingRLE        Encoding = 2
+	EncodingDiff       Encoding = 3
+	EncodingTS2Diff    Encoding = 4
+	EncodingBitmap     Encoding = 5
+	EncodingGorillaV1  Encoding = 6
+	EncodingRegular    Encoding = 7
+	EncodingGorilla    Encoding = 8
+	EncodingZigZag     Encoding = 9
+	EncodingFreq       Encoding = 10
+	EncodingChimp      Encoding = 11
+	EncodingSprintz    Encoding = 12
+	EncodingRLBE       Encoding = 13
+	EncodingCamel      Encoding = 14
+	EncodingInvalid    Encoding = 255
+)
+
+// Compression identifies the compression algorithm of a chunk.
+type Compression int32
+
+const (
+	CompressionUncompressed Compression = 0
+	CompressionSnappy       Compression = 1
+	CompressionGzip         Compression = 2
+	CompressionLZO          Compression = 3
+	CompressionSDT          Compression = 4
+	CompressionPAA          Compression = 5
+	CompressionPLA          Compression = 6
+	CompressionLZ4          Compression = 7
+	CompressionZstd         Compression = 8
+	CompressionLZMA2        Compression = 9
+	CompressionInvalid      Compression = 255
+)
+
+// ColumnCategory identifies the category of a schema entry.
+type ColumnCategory int32
+
+const (
+	ColumnCategoryTag       ColumnCategory = 0
+	ColumnCategoryField     ColumnCategory = 1
+	ColumnCategoryAttribute ColumnCategory = 2
+	ColumnCategoryTime      ColumnCategory = 3
+)

--- a/go/tsfile/constants_test.go
+++ b/go/tsfile/constants_test.go
@@ -1,0 +1,246 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tsfile
+
+import (
+	"fmt"
+	"testing"
+)
+
+// The expected values below are pinned to the C ABI definitions in
+// cpp/src/cwrapper/tsfile_cwrapper.h (TSDataType, TSEncoding,
+// CompressionType, ColumnCategory) and cpp/src/cwrapper/errno_define_c.h
+// (RET_*). Any change in either header must be mirrored here.
+
+// cErrnoCodes lists every RET_* value defined in errno_define_c.h.
+var cErrnoCodes = map[int32]string{
+	0:  "RET_OK",
+	1:  "RET_OOM",
+	2:  "RET_NOT_EXIST",
+	3:  "RET_ALREADY_EXIST",
+	4:  "RET_INVALID_ARG",
+	5:  "RET_OUT_OF_RANGE",
+	6:  "RET_PARTIAL_READ",
+	8:  "RET_INVALID_SCHEMA",
+	20: "RET_OVERFLOW",
+	21: "RET_NO_MORE_DATA",
+	22: "RET_OUT_OF_ORDER",
+	24: "RET_TSBLOCK_DATA_INCONSISTENCY",
+	26: "RET_TYPE_NOT_SUPPORTED",
+	27: "RET_TYPE_NOT_MATCH",
+	28: "RET_FILE_OPEN_ERR",
+	29: "RET_FILE_CLOSE_ERR",
+	30: "RET_FILE_WRITE_ERR",
+	31: "RET_FILE_READ_ERR",
+	32: "RET_FILE_SYNC_ERR",
+	33: "RET_TSFILE_WRITER_META_ERR",
+	34: "RET_FILE_STAT_ERR",
+	35: "RET_TSFILE_CORRUPTED",
+	36: "RET_BUF_NOT_ENOUGH",
+	37: "RET_INVALID_PATH",
+	38: "RET_NOT_MATCH",
+	40: "RET_NOT_SUPPORT",
+	43: "RET_INVALID_DATA_POINT",
+	44: "RET_DEVICE_NOT_EXIST",
+	45: "RET_MEASUREMENT_NOT_EXIST",
+	48: "RET_COMPRESS_ERR",
+	49: "RET_TABLE_NOT_EXIST",
+	50: "RET_COLUMN_NOT_EXIST",
+	51: "RET_UNSUPPORTED_ORDER",
+	52: "RET_INVALID_NODE_TYPE",
+	53: "RET_ENCODE_ERR",
+	54: "RET_DECODE_ERR",
+}
+
+func assertPinned(t *testing.T, kind string, cases map[string]int32, actual func(string) int32) {
+	t.Helper()
+	for name, expected := range cases {
+		if got := actual(name); got != expected {
+			t.Errorf("%s.%s = %d, want %d", kind, name, got, expected)
+		}
+	}
+}
+
+func TestDataTypeValuesMatchCHeader(t *testing.T) {
+	assertPinned(t, "DataType", map[string]int32{
+		"DataTypeBoolean":   0,   // TS_DATATYPE_BOOLEAN
+		"DataTypeInt32":     1,   // TS_DATATYPE_INT32
+		"DataTypeInt64":     2,   // TS_DATATYPE_INT64
+		"DataTypeFloat":     3,   // TS_DATATYPE_FLOAT
+		"DataTypeDouble":    4,   // TS_DATATYPE_DOUBLE
+		"DataTypeText":      5,   // TS_DATATYPE_TEXT
+		"DataTypeVector":    6,   // TS_DATATYPE_VECTOR
+		"DataTypeTimestamp": 8,   // TS_DATATYPE_TIMESTAMP
+		"DataTypeDate":      9,   // TS_DATATYPE_DATE
+		"DataTypeBlob":      10,  // TS_DATATYPE_BLOB
+		"DataTypeString":    11,  // TS_DATATYPE_STRING
+		"DataTypeNull":      254, // TS_DATATYPE_NULL_TYPE
+		"DataTypeInvalid":   255, // TS_DATATYPE_INVALID
+	}, func(name string) int32 {
+		return int32(map[string]DataType{
+			"DataTypeBoolean":   DataTypeBoolean,
+			"DataTypeInt32":     DataTypeInt32,
+			"DataTypeInt64":     DataTypeInt64,
+			"DataTypeFloat":     DataTypeFloat,
+			"DataTypeDouble":    DataTypeDouble,
+			"DataTypeText":      DataTypeText,
+			"DataTypeVector":    DataTypeVector,
+			"DataTypeTimestamp": DataTypeTimestamp,
+			"DataTypeDate":      DataTypeDate,
+			"DataTypeBlob":      DataTypeBlob,
+			"DataTypeString":    DataTypeString,
+			"DataTypeNull":      DataTypeNull,
+			"DataTypeInvalid":   DataTypeInvalid,
+		}[name])
+	})
+}
+
+func TestEncodingValuesMatchCHeader(t *testing.T) {
+	assertPinned(t, "Encoding", map[string]int32{
+		"EncodingPlain":      0,   // TS_ENCODING_PLAIN
+		"EncodingDictionary": 1,   // TS_ENCODING_DICTIONARY
+		"EncodingRLE":        2,   // TS_ENCODING_RLE
+		"EncodingDiff":       3,   // TS_ENCODING_DIFF
+		"EncodingTS2Diff":    4,   // TS_ENCODING_TS_2DIFF
+		"EncodingBitmap":     5,   // TS_ENCODING_BITMAP
+		"EncodingGorillaV1":  6,   // TS_ENCODING_GORILLA_V1
+		"EncodingRegular":    7,   // TS_ENCODING_REGULAR
+		"EncodingGorilla":    8,   // TS_ENCODING_GORILLA
+		"EncodingZigZag":     9,   // TS_ENCODING_ZIGZAG
+		"EncodingFreq":       10,  // TS_ENCODING_FREQ
+		"EncodingChimp":      11,  // TS_ENCODING_CHIMP
+		"EncodingSprintz":    12,  // TS_ENCODING_SPRINTZ
+		"EncodingRLBE":       13,  // TS_ENCODING_RLBE
+		"EncodingCamel":      14,  // TS_ENCODING_CAMEL
+		"EncodingInvalid":    255, // TS_ENCODING_INVALID
+	}, func(name string) int32 {
+		return int32(map[string]Encoding{
+			"EncodingPlain":      EncodingPlain,
+			"EncodingDictionary": EncodingDictionary,
+			"EncodingRLE":        EncodingRLE,
+			"EncodingDiff":       EncodingDiff,
+			"EncodingTS2Diff":    EncodingTS2Diff,
+			"EncodingBitmap":     EncodingBitmap,
+			"EncodingGorillaV1":  EncodingGorillaV1,
+			"EncodingRegular":    EncodingRegular,
+			"EncodingGorilla":    EncodingGorilla,
+			"EncodingZigZag":     EncodingZigZag,
+			"EncodingFreq":       EncodingFreq,
+			"EncodingChimp":      EncodingChimp,
+			"EncodingSprintz":    EncodingSprintz,
+			"EncodingRLBE":       EncodingRLBE,
+			"EncodingCamel":      EncodingCamel,
+			"EncodingInvalid":    EncodingInvalid,
+		}[name])
+	})
+}
+
+func TestCompressionValuesMatchCHeader(t *testing.T) {
+	assertPinned(t, "Compression", map[string]int32{
+		"CompressionUncompressed": 0,   // TS_COMPRESSION_UNCOMPRESSED
+		"CompressionSnappy":       1,   // TS_COMPRESSION_SNAPPY
+		"CompressionGzip":         2,   // TS_COMPRESSION_GZIP
+		"CompressionLZO":          3,   // TS_COMPRESSION_LZO
+		"CompressionSDT":          4,   // TS_COMPRESSION_SDT
+		"CompressionPAA":          5,   // TS_COMPRESSION_PAA
+		"CompressionPLA":          6,   // TS_COMPRESSION_PLA
+		"CompressionLZ4":          7,   // TS_COMPRESSION_LZ4
+		"CompressionZstd":         8,   // TS_COMPRESSION_ZSTD
+		"CompressionLZMA2":        9,   // TS_COMPRESSION_LZMA2
+		"CompressionInvalid":      255, // TS_COMPRESSION_INVALID
+	}, func(name string) int32 {
+		return int32(map[string]Compression{
+			"CompressionUncompressed": CompressionUncompressed,
+			"CompressionSnappy":       CompressionSnappy,
+			"CompressionGzip":         CompressionGzip,
+			"CompressionLZO":          CompressionLZO,
+			"CompressionSDT":          CompressionSDT,
+			"CompressionPAA":          CompressionPAA,
+			"CompressionPLA":          CompressionPLA,
+			"CompressionLZ4":          CompressionLZ4,
+			"CompressionZstd":         CompressionZstd,
+			"CompressionLZMA2":        CompressionLZMA2,
+			"CompressionInvalid":      CompressionInvalid,
+		}[name])
+	})
+}
+
+func TestColumnCategoryValuesMatchCHeader(t *testing.T) {
+	assertPinned(t, "ColumnCategory", map[string]int32{
+		"ColumnCategoryTag":       0, // TAG
+		"ColumnCategoryField":     1, // FIELD
+		"ColumnCategoryAttribute": 2, // ATTRIBUTE
+		"ColumnCategoryTime":      3, // TIME
+	}, func(name string) int32 {
+		return int32(map[string]ColumnCategory{
+			"ColumnCategoryTag":       ColumnCategoryTag,
+			"ColumnCategoryField":     ColumnCategoryField,
+			"ColumnCategoryAttribute": ColumnCategoryAttribute,
+			"ColumnCategoryTime":      ColumnCategoryTime,
+		}[name])
+	})
+}
+
+func TestErrorMessagesCoverAllCErrorCodes(t *testing.T) {
+	for code, name := range cErrnoCodes {
+		message := errorCodeMessage(code)
+		if message == "" {
+			t.Errorf("%s (%d): message is empty", name, code)
+		} else if message == fmt.Sprintf("unknown error code %d", code) {
+			t.Errorf("%s (%d) is mapped to the unknown-code message", name, code)
+		}
+	}
+}
+
+func TestErrorMessagesAreUnique(t *testing.T) {
+	seen := make(map[string]int32, len(cErrnoCodes))
+	for code, name := range cErrnoCodes {
+		message := errorCodeMessage(code)
+		if other, ok := seen[message]; ok {
+			t.Errorf("codes %d (%s) and %d (%s) share message %q", other, cErrnoCodes[other], code, name, message)
+		}
+		seen[message] = code
+	}
+}
+
+func TestSentinelErrorsMatchCErrorCodes(t *testing.T) {
+	want := map[*Error]int32{
+		ErrInvalidArgument:     4,  // RET_INVALID_ARG
+		ErrOutOfRange:          5,  // RET_OUT_OF_RANGE
+		ErrInvalidSchema:       8,  // RET_INVALID_SCHEMA
+		ErrTypeNotSupported:    26, // RET_TYPE_NOT_SUPPORTED
+		ErrTypeMismatch:        27, // RET_TYPE_NOT_MATCH
+		ErrFileOpen:            28, // RET_FILE_OPEN_ERR
+		ErrFileClose:           29, // RET_FILE_CLOSE_ERR
+		ErrFileWrite:           30, // RET_FILE_WRITE_ERR
+		ErrFileRead:            31, // RET_FILE_READ_ERR
+		ErrInvalidPath:         37, // RET_INVALID_PATH
+		ErrDeviceNotExist:      44, // RET_DEVICE_NOT_EXIST
+		ErrMeasurementNotExist: 45, // RET_MEASUREMENT_NOT_EXIST
+		ErrTableNotExist:       49, // RET_TABLE_NOT_EXIST
+		ErrColumnNotExist:      50, // RET_COLUMN_NOT_EXIST
+	}
+	for sentinel, code := range want {
+		if sentinel.Code != code {
+			t.Errorf("sentinel %#v has code %d, want %d", sentinel, sentinel.Code, code)
+		}
+		if _, known := cErrnoCodes[code]; !known {
+			t.Errorf("sentinel %#v maps to code %d not defined in errno_define_c.h", sentinel, code)
+		}
+	}
+}

--- a/go/tsfile/doc.go
+++ b/go/tsfile/doc.go
@@ -1,0 +1,21 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package tsfile provides typed Go bindings to the Apache TsFile C++ reader
+// and writer. Native handles are safe to close more than once and serialize
+// calls against concurrent Close operations.
+package tsfile

--- a/go/tsfile/errors.go
+++ b/go/tsfile/errors.go
@@ -1,0 +1,149 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tsfile
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Error represents a TsFile error code paired with an optional operation.
+type Error struct {
+	Code int32
+	Op   string
+}
+
+func (e *Error) Error() string {
+	message := errorCodeMessage(e.Code)
+	if e.Op != "" {
+		return e.Op + ": " + message
+	}
+	return message
+}
+
+// Is compares TsFile errors by numeric code.
+func (e *Error) Is(target error) bool {
+	targetError, ok := target.(*Error)
+	return ok && e.Code == targetError.Code
+}
+
+func newError(op string, code int32) error {
+	if code == 0 {
+		return nil
+	}
+	return &Error{Code: code, Op: op}
+}
+
+var (
+	ErrInvalidArgument     = &Error{Code: 4}
+	ErrOutOfRange          = &Error{Code: 5}
+	ErrOverflow            = &Error{Code: 20}
+	ErrInvalidSchema       = &Error{Code: 8}
+	ErrTypeNotSupported    = &Error{Code: 26}
+	ErrTypeMismatch        = &Error{Code: 27}
+	ErrFileOpen            = &Error{Code: 28}
+	ErrFileClose           = &Error{Code: 29}
+	ErrFileWrite           = &Error{Code: 30}
+	ErrFileRead            = &Error{Code: 31}
+	ErrInvalidPath         = &Error{Code: 37}
+	ErrDeviceNotExist      = &Error{Code: 44}
+	ErrMeasurementNotExist = &Error{Code: 45}
+	ErrTableNotExist       = &Error{Code: 49}
+	ErrColumnNotExist      = &Error{Code: 50}
+
+	ErrClosed    = errors.New("tsfile: closed")
+	ErrNullValue = errors.New("tsfile: null value")
+)
+
+func errorCodeMessage(code int32) string {
+	switch code {
+	case 0:
+		return "ok"
+	case 1:
+		return "out of memory"
+	case 2:
+		return "does not exist"
+	case 3:
+		return "already exists"
+	case 4:
+		return "invalid argument"
+	case 5:
+		return "out of range"
+	case 6:
+		return "partial read"
+	case 8:
+		return "invalid schema"
+	case 20:
+		return "overflow"
+	case 21:
+		return "no more data"
+	case 22:
+		return "out of order"
+	case 24:
+		return "TsBlock data inconsistency"
+	case 26:
+		return "type not supported"
+	case 27:
+		return "type mismatch"
+	case 28:
+		return "file open failed"
+	case 29:
+		return "file close failed"
+	case 30:
+		return "file write failed"
+	case 31:
+		return "file read failed"
+	case 32:
+		return "file sync failed"
+	case 33:
+		return "TsFile writer metadata error"
+	case 34:
+		return "file stat failed"
+	case 35:
+		return "TsFile corrupted"
+	case 36:
+		return "buffer not large enough"
+	case 37:
+		return "invalid path"
+	case 38:
+		return "does not match"
+	case 40:
+		return "operation not supported"
+	case 43:
+		return "invalid data point"
+	case 44:
+		return "device does not exist"
+	case 45:
+		return "measurement does not exist"
+	case 48:
+		return "compression failed"
+	case 49:
+		return "table does not exist"
+	case 50:
+		return "column does not exist"
+	case 51:
+		return "unsupported order"
+	case 52:
+		return "invalid node type"
+	case 53:
+		return "encoding failed"
+	case 54:
+		return "decoding failed"
+	default:
+		return fmt.Sprintf("unknown error code %d", code)
+	}
+}

--- a/go/tsfile/errors_test.go
+++ b/go/tsfile/errors_test.go
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tsfile
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNewErrorNilForOK(t *testing.T) {
+	if got := newError("op", 0); got != nil {
+		t.Fatalf("newError(op, 0) = %v, want nil", got)
+	}
+}
+
+func TestErrorString(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "known without op", err: newError("", 31), want: "file read failed"},
+		{name: "known with op", err: newError("Read", 28), want: "Read: file open failed"},
+		{name: "unknown", err: newError("Open", 12345), want: "Open: unknown error code 12345"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.err.Error(); got != test.want {
+				t.Fatalf("Error() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestErrorIsComparesCodes(t *testing.T) {
+	if !errors.Is(&Error{Code: 30, Op: "Write"}, ErrFileWrite) {
+		t.Fatal("fresh error with code 30 did not match ErrFileWrite")
+	}
+	if errors.Is(&Error{Code: 31}, ErrFileWrite) {
+		t.Fatal("different error codes matched")
+	}
+	if errors.Is(&Error{Code: 4}, ErrClosed) {
+		t.Fatal("TsFile error unexpectedly matched ErrClosed")
+	}
+	if !errors.Is(ErrClosed, ErrClosed) {
+		t.Fatal("ErrClosed did not match itself")
+	}
+}

--- a/go/tsfile/integration_test.go
+++ b/go/tsfile/integration_test.go
@@ -1,0 +1,271 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tsfile
+
+import (
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestTreeRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tree.tsfile")
+	writer, err := NewWriter(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := DeviceSchema{Device: "root.d1", TimeSeries: []TimeseriesSchema{
+		{Name: "s1", DataType: DataTypeInt64, Encoding: EncodingPlain, Compression: CompressionUncompressed},
+		{Name: "label", DataType: DataTypeString, Encoding: EncodingPlain, Compression: CompressionUncompressed},
+	}}
+	if err := writer.RegisterDevice(schema); err != nil {
+		t.Fatal(err)
+	}
+	tablet, err := NewTablet("root.d1", []TabletColumn{
+		{Name: "s1", DataType: DataTypeInt64},
+		{Name: "label", DataType: DataTypeString},
+	}, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tablet.Close()
+	for row, timestamp := range []int64{10, 20} {
+		if err := tablet.AddTimestamp(row, timestamp); err != nil {
+			t.Fatal(err)
+		}
+		if err := tablet.SetInt64(row, 0, timestamp*10); err != nil {
+			t.Fatal(err)
+		}
+		if err := tablet.SetString(row, 1, []string{"first", "second"}[row]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.WriteTreeTablet(tablet); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := NewReader(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	result, err := reader.QueryTree(TreeQuery{Paths: []string{"root.d1.s1", "root.d1.label"}, Start: 0, End: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer result.Close()
+	metadata := result.Metadata()
+	if len(metadata) != 3 {
+		t.Fatalf("metadata columns = %v, want timestamp and two values", metadata)
+	}
+	for row, wantTimestamp := range []int64{10, 20} {
+		ok, err := result.Next()
+		if err != nil || !ok {
+			t.Fatalf("row %d Next = %v, %v", row, ok, err)
+		}
+		if got, err := result.Int64(0); err != nil || got != wantTimestamp {
+			t.Fatalf("timestamp = %d, %v; want %d", got, err, wantTimestamp)
+		}
+		if got, err := result.Int64(1); err != nil || got != wantTimestamp*10 {
+			t.Fatalf("s1 = %d, %v", got, err)
+		}
+		if got, err := result.String(2); err != nil || got != []string{"first", "second"}[row] {
+			t.Fatalf("label = %q, %v", got, err)
+		}
+	}
+	if ok, err := result.Next(); err != nil || ok {
+		t.Fatalf("end Next = %v, %v; want false, nil", ok, err)
+	}
+	if err := result.Close(); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := reader.QueryTreeRows(TreeRowsQuery{
+		Devices: []string{"root.d1"}, Measurements: []string{"s1"}, Offset: 1, Limit: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	if ok, err := rows.Next(); err != nil || !ok {
+		t.Fatalf("row query Next = %v, %v", ok, err)
+	}
+	if got, err := rows.Int64(0); err != nil || got != 20 {
+		t.Fatalf("row query timestamp = %d, %v", got, err)
+	}
+	if got, err := rows.Int64(1); err != nil || got != 200 {
+		t.Fatalf("row query s1 = %d, %v", got, err)
+	}
+}
+
+func TestTableRoundTripAndNull(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "table.tsfile")
+	writer, err := NewWriter(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.RegisterTable(TableSchema{Table: "metrics", Columns: []ColumnSchema{
+		{Name: "device", DataType: DataTypeString, Category: ColumnCategoryTag},
+		{Name: "value", DataType: DataTypeDouble, Category: ColumnCategoryField},
+		{Name: "enabled", DataType: DataTypeBoolean, Category: ColumnCategoryField},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.AddProperty("source", []byte("go-integration")); err != nil {
+		t.Fatal(err)
+	}
+	tablet, err := NewTablet("metrics", []TabletColumn{
+		{Name: "device", DataType: DataTypeString},
+		{Name: "value", DataType: DataTypeDouble},
+		{Name: "enabled", DataType: DataTypeBoolean},
+	}, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tablet.Close()
+	for row := 0; row < 3; row++ {
+		if err := tablet.AddTimestamp(row, int64(row+1)); err != nil {
+			t.Fatal(err)
+		}
+		if err := tablet.SetString(row, 0, "d1"); err != nil {
+			t.Fatal(err)
+		}
+		if row < 2 {
+			if err := tablet.SetFloat64(row, 1, float64(row)+0.5); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := tablet.SetBool(row, 2, row%2 == 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.WriteTableTablet(tablet); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := NewReader(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	result, err := reader.QueryTable(TableQuery{Table: "metrics", Columns: []string{"device", "value", "enabled"}, Start: 0, End: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer result.Close()
+	for row := 0; row < 3; row++ {
+		ok, err := result.Next()
+		if err != nil || !ok {
+			t.Fatalf("row %d Next = %v, %v", row, ok, err)
+		}
+		if got, err := result.String(1); err != nil || got != "d1" {
+			t.Fatalf("device = %q, %v", got, err)
+		}
+		isNull, err := result.IsNull(2)
+		if err != nil || isNull != (row == 2) {
+			t.Fatalf("row %d null = %v, %v", row, isNull, err)
+		}
+		if row == 2 {
+			if _, err := result.Float64(2); !errors.Is(err, ErrNullValue) {
+				t.Fatalf("null Float64 error = %v", err)
+			}
+		} else if got, err := result.Float64(2); err != nil || got != float64(row)+0.5 {
+			t.Fatalf("value = %v, %v", got, err)
+		}
+		if _, err := result.Int64(1); !errors.Is(err, ErrTypeMismatch) {
+			t.Fatalf("type mismatch error = %v", err)
+		}
+	}
+	if err := result.Close(); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := reader.QueryTableRows(TableRowsQuery{
+		Table: "metrics", Columns: []string{"device", "value"}, Offset: 1, Limit: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	if ok, err := rows.Next(); err != nil || !ok {
+		t.Fatalf("table row query Next = %v, %v", ok, err)
+	}
+	if got, err := rows.Int64(0); err != nil || got != 2 {
+		t.Fatalf("table row timestamp = %d, %v", got, err)
+	}
+	if got, err := rows.Float64(2); err != nil || got != 1.5 {
+		t.Fatalf("table row value = %v, %v", got, err)
+	}
+}
+
+func TestReaderCloseClosesResultsConcurrently(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lifetime.tsfile")
+	writer, err := NewWriter(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.RegisterTimeseries("root.d1", TimeseriesSchema{Name: "s1", DataType: DataTypeInt64, Encoding: EncodingPlain, Compression: CompressionUncompressed}); err != nil {
+		t.Fatal(err)
+	}
+	tablet, err := NewTablet("root.d1", []TabletColumn{{Name: "s1", DataType: DataTypeInt64}}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tablet.Close()
+	if err := tablet.AddTimestamp(0, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := tablet.SetInt64(0, 0, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.WriteTreeTablet(tablet); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reader, err := NewReader(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := reader.QueryTree(TreeQuery{Paths: []string{"root.d1.s1"}, Start: 0, End: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			_ = result.Metadata()
+		}
+	}()
+	go func() { defer wg.Done(); _ = reader.Close() }()
+	wg.Wait()
+	if _, err := result.Next(); !errors.Is(err, ErrClosed) {
+		t.Fatalf("Next after Reader.Close = %v", err)
+	}
+	if err := result.Close(); err != nil {
+		t.Fatalf("ResultSet.Close after Reader.Close = %v", err)
+	}
+}

--- a/go/tsfile/reader.go
+++ b/go/tsfile/reader.go
@@ -1,0 +1,182 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tsfile
+
+import (
+	"fmt"
+	"sync"
+)
+
+// TableQuery selects table-model columns over an inclusive time range.
+type TableQuery struct {
+	Table      string
+	Columns    []string
+	Start, End int64
+}
+
+// TreeQuery selects exact tree-model full paths over an inclusive time range.
+type TreeQuery struct {
+	Paths      []string
+	Start, End int64
+}
+
+// TreeRowsQuery selects tree-model rows with global offset and limit.
+type TreeRowsQuery struct {
+	Devices, Measurements []string
+	Offset, Limit         int
+}
+
+// TableRowsQuery selects table-model rows with offset and limit.
+type TableRowsQuery struct {
+	Table                    string
+	Columns                  []string
+	Offset, Limit, BatchSize int
+}
+
+// Reader queries one TsFile and owns all ResultSets created from it.
+type Reader struct {
+	mu      sync.Mutex
+	handle  *readerHandle
+	results map[*ResultSet]struct{}
+}
+
+// NewReader opens an existing TsFile for queries.
+func NewReader(path string) (*Reader, error) {
+	handle, err := newReaderHandle(path)
+	if err != nil {
+		return nil, err
+	}
+	return &Reader{handle: handle, results: make(map[*ResultSet]struct{})}, nil
+}
+
+func validateQueryStrings(op, field string, values []string) error {
+	if len(values) == 0 {
+		return fmt.Errorf("%w: %s must not be empty", ErrInvalidArgument, field)
+	}
+	if err := validateCInt32(op, field+" count", len(values)); err != nil {
+		return err
+	}
+	if _, err := validateCStrings(op, field, values); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *Reader) query(fn func(*readerHandle) (*resultSetHandle, error)) (*ResultSet, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.handle == nil || r.handle.ptr == nil {
+		return nil, ErrClosed
+	}
+	handle, err := fn(r.handle)
+	if err != nil {
+		return nil, err
+	}
+	result := &ResultSet{handle: handle, reader: r}
+	result.metadata = handle.metadata()
+	r.results[result] = struct{}{}
+	return result, nil
+}
+
+// QueryTable executes a time-range table-model query.
+func (r *Reader) QueryTable(query TableQuery) (*ResultSet, error) {
+	if err := validateCString("query table", "table", query.Table); err != nil {
+		return nil, err
+	}
+	if err := validateQueryStrings("query table", "columns", query.Columns); err != nil {
+		return nil, err
+	}
+	if query.End < query.Start {
+		return nil, fmt.Errorf("%w: end must not precede start", ErrInvalidArgument)
+	}
+	return r.query(func(h *readerHandle) (*resultSetHandle, error) { return h.queryTable(query) })
+}
+
+// QueryTree executes a time-range query for exact full paths.
+func (r *Reader) QueryTree(query TreeQuery) (*ResultSet, error) {
+	if err := validateQueryStrings("query tree", "paths", query.Paths); err != nil {
+		return nil, err
+	}
+	if query.End < query.Start {
+		return nil, fmt.Errorf("%w: end must not precede start", ErrInvalidArgument)
+	}
+	return r.query(func(h *readerHandle) (*resultSetHandle, error) { return h.queryTree(query) })
+}
+
+func validateRows(offset, limit int, op string) error {
+	if offset < 0 {
+		return fmt.Errorf("%w: offset must be nonnegative", ErrInvalidArgument)
+	}
+	if err := validateCInt32(op, "offset", offset); err != nil {
+		return err
+	}
+	return validateCInt32(op, "limit", limit)
+}
+
+// QueryTreeRows executes an offset/limit tree-model query.
+func (r *Reader) QueryTreeRows(query TreeRowsQuery) (*ResultSet, error) {
+	if err := validateQueryStrings("query tree rows", "devices", query.Devices); err != nil {
+		return nil, err
+	}
+	if err := validateQueryStrings("query tree rows", "measurements", query.Measurements); err != nil {
+		return nil, err
+	}
+	if err := validateRows(query.Offset, query.Limit, "query tree rows"); err != nil {
+		return nil, err
+	}
+	return r.query(func(h *readerHandle) (*resultSetHandle, error) { return h.queryTreeRows(query) })
+}
+
+// QueryTableRows executes an offset/limit table-model query.
+func (r *Reader) QueryTableRows(query TableRowsQuery) (*ResultSet, error) {
+	if err := validateCString("query table rows", "table", query.Table); err != nil {
+		return nil, err
+	}
+	if err := validateQueryStrings("query table rows", "columns", query.Columns); err != nil {
+		return nil, err
+	}
+	if err := validateRows(query.Offset, query.Limit, "query table rows"); err != nil {
+		return nil, err
+	}
+	if query.BatchSize < 0 {
+		return nil, fmt.Errorf("%w: batch size must be nonnegative", ErrInvalidArgument)
+	}
+	if err := validateCInt32("query table rows", "batch size", query.BatchSize); err != nil {
+		return nil, err
+	}
+	return r.query(func(h *readerHandle) (*resultSetHandle, error) { return h.queryTableRows(query) })
+}
+
+// Close releases all active result sets and then the reader. It is idempotent.
+func (r *Reader) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.handle == nil || r.handle.ptr == nil {
+		return nil
+	}
+	for result := range r.results {
+		result.mu.Lock()
+		if result.handle != nil {
+			_ = result.handle.close()
+		}
+		result.current = false
+		result.mu.Unlock()
+		delete(r.results, result)
+	}
+	return r.handle.close()
+}

--- a/go/tsfile/result_set.go
+++ b/go/tsfile/result_set.go
@@ -1,0 +1,181 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tsfile
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// ErrNoCurrentRow indicates that a value was requested before a successful
+// call to Next or after the result set reached its end.
+var ErrNoCurrentRow = errors.New("tsfile: result set is not positioned on a row")
+
+// ResultSet is a forward-only query result owned by its Reader.
+type ResultSet struct {
+	mu       sync.Mutex
+	handle   *resultSetHandle
+	reader   *Reader
+	metadata []ColumnMetadata
+	current  bool
+}
+
+func (rs *ResultSet) locked(fn func() error) error {
+	reader := rs.reader
+	if reader == nil {
+		return ErrClosed
+	}
+	reader.mu.Lock()
+	defer reader.mu.Unlock()
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	if rs.handle == nil || rs.handle.ptr == nil {
+		return ErrClosed
+	}
+	return fn()
+}
+
+// Next advances to the next row. It returns false with a nil error at EOF.
+func (rs *ResultSet) Next() (bool, error) {
+	var next bool
+	err := rs.locked(func() error {
+		var err error
+		next, err = rs.handle.next()
+		rs.current = next
+		return err
+	})
+	return next, err
+}
+
+// Metadata returns a copy of the result columns, including timestamp at zero.
+func (rs *ResultSet) Metadata() []ColumnMetadata {
+	reader := rs.reader
+	if reader == nil {
+		return nil
+	}
+	reader.mu.Lock()
+	defer reader.mu.Unlock()
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	if rs.handle == nil || rs.handle.ptr == nil {
+		return nil
+	}
+	return append([]ColumnMetadata(nil), rs.metadata...)
+}
+
+func (rs *ResultSet) validateColumn(column int, allowed ...DataType) error {
+	if !rs.current {
+		return ErrNoCurrentRow
+	}
+	if column < 0 || column >= len(rs.metadata) {
+		return ErrOutOfRange
+	}
+	actual := rs.metadata[column].DataType
+	for _, expected := range allowed {
+		if actual == expected {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: column %d has data type %d", ErrTypeMismatch, column, actual)
+}
+
+// IsNull reports whether the zero-based column is null in the current row.
+func (rs *ResultSet) IsNull(column int) (value bool, err error) {
+	err = rs.locked(func() error {
+		if !rs.current {
+			return ErrNoCurrentRow
+		}
+		if column < 0 || column >= len(rs.metadata) {
+			return ErrOutOfRange
+		}
+		value = rs.handle.isNull(column)
+		return nil
+	})
+	return
+}
+
+func (rs *ResultSet) get(column int, allowed []DataType, fn func()) error {
+	return rs.locked(func() error {
+		if err := rs.validateColumn(column, allowed...); err != nil {
+			return err
+		}
+		if rs.handle.isNull(column) {
+			return ErrNullValue
+		}
+		fn()
+		return nil
+	})
+}
+
+// Bool returns a BOOLEAN column from the current row.
+func (rs *ResultSet) Bool(column int) (value bool, err error) {
+	err = rs.get(column, []DataType{DataTypeBoolean}, func() { value = rs.handle.bool(column) })
+	return
+}
+
+// Int32 returns an INT32 or DATE column from the current row.
+func (rs *ResultSet) Int32(column int) (value int32, err error) {
+	err = rs.get(column, []DataType{DataTypeInt32, DataTypeDate}, func() { value = rs.handle.int32(column) })
+	return
+}
+
+// Int64 returns an INT64 or TIMESTAMP column from the current row.
+func (rs *ResultSet) Int64(column int) (value int64, err error) {
+	err = rs.get(column, []DataType{DataTypeInt64, DataTypeTimestamp}, func() { value = rs.handle.int64(column) })
+	return
+}
+
+// Float32 returns a FLOAT column from the current row.
+func (rs *ResultSet) Float32(column int) (value float32, err error) {
+	err = rs.get(column, []DataType{DataTypeFloat}, func() { value = rs.handle.float32(column) })
+	return
+}
+
+// Float64 returns a DOUBLE column from the current row.
+func (rs *ResultSet) Float64(column int) (value float64, err error) {
+	err = rs.get(column, []DataType{DataTypeDouble}, func() { value = rs.handle.float64(column) })
+	return
+}
+
+// String returns a TEXT or STRING column from the current row.
+func (rs *ResultSet) String(column int) (value string, err error) {
+	err = rs.get(column, []DataType{DataTypeText, DataTypeString}, func() { value = rs.handle.string(column) })
+	return
+}
+
+// Close releases the native result. It is idempotent.
+func (rs *ResultSet) Close() error {
+	reader := rs.reader
+	if reader == nil {
+		return nil
+	}
+	reader.mu.Lock()
+	defer reader.mu.Unlock()
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	if rs.handle == nil || rs.handle.ptr == nil {
+		return nil
+	}
+	err := rs.handle.close()
+	if err == nil {
+		delete(reader.results, rs)
+		rs.current = false
+	}
+	return err
+}

--- a/go/tsfile/schema.go
+++ b/go/tsfile/schema.go
@@ -1,0 +1,110 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tsfile
+
+import "fmt"
+
+// TimeseriesSchema describes one tree-model measurement.
+type TimeseriesSchema struct {
+	Name        string
+	DataType    DataType
+	Encoding    Encoding
+	Compression Compression
+}
+
+// DeviceSchema groups tree-model measurements under one device.
+type DeviceSchema struct {
+	Device     string
+	TimeSeries []TimeseriesSchema
+}
+
+// ColumnSchema describes one table-model column.
+type ColumnSchema struct {
+	Name     string
+	DataType DataType
+	Category ColumnCategory
+}
+
+// TableSchema describes a table-model table.
+type TableSchema struct {
+	Table   string
+	Columns []ColumnSchema
+}
+
+// TabletColumn fixes the name and type of a Tablet column.
+type TabletColumn struct {
+	Name     string
+	DataType DataType
+}
+
+// ColumnMetadata describes one column in a query result. Column zero is the
+// timestamp column returned by the native result set.
+type ColumnMetadata struct {
+	Name     string
+	DataType DataType
+}
+
+func timeseriesNames(series []TimeseriesSchema) []string {
+	names := make([]string, len(series))
+	for i := range series {
+		names[i] = series[i].Name
+	}
+	return names
+}
+
+func columnNames(columns []ColumnSchema) []string {
+	names := make([]string, len(columns))
+	for i := range columns {
+		names[i] = columns[i].Name
+	}
+	return names
+}
+
+func validDataType(value DataType) bool {
+	switch value {
+	case DataTypeBoolean, DataTypeInt32, DataTypeInt64, DataTypeFloat,
+		DataTypeDouble, DataTypeText, DataTypeTimestamp, DataTypeDate,
+		DataTypeBlob, DataTypeString:
+		return true
+	default:
+		return false
+	}
+}
+
+func validEncoding(value Encoding) bool {
+	return value >= EncodingPlain && value <= EncodingCamel
+}
+
+func validCompression(value Compression) bool {
+	return value >= CompressionUncompressed && value <= CompressionLZMA2
+}
+
+func validColumnCategory(value ColumnCategory) bool {
+	return value >= ColumnCategoryTag && value <= ColumnCategoryTime
+}
+
+func validateTimeseriesSchema(op string, schema TimeseriesSchema) error {
+	if err := validateCString(op, "timeseries name", schema.Name); err != nil {
+		return err
+	}
+	if !validDataType(schema.DataType) || !validEncoding(schema.Encoding) ||
+		!validCompression(schema.Compression) {
+		return fmt.Errorf("%w: invalid timeseries schema for %q", newError(op, 8), schema.Name)
+	}
+	return nil
+}

--- a/go/tsfile/tablet.go
+++ b/go/tsfile/tablet.go
@@ -1,0 +1,167 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tsfile
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// Tablet is a fixed-capacity batch of rows for one device or table.
+type Tablet struct {
+	mu      sync.Mutex
+	handle  *tabletHandle
+	columns []TabletColumn
+	maxRows int
+}
+
+// NewTablet allocates a tablet with fixed columns and row capacity.
+func NewTablet(target string, columns []TabletColumn, maxRows int) (*Tablet, error) {
+	if len(columns) == 0 {
+		return nil, fmt.Errorf("%w: at least one column is required", ErrInvalidArgument)
+	}
+	names := make([]string, len(columns))
+	types := make([]DataType, len(columns))
+	for i, column := range columns {
+		if err := validateCString("new tablet", "column name", column.Name); err != nil {
+			return nil, fmt.Errorf("column %d: %w", i, err)
+		}
+		if !validDataType(column.DataType) {
+			return nil, fmt.Errorf("%w: unsupported data type %d for column %q", ErrInvalidSchema, column.DataType, column.Name)
+		}
+		names[i], types[i] = column.Name, column.DataType
+	}
+	handle, err := newTabletHandle(target, names, types, maxRows)
+	if err != nil {
+		return nil, err
+	}
+	return &Tablet{handle: handle, columns: append([]TabletColumn(nil), columns...), maxRows: maxRows}, nil
+}
+
+func (t *Tablet) validateLocked(row, column int, allowed ...DataType) error {
+	if t.handle == nil || t.handle.ptr == nil {
+		return ErrClosed
+	}
+	if row < 0 || row >= t.maxRows || column < 0 || column >= len(t.columns) {
+		return ErrOutOfRange
+	}
+	actual := t.columns[column].DataType
+	for _, expected := range allowed {
+		if actual == expected {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: column %d has data type %d", ErrTypeMismatch, column, actual)
+}
+
+// AddTimestamp assigns the timestamp for a row.
+func (t *Tablet) AddTimestamp(row int, timestamp int64) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.handle == nil || t.handle.ptr == nil {
+		return ErrClosed
+	}
+	if row < 0 || row >= t.maxRows {
+		return ErrOutOfRange
+	}
+	return t.handle.addTimestamp(row, timestamp)
+}
+
+// SetBool assigns a BOOLEAN value by zero-based row and column.
+func (t *Tablet) SetBool(row, column int, value bool) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if err := t.validateLocked(row, column, DataTypeBoolean); err != nil {
+		return err
+	}
+	return t.handle.addBool(row, column, value)
+}
+
+// SetInt32 assigns an INT32 or DATE value.
+func (t *Tablet) SetInt32(row, column int, value int32) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if err := t.validateLocked(row, column, DataTypeInt32, DataTypeDate); err != nil {
+		return err
+	}
+	return t.handle.addInt32(row, column, value)
+}
+
+// SetInt64 assigns an INT64 or TIMESTAMP value.
+func (t *Tablet) SetInt64(row, column int, value int64) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if err := t.validateLocked(row, column, DataTypeInt64, DataTypeTimestamp); err != nil {
+		return err
+	}
+	return t.handle.addInt64(row, column, value)
+}
+
+// SetFloat32 assigns a FLOAT value.
+func (t *Tablet) SetFloat32(row, column int, value float32) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if err := t.validateLocked(row, column, DataTypeFloat); err != nil {
+		return err
+	}
+	return t.handle.addFloat32(row, column, value)
+}
+
+// SetFloat64 assigns a DOUBLE value.
+func (t *Tablet) SetFloat64(row, column int, value float64) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if err := t.validateLocked(row, column, DataTypeDouble); err != nil {
+		return err
+	}
+	return t.handle.addFloat64(row, column, value)
+}
+
+// SetString assigns a TEXT or STRING value.
+func (t *Tablet) SetString(row, column int, value string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if err := t.validateLocked(row, column, DataTypeText, DataTypeString); err != nil {
+		return err
+	}
+	if strings.IndexByte(value, 0) >= 0 {
+		return fmt.Errorf("%w: strings with embedded NUL are not supported", ErrInvalidArgument)
+	}
+	return t.handle.addString(row, column, value)
+}
+
+// Rows returns the number of rows currently present in the tablet.
+func (t *Tablet) Rows() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.handle == nil || t.handle.ptr == nil {
+		return 0
+	}
+	return t.handle.rowCount()
+}
+
+// Close releases the native tablet. It is safe to call more than once.
+func (t *Tablet) Close() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.handle == nil {
+		return nil
+	}
+	return t.handle.close()
+}

--- a/go/tsfile/writer.go
+++ b/go/tsfile/writer.go
@@ -1,0 +1,169 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tsfile
+
+import (
+	"fmt"
+	"sync"
+)
+
+const defaultMemoryThreshold = 128 * 1024 * 1024
+
+type writerOptions struct{ memoryThreshold uint64 }
+
+// WriterOption customizes a writer constructor.
+type WriterOption func(*writerOptions) error
+
+// WithMemoryThreshold sets the native writer's in-memory threshold in bytes.
+func WithMemoryThreshold(bytes uint64) WriterOption {
+	return func(options *writerOptions) error {
+		if bytes == 0 {
+			return fmt.Errorf("%w: memory threshold must be positive", ErrInvalidArgument)
+		}
+		options.memoryThreshold = bytes
+		return nil
+	}
+}
+
+// Writer writes tree-model and table-model tablets to one TsFile.
+type Writer struct {
+	mu     sync.Mutex
+	handle *writerHandle
+}
+
+// NewWriter creates or truncates a TsFile at path.
+func NewWriter(path string, options ...WriterOption) (*Writer, error) {
+	settings := writerOptions{memoryThreshold: defaultMemoryThreshold}
+	for _, option := range options {
+		if option == nil {
+			return nil, fmt.Errorf("%w: nil writer option", ErrInvalidArgument)
+		}
+		if err := option(&settings); err != nil {
+			return nil, err
+		}
+	}
+	handle, err := newWriterHandle(path, settings.memoryThreshold)
+	if err != nil {
+		return nil, err
+	}
+	return &Writer{handle: handle}, nil
+}
+
+func (w *Writer) withHandle(fn func(*writerHandle) error) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.handle == nil || w.handle.ptr == nil {
+		return ErrClosed
+	}
+	return fn(w.handle)
+}
+
+// RegisterTable registers a table-model schema.
+func (w *Writer) RegisterTable(schema TableSchema) error {
+	if err := validateCString("register table", "table name", schema.Table); err != nil {
+		return err
+	}
+	if len(schema.Columns) == 0 {
+		return fmt.Errorf("%w: table requires at least one column", ErrInvalidSchema)
+	}
+	for i, column := range schema.Columns {
+		if err := validateCString("register table", "column name", column.Name); err != nil {
+			return fmt.Errorf("column %d: %w", i, err)
+		}
+		if !validDataType(column.DataType) || !validColumnCategory(column.Category) {
+			return fmt.Errorf("%w: invalid column %q", ErrInvalidSchema, column.Name)
+		}
+	}
+	return w.withHandle(func(h *writerHandle) error { return h.registerTable(schema) })
+}
+
+// RegisterTimeseries registers one tree-model measurement for a device.
+func (w *Writer) RegisterTimeseries(device string, schema TimeseriesSchema) error {
+	if err := validateCString("register timeseries", "device", device); err != nil {
+		return err
+	}
+	if err := validateTimeseriesSchema("register timeseries", schema); err != nil {
+		return err
+	}
+	return w.withHandle(func(h *writerHandle) error { return h.registerTimeseries(device, schema) })
+}
+
+// RegisterDevice registers all tree-model measurements for a device.
+func (w *Writer) RegisterDevice(schema DeviceSchema) error {
+	if err := validateCString("register device", "device", schema.Device); err != nil {
+		return err
+	}
+	if len(schema.TimeSeries) == 0 {
+		return fmt.Errorf("%w: device requires at least one timeseries", ErrInvalidSchema)
+	}
+	for i, series := range schema.TimeSeries {
+		if err := validateTimeseriesSchema("register device", series); err != nil {
+			return fmt.Errorf("timeseries %d: %w", i, err)
+		}
+	}
+	return w.withHandle(func(h *writerHandle) error { return h.registerDevice(schema) })
+}
+
+func (w *Writer) writeTablet(tablet *Tablet, tableModel bool) error {
+	if tablet == nil {
+		return fmt.Errorf("%w: nil tablet", ErrInvalidArgument)
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.handle == nil || w.handle.ptr == nil {
+		return ErrClosed
+	}
+	tablet.mu.Lock()
+	defer tablet.mu.Unlock()
+	if tablet.handle == nil || tablet.handle.ptr == nil {
+		return ErrClosed
+	}
+	if tableModel {
+		return w.handle.writeTableTablet(tablet.handle)
+	}
+	return w.handle.writeTreeTablet(tablet.handle)
+}
+
+// WriteTreeTablet writes a tree-model tablet without consuming it.
+func (w *Writer) WriteTreeTablet(tablet *Tablet) error { return w.writeTablet(tablet, false) }
+
+// WriteTableTablet writes a table-model tablet without consuming it.
+func (w *Writer) WriteTableTablet(tablet *Tablet) error { return w.writeTablet(tablet, true) }
+
+// AddProperty adds a binary TsFile property.
+func (w *Writer) AddProperty(key string, value []byte) error {
+	if key == "" {
+		return fmt.Errorf("%w: property key must not be empty", ErrInvalidArgument)
+	}
+	return w.withHandle(func(h *writerHandle) error { return h.addProperty(key, value) })
+}
+
+// Flush writes buffered data without closing the writer.
+func (w *Writer) Flush() error {
+	return w.withHandle(func(h *writerHandle) error { return h.flush() })
+}
+
+// Close flushes and releases the writer. It is idempotent.
+func (w *Writer) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.handle == nil {
+		return nil
+	}
+	return w.handle.close()
+}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -39,9 +39,9 @@ dependencies = [
     "numpy>=1.26.4,<3",
     "pandas>=2.0,<2.3; python_version < '3.13'",
     "pandas>=2.3.3; python_version >= '3.13'",
-    "pyarrow>=16.0,<18; python_version<'3.10'",
-    "pyarrow>=18.0,<20; python_version>='3.10' and python_version<'3.14'",
-    "pyarrow>=22.0,<24; python_version>='3.14'"
+    "pyarrow>=16.0; python_version<'3.13'",
+    "pyarrow>=18.0; python_version>='3.13' and python_version<'3.14'",
+    "pyarrow>=22.0; python_version>='3.14'"
 ]
 
 [project.urls]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,7 +21,9 @@ requires = [
     "setuptools>=69",
     "wheel", 
     "Cython>=3", 
-    "numpy>=1.26.4,<3"
+    "numpy>=1.26.4; python_version<'3.13'",
+    "numpy>=2.1.0; python_version>='3.13' and python_version<'3.14'",
+    "numpy>=2.3.2; python_version>='3.14'"
     ]
 
 build-backend = "setuptools.build_meta"
@@ -36,9 +38,13 @@ maintainers = [
     {name = "Apache TsFile Developers", email = "dev@tsfile.apache.org"}
 ]
 dependencies = [
-    "numpy>=1.26.4,<3",
-    "pandas>=2.0,<2.3; python_version < '3.13'",
-    "pandas>=2.3.3; python_version >= '3.13'",
+    "numpy>=1.26.4; python_version<'3.13'",
+    "numpy>=2.1.0; python_version>='3.13' and python_version<'3.14'",
+    "numpy>=2.3.2; python_version>='3.14'",
+    "pandas>=2.0.0; python_version<'3.12'",
+    "pandas>=2.1.1; python_version>='3.12' and python_version<'3.13'",
+    "pandas>=2.2.3; python_version>='3.13' and python_version<'3.14'",
+    "pandas>=2.3.3; python_version>='3.14'",
     "pyarrow>=16.0; python_version<'3.13'",
     "pyarrow>=18.0; python_version>='3.13' and python_version<'3.14'",
     "pyarrow>=22.0; python_version>='3.14'"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -20,9 +20,13 @@
 cython==3.0.10
 black==25.11.0; python_version < "3.10"
 black==26.3.1; python_version >= "3.10"
-numpy>=1.26.4,<3
-pandas==2.2.2; python_version < "3.13"
-pandas>=2.3.3; python_version >= "3.13"
+numpy>=1.26.4; python_version < "3.13"
+numpy>=2.1.0; python_version >= "3.13" and python_version < "3.14"
+numpy>=2.3.2; python_version >= "3.14"
+pandas>=2.0.0; python_version < "3.12"
+pandas>=2.1.1; python_version >= "3.12" and python_version < "3.13"
+pandas>=2.2.3; python_version >= "3.13" and python_version < "3.14"
+pandas>=2.3.3; python_version >= "3.14"
 setuptools==78.1.1
 wheel==0.46.2
 pyarrow>=16.0; python_version < "3.13"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -25,4 +25,6 @@ pandas==2.2.2; python_version < "3.13"
 pandas>=2.3.3; python_version >= "3.13"
 setuptools==78.1.1
 wheel==0.46.2
-pyarrow>=8.0.0
+pyarrow>=16.0; python_version < "3.13"
+pyarrow>=18.0; python_version >= "3.13" and python_version < "3.14"
+pyarrow>=22.0; python_version >= "3.14"

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -285,8 +285,14 @@ def test_write_dataframe_all_datatypes():
         assert df_read["bool_col"].equals(df_sorted["bool_col"])
         assert df_read["int32_col"].equals(df_sorted["int32_col"])
         assert df_read["int64_col"].equals(df_sorted["int64_col"])
-        assert np.allclose(df_read["float_col"], df_sorted["float_col"])
-        assert np.allclose(df_read["double_col"], df_sorted["double_col"])
+        assert np.allclose(
+            df_read["float_col"].to_numpy(dtype=np.float32, na_value=np.nan),
+            df_sorted["float_col"].to_numpy(dtype=np.float32, na_value=np.nan),
+        )
+        assert np.allclose(
+            df_read["double_col"].to_numpy(dtype=np.float64, na_value=np.nan),
+            df_sorted["double_col"].to_numpy(dtype=np.float64, na_value=np.nan),
+        )
         assert df_read["string_col"].equals(df_sorted["string_col"])
         assert df_read["blob_col"].equals(df_sorted["blob_col"])
         assert df_read["text_col"].equals(df_sorted["text_col"])

--- a/python/tests/test_to_tsfile.py
+++ b/python/tests/test_to_tsfile.py
@@ -299,8 +299,14 @@ def test_dataframe_to_tsfile_all_datatypes():
         assert df_read["bool_col"].equals(df_sorted["bool_col"])
         assert df_read["int32_col"].equals(df_sorted["int32_col"])
         assert df_read["int64_col"].equals(df_sorted["int64_col"])
-        assert np.allclose(df_read["float_col"], df_sorted["float_col"])
-        assert np.allclose(df_read["double_col"], df_sorted["double_col"])
+        assert np.allclose(
+            df_read["float_col"].to_numpy(dtype=np.float32, na_value=np.nan),
+            df_sorted["float_col"].to_numpy(dtype=np.float32, na_value=np.nan),
+        )
+        assert np.allclose(
+            df_read["double_col"].to_numpy(dtype=np.float64, na_value=np.nan),
+            df_sorted["double_col"].to_numpy(dtype=np.float64, na_value=np.nan),
+        )
         assert df_read["string_col"].equals(df_sorted["string_col"])
         assert df_read["text_col"].equals(df_sorted["text_col"])
         assert df_read["date_col"].equals(df_sorted["date_col"])


### PR DESCRIPTION
## Summary

- add a cgo-based Go module with Reader, ResultSet, Writer, Tablet, tree/table schemas, typed values, and error mapping
- expose stable public C writer and exact tree-query entry points without depending on private Python symbols
- add tree/table round-trip tests, lifetime and race coverage, examples, build documentation, and Linux/macOS CI

## Validation

- cmake --build cpp/target/build -j4
- 25 C wrapper tests passed
- go vet ./...
- go test ./...
- go test -race ./...
- GOEXPERIMENT=cgocheck2 go test ./...
- clang-format --dry-run --Werror on changed C/C++ files
- git diff --check

## Scope

This initial API targets Linux amd64 and macOS arm64 with cgo enabled. The native TsFile C++ library remains an explicit prerequisite; the Go module does not install native dependencies. Windows, a pure-Go implementation, Arrow, dataframe APIs, and tag-filter construction are intentionally out of scope.