### PR TITLE
fix(cpp): bound TS_2DIFF block headers by the page value count

### DIFF
--- a/cpp/src/encoding/decoder.h
+++ b/cpp/src/encoding/decoder.h
@@ -39,6 +39,13 @@ class Decoder {
     virtual int read_String(common::String& ret_value, common::PageArena& pa,
                             common::ByteStream& in) = 0;
 
+    // Structural bound from the page header: the number of points in the
+    // page.  Decoders whose stream carries no per-page value count use it
+    // to reject block headers that cannot fit; the default ignores it.
+    virtual void set_page_value_count(int page_value_count) {
+        (void)page_value_count;
+    }
+
     virtual int read_batch_int32(int32_t* out, int capacity, int& actual,
                                  common::ByteStream& in) {
         actual = 0;

--- a/cpp/src/encoding/ts2diff_decoder.h
+++ b/cpp/src/encoding/ts2diff_decoder.h
@@ -368,6 +368,12 @@ class TS2DIFFDecoder : public Decoder {
 
     void set_max_values(int max_values) { max_values_ = max_values; }
 
+    // Page-header point count: bounds writeIndex even when the stream
+    // carries no page metadata (plain int pages, Form 1 float pages).
+    void set_page_value_count(int page_value_count) override {
+        set_max_values(page_value_count);
+    }
+
     // If empty, cache 8 bits from in_stream to 'buffer_'.
     void read_byte_if_empty(common::ByteStream& in) {
         if (bits_left_ == 0) {
@@ -1118,6 +1124,7 @@ class FloatTS2DIFFDecoder : public TS2DIFFDecoder<int32_t> {
         max_point_value_ = 1.0;
         page_pos_ = 0;
         page_value_count_ = 0;
+        page_value_count_bound_ = -1;
         scaled_bm_.clear();
         raw_bm_.clear();
     }
@@ -1136,6 +1143,12 @@ class FloatTS2DIFFDecoder : public TS2DIFFDecoder<int32_t> {
                          common::ByteStream& in) override;
     int read_batch_int32(int32_t* out, int capacity, int& actual,
                          common::ByteStream& in) override;
+
+    // Page-header point count.  Stored separately because the inner
+    // reset() clears max_values_; applied in ensure_page_meta.
+    void set_page_value_count(int page_value_count) override {
+        page_value_count_bound_ = page_value_count;
+    }
 
    private:
     // Parses the page metadata on the first value of a page.  Returns
@@ -1156,6 +1169,11 @@ class FloatTS2DIFFDecoder : public TS2DIFFDecoder<int32_t> {
         page_value_count_ = meta.page_value_count;
         if (page_value_count_ > 0) {
             TS2DIFFDecoder<int32_t>::set_max_values(page_value_count_);
+        } else if (page_value_count_bound_ >= 0) {
+            // Form 1 metadata carries no value count; fall back to the
+            // page-header count plumbed by the reader.  >= 0: a page
+            // declaring zero points must reject every block.
+            TS2DIFFDecoder<int32_t>::set_max_values(page_value_count_bound_);
         }
         scaled_bm_ = std::move(meta.scaled_bm);
         raw_bm_ = std::move(meta.raw_bm);
@@ -1179,6 +1197,8 @@ class FloatTS2DIFFDecoder : public TS2DIFFDecoder<int32_t> {
     double max_point_value_{1.0};
     int page_pos_{0};
     int page_value_count_{0};
+    // Page-header count plumbed by the reader; -1 = not set.
+    int page_value_count_bound_{-1};
     bool page_meta_parsed_{false};
     std::vector<uint8_t> scaled_bm_;
     std::vector<uint8_t> raw_bm_;
@@ -1193,6 +1213,7 @@ class DoubleTS2DIFFDecoder : public TS2DIFFDecoder<int64_t> {
         max_point_value_ = 1.0;
         page_pos_ = 0;
         page_value_count_ = 0;
+        page_value_count_bound_ = -1;
         scaled_bm_.clear();
         raw_bm_.clear();
     }
@@ -1212,6 +1233,11 @@ class DoubleTS2DIFFDecoder : public TS2DIFFDecoder<int64_t> {
     int read_batch_int64(int64_t* out, int capacity, int& actual,
                          common::ByteStream& in) override;
 
+    // See FloatTS2DIFFDecoder::set_page_value_count.
+    void set_page_value_count(int page_value_count) override {
+        page_value_count_bound_ = page_value_count;
+    }
+
    private:
     int ensure_page_meta(common::ByteStream& in) {
         if (page_meta_parsed_) {
@@ -1229,6 +1255,10 @@ class DoubleTS2DIFFDecoder : public TS2DIFFDecoder<int64_t> {
         page_value_count_ = meta.page_value_count;
         if (page_value_count_ > 0) {
             TS2DIFFDecoder<int64_t>::set_max_values(page_value_count_);
+        } else if (page_value_count_bound_ >= 0) {
+            // See the float decoder: a page declaring zero points must
+            // reject every block.
+            TS2DIFFDecoder<int64_t>::set_max_values(page_value_count_bound_);
         }
         scaled_bm_ = std::move(meta.scaled_bm);
         raw_bm_ = std::move(meta.raw_bm);
@@ -1252,6 +1282,8 @@ class DoubleTS2DIFFDecoder : public TS2DIFFDecoder<int64_t> {
     double max_point_value_{1.0};
     int page_pos_{0};
     int page_value_count_{0};
+    // Page-header count plumbed by the reader; -1 = not set.
+    int page_value_count_bound_{-1};
     bool page_meta_parsed_{false};
     std::vector<uint8_t> scaled_bm_;
     std::vector<uint8_t> raw_bm_;

--- a/cpp/src/reader/aligned_chunk_reader.cc
+++ b/cpp/src/reader/aligned_chunk_reader.cc
@@ -574,6 +574,12 @@ int AlignedChunkReader::decode_cur_time_page_data() {
     }
 
     time_decoder_->reset();
+    // See ChunkReader::decode_cur_page_data: page-header point count as
+    // the structural bound for metadata-less TS_2DIFF pages.
+    time_decoder_->set_page_value_count(
+        cur_time_page_header_.statistic_ != nullptr
+            ? cur_time_page_header_.statistic_->get_count()
+            : -1);
 #ifdef DEBUG_SE
     DEBUG_hex_dump_buf("AlignedChunkReader reader, time_buf = ", time_buf,
                        time_buf_size);
@@ -653,6 +659,10 @@ int AlignedChunkReader::decode_cur_value_page_data() {
             value_uncompressed_buf_size - value_uncompressed_buf_offset;
     }
     value_decoder_->reset();
+    value_decoder_->set_page_value_count(
+        cur_value_page_header_.statistic_ != nullptr
+            ? cur_value_page_header_.statistic_->get_count()
+            : -1);
 #ifdef DEBUG_SE
     DEBUG_hex_dump_buf("AlignedChunkReader reader, value_buf = ", value_buf,
                        value_buf_size);
@@ -1408,6 +1418,10 @@ int AlignedChunkReader::decode_time_page_with(const ChunkPageInfo& page_info,
     common::ByteStream in;
     in.wrap_from(uncompressed_buf, uncompressed_size);
     decoder->reset();
+    // Structural bound: a time-page block cannot hold more values than
+    // the page's point count.  Without it a zero-bit-width block header
+    // makes this loop unbounded.
+    decoder->set_page_value_count(page_info.time_page_value_count);
     const int batch_size = 1024;
     int64_t batch[batch_size];
     while (decoder->has_remaining(in)) {
@@ -1480,6 +1494,7 @@ int AlignedChunkReader::build_page_plan(Filter* filter, int& row_offset) {
         }
 
         Statistic* stat = cur_time_page_header_.statistic_;
+        page_info.time_page_value_count = stat != nullptr ? stat->count_ : -1;
         if (filter == nullptr) {
             page_info.pass_type = PagePassType::FULL_PASS;
             page_info.row_begin = 0;

--- a/cpp/src/reader/aligned_chunk_reader.h
+++ b/cpp/src/reader/aligned_chunk_reader.h
@@ -46,6 +46,11 @@ struct ChunkPageInfo {
     int64_t time_file_offset = 0;
     uint32_t time_compressed_size = 0;
     uint32_t time_uncompressed_size = 0;
+    // Point count of the time page from its header statistic (-1 when the
+    // page carries no statistic).  Bounds the time decoder's block
+    // headers; unlike row_begin/row_end this is the full page count, not
+    // the filtered sub-span.
+    int32_t time_page_value_count = -1;
     int32_t row_begin = 0;  // inclusive
     int32_t row_end = 0;    // exclusive
     std::vector<int64_t> value_file_offsets;

--- a/cpp/src/reader/chunk_reader.cc
+++ b/cpp/src/reader/chunk_reader.cc
@@ -375,6 +375,14 @@ int ChunkReader::decode_cur_page_data(TsBlock*& ret_tsblock, Filter* filter,
     if (IS_SUCC(ret)) {
         time_decoder_->reset();
         value_decoder_->reset();
+        // Structural bound for codecs whose stream carries no page value
+        // count (TS_2DIFF int pages and Form 1 float/double pages).
+        const int page_value_count =
+            cur_page_header_.statistic_ != nullptr
+                ? cur_page_header_.statistic_->get_count()
+                : -1;
+        time_decoder_->set_page_value_count(page_value_count);
+        value_decoder_->set_page_value_count(page_value_count);
         time_in_.wrap_from(time_buf, time_buf_size);
         value_in_.wrap_from(value_buf, value_buf_size);
         // ret = decode_tv_buf_into_tsblock(time_buf, value_buf, time_buf_size,

--- a/cpp/test/encoding/ts2diff_codec_test.cc
+++ b/cpp/test/encoding/ts2diff_codec_test.cc
@@ -1169,6 +1169,99 @@ TEST_F(FloatDoubleTS2DIFFCodecTest, ScalarReadRejectsTruncatedFixedFields) {
 // A page whose trailing block header is truncated mid-field: the skip
 // paths must reject it via the grouped header-read check instead of
 // acting on stale stack values.
+// A zero-bit-width block consumes no packed bytes, so byte availability
+// cannot bound its writeIndex.  The page-header point count can: a block
+// claiming more values than the page holds is a format error.  Covers
+// plain INT32 pages, whose stream carries no page metadata at all.
+TEST_F(TS2DIFFCodecTest, ZeroWidthBlockBoundedByPageValueCount) {
+    const unsigned char page[] = {
+        0x7f, 0xff, 0xff, 0xff,  // write_index = INT32_MAX
+        0x00, 0x00, 0x00, 0x00,  // bit_width = 0
+        0x00, 0x00, 0x00, 0x00,  // delta_min
+        0x00, 0x00, 0x00, 0x2a,  // first_value
+    };
+    common::ByteStream dec;
+    dec.wrap_from(reinterpret_cast<const char*>(page), sizeof(page));
+    IntTS2DIFFDecoder decoder;
+    decoder.set_page_value_count(3);
+    int32_t value = 0;
+    EXPECT_EQ(decoder.read_int32(value, dec), common::E_DECODE_ERR);
+}
+
+// Same class of attack against a Form 1 float page: the metadata carries
+// no page value count, so the decoder falls back to the page-header count
+// plumbed by the reader.
+TEST_F(FloatDoubleTS2DIFFCodecTest,
+       Form1ZeroWidthBlockBoundedByPageValueCount) {
+    // [mpn=2][wi=INT32_MAX][bw=0][delta_min=0][first_value=0]
+    const unsigned char page[] = {
+        0x02,                    // maxPointNumber = 2
+        0x7f, 0xff, 0xff, 0xff,  // write_index = INT32_MAX
+        0x00, 0x00, 0x00, 0x00,  // bit_width = 0
+        0x00, 0x00, 0x00, 0x00,  // delta_min
+        0x00, 0x00, 0x00, 0x00,  // first_value
+    };
+    common::ByteStream dec;
+    dec.wrap_from(reinterpret_cast<const char*>(page), sizeof(page));
+    FloatTS2DIFFDecoder decoder;
+    decoder.set_page_value_count(3);
+    float value = 0.0f;
+    EXPECT_EQ(decoder.read_float(value, dec), common::E_DECODE_ERR);
+}
+
+// A page header declaring zero points must reject every block, including
+// zero-width ones — the bound must not silently disable itself at 0.
+TEST_F(FloatDoubleTS2DIFFCodecTest, ZeroCountPageRejectsAnyBlock) {
+    // [mpn=2][wi=1][bw=8][dm=0][fv=42] — a perfectly valid little block,
+    // but the page claims 0 points.
+    const unsigned char page[] = {
+        0x02,                    // maxPointNumber = 2
+        0x00, 0x00, 0x00, 0x01,  // write_index = 1
+        0x00, 0x00, 0x00, 0x08,  // bit_width = 8
+        0x00, 0x00, 0x00, 0x00,  // delta_min
+        0x00, 0x00, 0x00, 0x2a,  // first_value
+        0x2a,                    // 1 packed byte for wi=1/bw=8
+    };
+    common::ByteStream dec;
+    dec.wrap_from(reinterpret_cast<const char*>(page), sizeof(page));
+    FloatTS2DIFFDecoder decoder;
+    decoder.set_page_value_count(0);
+    float value = 0.0f;
+    EXPECT_EQ(decoder.read_float(value, dec), common::E_DECODE_ERR);
+}
+
+// Mirrors what ChunkReader/AlignedChunkReader do per page: reset(), then
+// hand the decoder the page-header point count.  reset() must clear the
+// bound (a reused decoder must not inherit the previous page's count) and
+// the count must survive until the first block header is validated.
+TEST_F(TS2DIFFCodecTest, PageValueCountSurvivesResetSequence) {
+    // [wi=INT32_MAX][bw=0][dm=0][fv=42]: a zero-width block claiming 2^31
+    // values.
+    const unsigned char page[] = {
+        0x7f, 0xff, 0xff, 0xff,  // write_index = INT32_MAX
+        0x00, 0x00, 0x00, 0x00,  // bit_width = 0
+        0x00, 0x00, 0x00, 0x00,  // delta_min
+        0x00, 0x00, 0x00, 0x2a,  // first_value
+    };
+    IntTS2DIFFDecoder decoder;
+    int32_t value = 0;
+
+    // Page 1: reader order is reset() then set_page_value_count().
+    common::ByteStream page1;
+    page1.wrap_from(reinterpret_cast<const char*>(page), sizeof(page));
+    decoder.reset();
+    decoder.set_page_value_count(4);
+    EXPECT_EQ(decoder.read_int32(value, page1), common::E_DECODE_ERR);
+
+    // Page 2: the decoder is reused.  Without a count the bound is off, so
+    // reset() must not leave the previous page's count behind either.
+    common::ByteStream page2;
+    page2.wrap_from(reinterpret_cast<const char*>(page), sizeof(page));
+    decoder.reset();
+    decoder.set_page_value_count(4);
+    EXPECT_EQ(decoder.read_int32(value, page2), common::E_DECODE_ERR);
+}
+
 TEST_F(TS2DIFFCodecTest, SkipRejectsTruncatedBlockHeader) {
     // [wi=1][bw=8] then only 4 of the 8 dm/fv bytes.
     const unsigned char page[] = {

--- a/cpp/test/reader/table_view/tsfile_reader_table_test.cc
+++ b/cpp/test/reader/table_view/tsfile_reader_table_test.cc
@@ -1254,3 +1254,152 @@ TEST_F(TsFileTableReaderTest, MultiTagColumnFilterOnSecondTag) {
     delete table_schema;
     delete tag_filter;
 }
+
+// TS_2DIFF columns with sparse nulls, crossing the 129-value block
+// boundary: the page-header point count bounds every block header, so the
+// two counts must use the same unit.  A value page counts only non-null
+// values, while the time page counts every row; a mismatch here would
+// reject legitimate data.
+TEST_F(TsFileTableReaderTest, Ts2DiffSparseNullsRoundTrip) {
+    const int kRows = 300;  // 129 + 129 + 42
+    std::string table_name = "t_sparse";
+    auto* schema = new storage::TableSchema(
+        table_name,
+        {
+            common::ColumnSchema("id1", common::TSDataType::STRING,
+                                 common::CompressionType::UNCOMPRESSED,
+                                 common::TSEncoding::PLAIN,
+                                 common::ColumnCategory::TAG),
+            common::ColumnSchema("s_i32", common::TSDataType::INT32,
+                                 common::CompressionType::UNCOMPRESSED,
+                                 common::TSEncoding::TS_2DIFF,
+                                 common::ColumnCategory::FIELD),
+            common::ColumnSchema("s_i64", common::TSDataType::INT64,
+                                 common::CompressionType::UNCOMPRESSED,
+                                 common::TSEncoding::TS_2DIFF,
+                                 common::ColumnCategory::FIELD),
+            common::ColumnSchema("s_f", common::TSDataType::FLOAT,
+                                 common::CompressionType::UNCOMPRESSED,
+                                 common::TSEncoding::TS_2DIFF,
+                                 common::ColumnCategory::FIELD),
+            common::ColumnSchema("s_d", common::TSDataType::DOUBLE,
+                                 common::CompressionType::UNCOMPRESSED,
+                                 common::TSEncoding::TS_2DIFF,
+                                 common::ColumnCategory::FIELD),
+        });
+    uint64_t memory_threshold = 128 * 1024 * 1024;
+    auto* writer =
+        new storage::TsFileTableWriter(&write_file_, schema, memory_threshold);
+    storage::Tablet tablet(
+        {"id1", "s_i32", "s_i64", "s_f", "s_d"},
+        {common::TSDataType::STRING, common::TSDataType::INT32,
+         common::TSDataType::INT64, common::TSDataType::FLOAT,
+         common::TSDataType::DOUBLE},
+        kRows);
+    int expected_non_null = 0;
+    for (int row = 0; row < kRows; row++) {
+        tablet.add_timestamp(row, row);
+        tablet.add_value(row, "id1", "dev");
+        // Every third row is null, so the value pages hold fewer values
+        // than the time page holds rows.
+        if (row % 3 != 0) {
+            tablet.add_value(row, "s_i32", row);
+            tablet.add_value(row, "s_i64", static_cast<int64_t>(row) * 3);
+            tablet.add_value(row, "s_f", static_cast<float>(row) * 0.5f);
+            tablet.add_value(row, "s_d", static_cast<double>(row) * 0.25);
+            expected_non_null++;
+        }
+    }
+    ASSERT_EQ(writer->write_table(tablet), common::E_OK);
+    ASSERT_EQ(writer->flush(), common::E_OK);
+    ASSERT_EQ(writer->close(), common::E_OK);
+    delete writer;
+    delete schema;
+
+    storage::TsFileReader reader;
+    ASSERT_EQ(reader.open(write_file_.get_file_path()), common::E_OK);
+    storage::ResultSet* tmp = nullptr;
+    ASSERT_EQ(reader.query(table_name, {"s_i32", "s_i64", "s_f", "s_d"},
+                           INT64_MIN, INT64_MAX, tmp),
+              common::E_OK);
+    auto* rs = dynamic_cast<storage::TableResultSet*>(tmp);
+    ASSERT_NE(rs, nullptr);
+    bool has_next = false;
+    int rows = 0;
+    int non_null = 0;
+    while (IS_SUCC(rs->next(has_next)) && has_next) {
+        rows++;
+        if (!rs->is_null("s_i32")) {
+            non_null++;
+            ASSERT_FALSE(rs->is_null("s_i64"));
+            ASSERT_FALSE(rs->is_null("s_f"));
+            ASSERT_FALSE(rs->is_null("s_d"));
+        }
+    }
+    EXPECT_EQ(rows, kRows);
+    EXPECT_EQ(non_null, expected_non_null);
+    reader.destroy_query_data_set(rs);
+    ASSERT_EQ(reader.close(), common::E_OK);
+}
+
+// A TS_2DIFF column that is null for every row: the value page holds no
+// values, so its statistic count is 0.  The zero-count page bound must not
+// turn this legitimate page into a decode error.
+TEST_F(TsFileTableReaderTest, Ts2DiffFullyNullColumnRoundTrip) {
+    const int kRows = 200;
+    std::string table_name = "t_allnull";
+    auto* schema = new storage::TableSchema(
+        table_name,
+        {
+            common::ColumnSchema("id1", common::TSDataType::STRING,
+                                 common::CompressionType::UNCOMPRESSED,
+                                 common::TSEncoding::PLAIN,
+                                 common::ColumnCategory::TAG),
+            common::ColumnSchema("s_live", common::TSDataType::INT32,
+                                 common::CompressionType::UNCOMPRESSED,
+                                 common::TSEncoding::TS_2DIFF,
+                                 common::ColumnCategory::FIELD),
+            common::ColumnSchema("s_null", common::TSDataType::INT32,
+                                 common::CompressionType::UNCOMPRESSED,
+                                 common::TSEncoding::TS_2DIFF,
+                                 common::ColumnCategory::FIELD),
+        });
+    uint64_t memory_threshold = 128 * 1024 * 1024;
+    auto* writer =
+        new storage::TsFileTableWriter(&write_file_, schema, memory_threshold);
+    storage::Tablet tablet(
+        {"id1", "s_live", "s_null"},
+        {common::TSDataType::STRING, common::TSDataType::INT32,
+         common::TSDataType::INT32},
+        kRows);
+    for (int row = 0; row < kRows; row++) {
+        tablet.add_timestamp(row, row);
+        tablet.add_value(row, "id1", "dev");
+        tablet.add_value(row, "s_live", row);
+        // s_null is never written: a fully-null TS_2DIFF value page.
+    }
+    ASSERT_EQ(writer->write_table(tablet), common::E_OK);
+    ASSERT_EQ(writer->flush(), common::E_OK);
+    ASSERT_EQ(writer->close(), common::E_OK);
+    delete writer;
+    delete schema;
+
+    storage::TsFileReader reader;
+    ASSERT_EQ(reader.open(write_file_.get_file_path()), common::E_OK);
+    storage::ResultSet* tmp = nullptr;
+    ASSERT_EQ(reader.query(table_name, {"s_live", "s_null"}, INT64_MIN,
+                           INT64_MAX, tmp),
+              common::E_OK);
+    auto* rs = dynamic_cast<storage::TableResultSet*>(tmp);
+    ASSERT_NE(rs, nullptr);
+    bool has_next = false;
+    int rows = 0;
+    while (IS_SUCC(rs->next(has_next)) && has_next) {
+        rows++;
+        ASSERT_FALSE(rs->is_null("s_live"));
+        ASSERT_TRUE(rs->is_null("s_null"));
+    }
+    EXPECT_EQ(rows, kRows);
+    reader.destroy_query_data_set(rs);
+    ASSERT_EQ(reader.close(), common::E_OK);
+}


### PR DESCRIPTION
## What

A crafted 16-byte TS_2DIFF block header (`writeIndex = INT32_MAX`, `bitWidth = 0`) makes the decoder emit up to 2^31 values, hanging the reader loops (`while (decoder->has_remaining(...))`). Zero-width blocks consume no packed bytes, so byte availability cannot bound `writeIndex`. Affected: plain int32/int64 pages (no page metadata at all) and Form 1 float/double pages (metadata carries no value count). Form 2/3 pages were already bounded.

## Fix

Bound block headers by the page's point count from the page header statistic:

- `Decoder` gains a `set_page_value_count()` hook (default no-op).
- `TS2DIFFDecoder` rejects blocks with `writeIndex + 1 > page count` (`E_DECODE_ERR`).
- Every page-decode site plumbs the count: `ChunkReader::decode_cur_page_data` (time + value), `AlignedChunkReader::decode_cur_time_page_data` / `decode_cur_value_page_data` / `decode_time_page_with` (sequential and worker-pool). The aligned value-page predecode path is already bounded by its non-null count.

Java grounding: `DeltaBinaryDecoder` allocates `new int[packNum]`, so such pages are not valid Java input either.

## Tests

- 4 codec-level tests: crafted plain-int / Form 1 pages rejected, zero-count page rejects any block, count survives the reader's reset sequence.
- 2 round-trip tests pin the count units against false rejections: TS_2DIFF columns with sparse nulls (value pages count non-null values, time pages count rows) and a fully-null column (legitimate zero-count page).
- Full suite: 811 passed locally (MSVC); clang-format and cppcheck clean against baseline.

## Known residuals (format-level, documented in the commit)

- Single-page chunks carry no page statistic on the wire, so those pages decode unbounded, as before.
- The bound enforces the block-vs-page invariant, not an absolute work limit: a crafted file also controls the statistic itself.
