### PR TITLE
perf(cpp): cache per-device schema check for repeated tablet writes (#885)

### DIFF
--- a/cpp/src/common/schema.h
+++ b/cpp/src/common/schema.h
@@ -28,6 +28,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "common/db_common.h"
 #include "writer/time_chunk_writer.h"
@@ -175,6 +176,30 @@ struct MeasurementSchemaGroup {
     bool is_aligned_ = false;
     TimeChunkWriter* time_chunk_writer_ = nullptr;
     int64_t last_time_ = INT64_MIN;
+
+    // Per-device schema-check cache (do_check_schema /
+    // do_check_schema_aligned): the resolved chunk writers + data types for
+    // the last fully-resolved measurement-name sequence, so repeated writes
+    // with an unchanged schema skip the per-column measurement_schema_map_
+    // string lookup (#885). Entries are the SAME non-owning pointers the
+    // uncached path returns, so the written file is byte-identical.
+    //
+    // Guarded by the measurement NAME SEQUENCE, not just the column count:
+    // entries are reused by position, so the same count with a different
+    // name order (or one column swapped) would silently write values into
+    // the wrong column AND with the wrong data type.
+    //
+    // The plain and aligned paths keep separate caches: sharing one flag
+    // would let whichever path ran first lock the other out permanently.
+    std::vector<ChunkWriter*> cached_chunk_writers_;
+    std::vector<common::TSDataType> cached_data_types_;
+    std::vector<std::string> cached_measurement_names_;
+    bool schema_check_cached_ = false;
+
+    std::vector<ValueChunkWriter*> cached_value_chunk_writers_;
+    std::vector<common::TSDataType> cached_aligned_data_types_;
+    std::vector<std::string> cached_aligned_measurement_names_;
+    bool schema_check_aligned_cached_ = false;
 
     ~MeasurementSchemaGroup() {
         if (time_chunk_writer_ != nullptr) {

--- a/cpp/src/writer/tsfile_writer.cc
+++ b/cpp/src/writer/tsfile_writer.cc
@@ -468,10 +468,48 @@ int TsFileWriter::do_check_schema(
     }
     MeasurementSchemaMap& msm = device_schema->measurement_schema_map_;
     uint32_t measurement_count = measurement_names.get_count();
-    // chunk_writers.reserve(measurement_count);
+    // The getter is single-pass (next() advances an index), so buffer the
+    // name sequence up front. next() returns a reference, so this buffers
+    // pointers rather than copies, which lets the cache check below compare
+    // the real names and still fall through to the full lookup on mismatch.
+    static thread_local std::vector<const std::string*> names;
+    names.clear();
+    names.reserve(measurement_count);
     for (uint32_t i = 0; i < measurement_count; i++) {
-        auto ms_iter = msm.find(measurement_names.next());
+        names.push_back(&measurement_names.next());
+    }
+    // Column count alone is not a safe cache key: entries are reused by
+    // position, so the same count with a different name order (or one column
+    // swapped) would silently write values into the wrong column with the
+    // wrong data type.
+    if (device_schema->schema_check_cached_ &&
+        device_schema->cached_measurement_names_.size() == measurement_count) {
+        bool same_schema = true;
+        for (uint32_t i = 0; i < measurement_count; i++) {
+            if (device_schema->cached_measurement_names_[i] != *names[i]) {
+                same_schema = false;
+                break;
+            }
+        }
+        if (same_schema) {
+            for (uint32_t i = 0; i < measurement_count; i++) {
+                chunk_writers.push_back(
+                    device_schema->cached_chunk_writers_[i]);
+                data_types.push_back(device_schema->cached_data_types_[i]);
+            }
+            return E_OK;
+        }
+        // Schema changed for this device: drop the stale cache and re-resolve.
+        device_schema->cached_chunk_writers_.clear();
+        device_schema->cached_data_types_.clear();
+        device_schema->cached_measurement_names_.clear();
+        device_schema->schema_check_cached_ = false;
+    }
+    bool all_resolved = true;
+    for (uint32_t i = 0; i < measurement_count; i++) {
+        auto ms_iter = msm.find(*names[i]);
         if (UNLIKELY(ms_iter == msm.end())) {
+            all_resolved = false;
             chunk_writers.push_back(NULL);
             data_types.push_back(common::NULL_TYPE);
         } else {
@@ -502,6 +540,22 @@ int TsFileWriter::do_check_schema(
             data_types.push_back(ms->data_type_);
         }
     }
+    // Cache only fully-resolved results: a NULL entry for a measurement that
+    // is not registered yet would keep masking the column even after it is
+    // registered later.
+    if (IS_SUCC(ret) && all_resolved) {
+        device_schema->cached_chunk_writers_.reserve(measurement_count);
+        device_schema->cached_data_types_.reserve(measurement_count);
+        for (uint32_t i = 0; i < measurement_count; i++) {
+            device_schema->cached_chunk_writers_.push_back(chunk_writers[i]);
+            device_schema->cached_data_types_.push_back(data_types[i]);
+        }
+        device_schema->cached_measurement_names_.reserve(measurement_count);
+        for (uint32_t i = 0; i < measurement_count; i++) {
+            device_schema->cached_measurement_names_.push_back(*names[i]);
+        }
+        device_schema->schema_check_cached_ = true;
+    }
     return ret;
 }
 
@@ -528,9 +582,46 @@ int TsFileWriter::do_check_schema_aligned(
     time_chunk_writer = device_schema->time_chunk_writer_;
     MeasurementSchemaMap& msm = device_schema->measurement_schema_map_;
     uint32_t measurement_count = measurement_names.get_count();
+    // Same single-pass buffering + name-sequence guard as do_check_schema;
+    // see the comment there and on MeasurementSchemaGroup. This path keeps
+    // its own cache because sharing one flag with the plain path locked
+    // whichever ran second out.
+    static thread_local std::vector<const std::string*> names;
+    names.clear();
+    names.reserve(measurement_count);
     for (uint32_t i = 0; i < measurement_count; i++) {
-        auto ms_iter = msm.find(measurement_names.next());
+        names.push_back(&measurement_names.next());
+    }
+    if (device_schema->schema_check_aligned_cached_ &&
+        device_schema->cached_aligned_measurement_names_.size() ==
+            measurement_count) {
+        bool same_schema = true;
+        for (uint32_t i = 0; i < measurement_count; i++) {
+            if (device_schema->cached_aligned_measurement_names_[i] !=
+                *names[i]) {
+                same_schema = false;
+                break;
+            }
+        }
+        if (same_schema) {
+            for (uint32_t i = 0; i < measurement_count; i++) {
+                value_chunk_writers.push_back(
+                    device_schema->cached_value_chunk_writers_[i]);
+                data_types.push_back(
+                    device_schema->cached_aligned_data_types_[i]);
+            }
+            return E_OK;
+        }
+        device_schema->cached_value_chunk_writers_.clear();
+        device_schema->cached_aligned_data_types_.clear();
+        device_schema->cached_aligned_measurement_names_.clear();
+        device_schema->schema_check_aligned_cached_ = false;
+    }
+    bool all_resolved = true;
+    for (uint32_t i = 0; i < measurement_count; i++) {
+        auto ms_iter = msm.find(*names[i]);
         if (UNLIKELY(ms_iter == msm.end())) {
+            all_resolved = false;
             value_chunk_writers.push_back(NULL);
             data_types.push_back(common::NULL_TYPE);
         } else {
@@ -561,6 +652,23 @@ int TsFileWriter::do_check_schema_aligned(
             }
             data_types.push_back(ms->data_type_);
         }
+    }
+    // See do_check_schema: never cache a result with unresolved columns.
+    if (IS_SUCC(ret) && all_resolved) {
+        device_schema->cached_value_chunk_writers_.reserve(measurement_count);
+        device_schema->cached_aligned_data_types_.reserve(measurement_count);
+        for (uint32_t i = 0; i < measurement_count; i++) {
+            device_schema->cached_value_chunk_writers_.push_back(
+                value_chunk_writers[i]);
+            device_schema->cached_aligned_data_types_.push_back(data_types[i]);
+        }
+        device_schema->cached_aligned_measurement_names_.reserve(
+            measurement_count);
+        for (uint32_t i = 0; i < measurement_count; i++) {
+            device_schema->cached_aligned_measurement_names_.push_back(
+                *names[i]);
+        }
+        device_schema->schema_check_aligned_cached_ = true;
     }
     return ret;
 }

--- a/cpp/src/writer/tsfile_writer.cc
+++ b/cpp/src/writer/tsfile_writer.cc
@@ -88,7 +88,31 @@ TsFileWriter::TsFileWriter()
 
 TsFileWriter::~TsFileWriter() { destroy(); }
 
+void TsFileWriter::clear_schema_check_cache() {
+    plain_schema_check_cache_.clear();
+    aligned_schema_check_cache_.clear();
+}
+
+bool TsFileWriter::plain_schema_cache_matches(
+    const std::shared_ptr<IDeviceID>& device_id,
+    const std::vector<std::string>& measurement_names) const {
+    return plain_schema_check_cache_.valid_ &&
+           plain_schema_check_cache_.device_id_ != nullptr &&
+           *plain_schema_check_cache_.device_id_ == *device_id &&
+           plain_schema_check_cache_.measurement_names_ == measurement_names;
+}
+
+bool TsFileWriter::aligned_schema_cache_matches(
+    const std::shared_ptr<IDeviceID>& device_id,
+    const std::vector<std::string>& measurement_names) const {
+    return aligned_schema_check_cache_.valid_ &&
+           aligned_schema_check_cache_.device_id_ != nullptr &&
+           *aligned_schema_check_cache_.device_id_ == *device_id &&
+           aligned_schema_check_cache_.measurement_names_ == measurement_names;
+}
+
 void TsFileWriter::destroy() {
+    clear_schema_check_cache();
     if (write_file_created_ && write_file_ != nullptr) {
         delete write_file_;
         write_file_ = nullptr;
@@ -141,6 +165,7 @@ int TsFileWriter::init(WriteFile* write_file) {
     // the new file and produce headerless output.
     enforce_recovered_last_time_order_ = false;
     unrecoverable_ = false;
+    clear_schema_check_cache();
     start_file_done_ = false;
     record_count_since_last_flush_ = 0;
     io_writer_ = new TsFileIOWriter();
@@ -165,6 +190,7 @@ int TsFileWriter::init(RestorableTsFileIOWriter* rw) {
     // Clear any unrecoverable_ latched from a previous lifecycle so the
     // re-init isn't immediately poisoned.
     unrecoverable_ = false;
+    clear_schema_check_cache();
     // Reject new writes whose timestamps fall back into the recovered range.
     enforce_recovered_last_time_order_ = true;
     io_writer_ = rw;
@@ -213,13 +239,22 @@ int TsFileWriter::init(RestorableTsFileIOWriter* rw) {
             if (mname.empty()) {
                 continue;
             }
-            if (group->measurement_schema_map_.find(mname) !=
-                group->measurement_schema_map_.end()) {
-                continue;
+            auto schema_it = group->measurement_schema_map_.find(mname);
+            if (schema_it == group->measurement_schema_map_.end()) {
+                MeasurementSchema* ms =
+                    new MeasurementSchema(mname, cm->data_type_, cm->encoding_,
+                                          cm->compression_type_);
+                group->measurement_schema_map_.insert(
+                    std::make_pair(mname, ms));
+            } else {
+                // A series may have different codecs in different chunks.
+                // Appends must use the latest chunk's codec, not the first
+                // recovered chunk's stale settings.
+                MeasurementSchema* ms = schema_it->second;
+                ms->data_type_ = cm->data_type_;
+                ms->encoding_ = cm->encoding_;
+                ms->compression_type_ = cm->compression_type_;
             }
-            MeasurementSchema* ms = new MeasurementSchema(
-                mname, cm->data_type_, cm->encoding_, cm->compression_type_);
-            group->measurement_schema_map_.insert(std::make_pair(mname, ms));
         }
     }
 
@@ -330,12 +365,14 @@ int TsFileWriter::register_timeseries(const std::string& device_path,
         if (UNLIKELY(!ins_res.second)) {
             return E_ALREADY_EXIST;
         }
+        clear_schema_check_cache();
     } else {
         MeasurementSchemaGroup* ms_group = new MeasurementSchemaGroup;
         ms_group->is_aligned_ = is_aligned;
         ms_group->measurement_schema_map_.insert(std::make_pair(
             measurement_schema->measurement_name_, measurement_schema));
         schemas_.insert(std::make_pair(device_id, ms_group));
+        clear_schema_check_cache();
     }
     return E_OK;
 }
@@ -466,95 +503,59 @@ int TsFileWriter::do_check_schema(
         IS_NULL(device_schema = dev_it->second)) {
         return E_DEVICE_NOT_EXIST;
     }
+
     MeasurementSchemaMap& msm = device_schema->measurement_schema_map_;
-    uint32_t measurement_count = measurement_names.get_count();
-    // The getter is single-pass (next() advances an index), so buffer the
-    // name sequence up front. next() returns a reference, so this buffers
-    // pointers rather than copies, which lets the cache check below compare
-    // the real names and still fall through to the full lookup on mismatch.
-    static thread_local std::vector<const std::string*> names;
+    static thread_local std::vector<std::string> names;
     names.clear();
-    names.reserve(measurement_count);
-    for (uint32_t i = 0; i < measurement_count; i++) {
-        names.push_back(&measurement_names.next());
+    names.reserve(measurement_names.get_count());
+    for (uint32_t i = 0; i < measurement_names.get_count(); ++i) {
+        names.push_back(measurement_names.next());
     }
-    // Column count alone is not a safe cache key: entries are reused by
-    // position, so the same count with a different name order (or one column
-    // swapped) would silently write values into the wrong column with the
-    // wrong data type.
-    if (device_schema->schema_check_cached_ &&
-        device_schema->cached_measurement_names_.size() == measurement_count) {
-        bool same_schema = true;
-        for (uint32_t i = 0; i < measurement_count; i++) {
-            if (device_schema->cached_measurement_names_[i] != *names[i]) {
-                same_schema = false;
-                break;
-            }
+    if (plain_schema_cache_matches(device_id, names)) {
+        for (size_t i = 0; i < plain_schema_check_cache_.chunk_writers_.size();
+             ++i) {
+            chunk_writers.push_back(
+                plain_schema_check_cache_.chunk_writers_[i]);
+            data_types.push_back(plain_schema_check_cache_.data_types_[i]);
         }
-        if (same_schema) {
-            for (uint32_t i = 0; i < measurement_count; i++) {
-                chunk_writers.push_back(
-                    device_schema->cached_chunk_writers_[i]);
-                data_types.push_back(device_schema->cached_data_types_[i]);
-            }
-            return E_OK;
-        }
-        // Schema changed for this device: drop the stale cache and re-resolve.
-        device_schema->cached_chunk_writers_.clear();
-        device_schema->cached_data_types_.clear();
-        device_schema->cached_measurement_names_.clear();
-        device_schema->schema_check_cached_ = false;
+        return E_OK;
     }
+
     bool all_resolved = true;
-    for (uint32_t i = 0; i < measurement_count; i++) {
-        auto ms_iter = msm.find(*names[i]);
+    for (uint32_t i = 0; i < names.size(); ++i) {
+        auto ms_iter = msm.find(names[i]);
         if (UNLIKELY(ms_iter == msm.end())) {
             all_resolved = false;
             chunk_writers.push_back(NULL);
             data_types.push_back(common::NULL_TYPE);
-        } else {
-            // In Java we will check data_type. But in C++, no check here.
-            // Because checks are performed at the chunk layer and page layer
-            MeasurementSchema* ms = ms_iter->second;
-            if (IS_NULL(ms->chunk_writer_)) {
-                ms->chunk_writer_ = new ChunkWriter;
-                ret = ms->chunk_writer_->init(ms->measurement_name_,
-                                              ms->data_type_, ms->encoding_,
-                                              ms->compression_type_);
-                if (IS_SUCC(ret)) {
-                    chunk_writers.push_back(ms->chunk_writer_);
-                } else {
-                    for (size_t chunk_writer_idx = 0;
-                         chunk_writer_idx < chunk_writers.size();
-                         chunk_writer_idx++) {
-                        if (!chunk_writers[chunk_writer_idx]) {
-                            delete chunk_writers[chunk_writer_idx];
-                        }
-                    }
-                    ret = common::E_INVALID_ARG;
-                    return ret;
-                }
-            } else {
-                chunk_writers.push_back(ms->chunk_writer_);
+            continue;
+        }
+
+        MeasurementSchema* ms = ms_iter->second;
+        if (IS_NULL(ms->chunk_writer_)) {
+            ms->chunk_writer_ = new ChunkWriter;
+            ret = ms->chunk_writer_->init(ms->measurement_name_, ms->data_type_,
+                                          ms->encoding_, ms->compression_type_);
+            if (IS_FAIL(ret)) {
+                ret = common::E_INVALID_ARG;
+                return ret;
             }
-            data_types.push_back(ms->data_type_);
         }
+        chunk_writers.push_back(ms->chunk_writer_);
+        data_types.push_back(ms->data_type_);
     }
-    // Cache only fully-resolved results: a NULL entry for a measurement that
-    // is not registered yet would keep masking the column even after it is
-    // registered later.
+
     if (IS_SUCC(ret) && all_resolved) {
-        device_schema->cached_chunk_writers_.reserve(measurement_count);
-        device_schema->cached_data_types_.reserve(measurement_count);
-        for (uint32_t i = 0; i < measurement_count; i++) {
-            device_schema->cached_chunk_writers_.push_back(chunk_writers[i]);
-            device_schema->cached_data_types_.push_back(data_types[i]);
+        plain_schema_check_cache_.valid_ = true;
+        plain_schema_check_cache_.device_id_ = device_id;
+        plain_schema_check_cache_.measurement_names_ = names;
+        plain_schema_check_cache_.chunk_writers_.clear();
+        plain_schema_check_cache_.data_types_.clear();
+        for (uint32_t i = 0; i < names.size(); ++i) {
+            plain_schema_check_cache_.chunk_writers_.push_back(
+                chunk_writers[i]);
+            plain_schema_check_cache_.data_types_.push_back(data_types[i]);
         }
-        device_schema->cached_measurement_names_.reserve(measurement_count);
-        for (uint32_t i = 0; i < measurement_count; i++) {
-            device_schema->cached_measurement_names_.push_back(*names[i]);
-        }
-        device_schema->schema_check_cached_ = true;
     }
     return ret;
 }
@@ -580,95 +581,60 @@ int TsFileWriter::do_check_schema_aligned(
             g_config_value_.time_compress_type_);
     }
     time_chunk_writer = device_schema->time_chunk_writer_;
+
     MeasurementSchemaMap& msm = device_schema->measurement_schema_map_;
-    uint32_t measurement_count = measurement_names.get_count();
-    // Same single-pass buffering + name-sequence guard as do_check_schema;
-    // see the comment there and on MeasurementSchemaGroup. This path keeps
-    // its own cache because sharing one flag with the plain path locked
-    // whichever ran second out.
-    static thread_local std::vector<const std::string*> names;
+    static thread_local std::vector<std::string> names;
     names.clear();
-    names.reserve(measurement_count);
-    for (uint32_t i = 0; i < measurement_count; i++) {
-        names.push_back(&measurement_names.next());
+    names.reserve(measurement_names.get_count());
+    for (uint32_t i = 0; i < measurement_names.get_count(); ++i) {
+        names.push_back(measurement_names.next());
     }
-    if (device_schema->schema_check_aligned_cached_ &&
-        device_schema->cached_aligned_measurement_names_.size() ==
-            measurement_count) {
-        bool same_schema = true;
-        for (uint32_t i = 0; i < measurement_count; i++) {
-            if (device_schema->cached_aligned_measurement_names_[i] !=
-                *names[i]) {
-                same_schema = false;
-                break;
-            }
+    if (aligned_schema_cache_matches(device_id, names)) {
+        for (size_t i = 0;
+             i < aligned_schema_check_cache_.value_chunk_writers_.size(); ++i) {
+            value_chunk_writers.push_back(
+                aligned_schema_check_cache_.value_chunk_writers_[i]);
+            data_types.push_back(aligned_schema_check_cache_.data_types_[i]);
         }
-        if (same_schema) {
-            for (uint32_t i = 0; i < measurement_count; i++) {
-                value_chunk_writers.push_back(
-                    device_schema->cached_value_chunk_writers_[i]);
-                data_types.push_back(
-                    device_schema->cached_aligned_data_types_[i]);
-            }
-            return E_OK;
-        }
-        device_schema->cached_value_chunk_writers_.clear();
-        device_schema->cached_aligned_data_types_.clear();
-        device_schema->cached_aligned_measurement_names_.clear();
-        device_schema->schema_check_aligned_cached_ = false;
+        return E_OK;
     }
+
     bool all_resolved = true;
-    for (uint32_t i = 0; i < measurement_count; i++) {
-        auto ms_iter = msm.find(*names[i]);
+    for (uint32_t i = 0; i < names.size(); ++i) {
+        auto ms_iter = msm.find(names[i]);
         if (UNLIKELY(ms_iter == msm.end())) {
             all_resolved = false;
             value_chunk_writers.push_back(NULL);
             data_types.push_back(common::NULL_TYPE);
-        } else {
-            // Here we may check data_type against ms_iter. But in Java
-            // libtsfile, no check here.
-            MeasurementSchema* ms = ms_iter->second;
-            if (IS_NULL(ms->value_chunk_writer_)) {
-                ms->value_chunk_writer_ = new ValueChunkWriter;
-                ret = ms->value_chunk_writer_->init(
-                    ms->measurement_name_, ms->data_type_, ms->encoding_,
-                    ms->compression_type_);
-                if (IS_SUCC(ret)) {
-                    value_chunk_writers.push_back(ms->value_chunk_writer_);
-                } else {
-                    value_chunk_writers.push_back(NULL);
-                    for (size_t chunk_writer_idx = 0;
-                         chunk_writer_idx < value_chunk_writers.size();
-                         chunk_writer_idx++) {
-                        if (!value_chunk_writers[chunk_writer_idx]) {
-                            delete value_chunk_writers[chunk_writer_idx];
-                        }
-                    }
-                    ret = common::E_INVALID_ARG;
-                    return ret;
-                }
-            } else {
-                value_chunk_writers.push_back(ms->value_chunk_writer_);
+            continue;
+        }
+
+        MeasurementSchema* ms = ms_iter->second;
+        if (IS_NULL(ms->value_chunk_writer_)) {
+            ms->value_chunk_writer_ = new ValueChunkWriter;
+            ret = ms->value_chunk_writer_->init(ms->measurement_name_,
+                                                ms->data_type_, ms->encoding_,
+                                                ms->compression_type_);
+            if (IS_FAIL(ret)) {
+                ret = common::E_INVALID_ARG;
+                return ret;
             }
-            data_types.push_back(ms->data_type_);
         }
+        value_chunk_writers.push_back(ms->value_chunk_writer_);
+        data_types.push_back(ms->data_type_);
     }
-    // See do_check_schema: never cache a result with unresolved columns.
+
     if (IS_SUCC(ret) && all_resolved) {
-        device_schema->cached_value_chunk_writers_.reserve(measurement_count);
-        device_schema->cached_aligned_data_types_.reserve(measurement_count);
-        for (uint32_t i = 0; i < measurement_count; i++) {
-            device_schema->cached_value_chunk_writers_.push_back(
+        aligned_schema_check_cache_.valid_ = true;
+        aligned_schema_check_cache_.device_id_ = device_id;
+        aligned_schema_check_cache_.measurement_names_ = names;
+        aligned_schema_check_cache_.value_chunk_writers_.clear();
+        aligned_schema_check_cache_.data_types_.clear();
+        for (uint32_t i = 0; i < names.size(); ++i) {
+            aligned_schema_check_cache_.value_chunk_writers_.push_back(
                 value_chunk_writers[i]);
-            device_schema->cached_aligned_data_types_.push_back(data_types[i]);
+            aligned_schema_check_cache_.data_types_.push_back(data_types[i]);
         }
-        device_schema->cached_aligned_measurement_names_.reserve(
-            measurement_count);
-        for (uint32_t i = 0; i < measurement_count; i++) {
-            device_schema->cached_aligned_measurement_names_.push_back(
-                *names[i]);
-        }
-        device_schema->schema_check_aligned_cached_ = true;
     }
     return ret;
 }

--- a/cpp/src/writer/tsfile_writer.h
+++ b/cpp/src/writer/tsfile_writer.h
@@ -183,6 +183,51 @@ class TsFileWriter {
     std::vector<std::pair<std::shared_ptr<IDeviceID>, int>>
     split_tablet_by_device(const Tablet& tablet);
 
+    struct PlainSchemaCheckCache {
+        bool valid_ = false;
+        std::shared_ptr<IDeviceID> device_id_;
+        std::vector<std::string> measurement_names_;
+        std::vector<storage::ChunkWriter*> chunk_writers_;
+        std::vector<common::TSDataType> data_types_;
+
+        void clear() {
+            valid_ = false;
+            device_id_.reset();
+            measurement_names_.clear();
+            chunk_writers_.clear();
+            data_types_.clear();
+        }
+    };
+
+    struct AlignedSchemaCheckCache {
+        bool valid_ = false;
+        std::shared_ptr<IDeviceID> device_id_;
+        std::vector<std::string> measurement_names_;
+        std::vector<storage::ValueChunkWriter*> value_chunk_writers_;
+        std::vector<common::TSDataType> data_types_;
+
+        void clear() {
+            valid_ = false;
+            device_id_.reset();
+            measurement_names_.clear();
+            value_chunk_writers_.clear();
+            data_types_.clear();
+        }
+    };
+
+    void clear_schema_check_cache();
+    bool plain_schema_cache_matches(
+        const std::shared_ptr<IDeviceID>& device_id,
+        const std::vector<std::string>& measurement_names) const;
+    bool aligned_schema_cache_matches(
+        const std::shared_ptr<IDeviceID>& device_id,
+        const std::vector<std::string>& measurement_names) const;
+
+    // Each cache is a one-entry MRU cache. Entries contain non-owning writer
+    // pointers; MeasurementSchema remains responsible for their lifetime.
+    PlainSchemaCheckCache plain_schema_check_cache_;
+    AlignedSchemaCheckCache aligned_schema_check_cache_;
+
    private:
     storage::WriteFile* write_file_;
     storage::TsFileIOWriter* io_writer_;

--- a/cpp/test/writer/tsfile_writer_schema_cache_test.cc
+++ b/cpp/test/writer/tsfile_writer_schema_cache_test.cc
@@ -1,0 +1,437 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Tests for the per-device schema-check cache in do_check_schema /
+// do_check_schema_aligned (issue #885). The cache resolves chunk writers and
+// data types once per device and reuses them while the tablet's measurement
+// NAME SEQUENCE is unchanged. These tests pin the behaviors the cache must
+// preserve:
+//  1. repeated same-schema writes round-trip every row (cache hit path);
+//  2. a same-column-count tablet with different names/order re-resolves and
+//     writes each value into the right column (cache invalidation);
+//  3. a column that was unregistered at first write is NOT masked by a cached
+//     NULL after it is registered (only fully-resolved results are cached);
+//  4. the aligned path keeps its own cache with the same guarantees;
+//  5. per-device caches never cross-wire two devices.
+#include <gtest/gtest.h>
+
+#include "writer/tsfile_writer.h"
+
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+#include <atomic>
+#include <memory>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "common/path.h"
+#include "common/record.h"
+#include "common/schema.h"
+#include "common/tablet.h"
+#include "common/tsfile_common.h"
+#include "reader/qds_without_timegenerator.h"
+#include "reader/tsfile_reader.h"
+
+using namespace storage;
+using namespace common;
+
+namespace {
+
+class SchemaCheckCacheTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        libtsfile_init();
+        tsfile_writer_ = new TsFileWriter();
+        file_name_ = std::string("tsfile_schema_cache_test_") +
+                     generate_random_string(10) + std::string(".tsfile");
+        remove(file_name_.c_str());
+        int flags = O_WRONLY | O_CREAT | O_TRUNC;
+#ifdef _WIN32
+        flags |= O_BINARY;
+#endif
+        ASSERT_EQ(tsfile_writer_->open(file_name_, flags, 0666), common::E_OK);
+    }
+    void TearDown() override {
+        delete tsfile_writer_;
+        ASSERT_EQ(0, remove(file_name_.c_str()));
+        libtsfile_destroy();
+    }
+
+    std::string file_name_;
+    TsFileWriter* tsfile_writer_ = nullptr;
+
+   public:
+    static std::string generate_random_string(int length) {
+        static std::atomic<uint64_t> counter{0};
+        std::mt19937 gen(static_cast<unsigned int>(
+            std::chrono::system_clock::now().time_since_epoch().count()));
+        std::uniform_int_distribution<> dis(0, 61);
+        const std::string chars =
+            "0123456789"
+            "abcdefghijklmnopqrstuvwxyz"
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        std::string random_string;
+        for (int i = 0; i < length; ++i) {
+            random_string += chars[dis(gen)];
+        }
+#ifdef _WIN32
+        const auto process_id = static_cast<uint64_t>(_getpid());
+#else
+        const auto process_id = static_cast<uint64_t>(getpid());
+#endif
+        random_string += "_" + std::to_string(process_id) + "_" +
+                         std::to_string(counter.fetch_add(1));
+        return random_string;
+    }
+
+    // Reads back (device, measurement) pairs and returns one row per
+    // timestamp: {timestamp, value-string per series}. Row count is asserted
+    // by the caller so dropped rows cannot pass silently.
+    std::vector<std::vector<std::string>> query_all(
+        const std::vector<Path>& select_list) {
+        storage::TsFileReader reader;
+        EXPECT_EQ(reader.open(file_name_), E_OK);
+        QueryExpression* query_expr =
+            QueryExpression::create(select_list, nullptr);
+        ResultSet* tmp_qds = nullptr;
+        EXPECT_EQ(reader.query(query_expr, tmp_qds), E_OK);
+        auto* qds = (QDSWithoutTimeGenerator*)tmp_qds;
+
+        std::vector<std::vector<std::string>> rows;
+        bool has_next = false;
+        while (IS_SUCC(qds->next(has_next)) && has_next) {
+            RowRecord* record = qds->get_row_record();
+            std::vector<std::string> row;
+            row.push_back(std::to_string(record->get_timestamp()));
+            // field(0) is the timestamp; value fields start at 1.
+            for (size_t i = 1; i < record->get_fields()->size(); ++i) {
+                row.push_back(field_to_string(record->get_field(i)));
+            }
+            rows.push_back(row);
+        }
+        reader.destroy_query_data_set(qds);
+        return rows;
+    }
+
+    MeasurementSchema int32_schema(const std::string& name) {
+        return MeasurementSchema(name, TSDataType::INT32, TSEncoding::PLAIN,
+                                 CompressionType::UNCOMPRESSED);
+    }
+
+    static std::string field_to_string(storage::Field* value) {
+        if (value->type_ == common::TEXT || value->type_ == STRING ||
+            value->type_ == BLOB) {
+            return std::string(value->value_.sval_);
+        }
+        std::stringstream ss;
+        switch (value->type_) {
+            case common::BOOLEAN:
+                ss << (value->value_.bval_ ? "true" : "false");
+                break;
+            case common::INT32:
+                ss << value->value_.ival_;
+                break;
+            case common::INT64:
+            case common::TIMESTAMP:
+                ss << value->value_.lval_;
+                break;
+            case common::FLOAT:
+                ss << value->value_.fval_;
+                break;
+            case common::DOUBLE:
+                ss << value->value_.dval_;
+                break;
+            case common::NULL_TYPE:
+                ss << "NULL";
+                break;
+            default:
+                ASSERT(false);
+                break;
+        }
+        return ss.str();
+    }
+
+    // Path's two-part ctor takes non-const std::string&, so route every
+    // construction through copies.
+    Path make_path(const std::string& device, const std::string& measurement) {
+        std::string dev = device;
+        std::string meas = measurement;
+        return Path(dev, meas);
+    }
+};
+
+// 1. Cache hit: the same tablet schema written repeatedly (with a flush in
+// between, so chunk writers survive a seal and are re-resolved from the
+// cache) must round-trip every row of every column.
+TEST_F(SchemaCheckCacheTest, RepeatedSameSchemaRoundTrip) {
+    const std::string device = "root.cache_hit";
+    const std::vector<std::string> names = {"s0", "s1", "s2"};
+    for (const auto& name : names) {
+        ASSERT_EQ(
+            tsfile_writer_->register_timeseries(device, int32_schema(name)),
+            E_OK);
+    }
+
+    const int num_tablets = 5;
+    for (int t = 0; t < num_tablets; t++) {
+        std::vector<MeasurementSchema> schema_vec;
+        for (const auto& name : names) schema_vec.push_back(int32_schema(name));
+        Tablet tablet(
+            device,
+            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
+        ASSERT_EQ(tablet.add_timestamp(0, 1000 + t), E_OK);
+        for (uint32_t j = 0; j < names.size(); j++) {
+            ASSERT_EQ(tablet.add_value(0, j, t * 100 + (int32_t)j), E_OK);
+        }
+        ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
+        if (t == 2) {
+            ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+        }
+    }
+    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+
+    std::vector<Path> select_list;
+    for (const auto& name : names)
+        select_list.push_back(make_path(device, name));
+    auto rows = query_all(select_list);
+    ASSERT_EQ(rows.size(), (size_t)num_tablets);
+    for (int t = 0; t < num_tablets; t++) {
+        ASSERT_EQ(rows[t][0], std::to_string(1000 + t));
+        for (uint32_t j = 0; j < names.size(); j++) {
+            ASSERT_EQ(rows[t][j + 1], std::to_string(t * 100 + j))
+                << "row " << t << " column " << j;
+        }
+    }
+}
+
+// 2. Invalidation by name sequence: same column count, different names and
+// order. Values must land in the column their NAME says, not the position
+// the previous tablet used.
+TEST_F(SchemaCheckCacheTest, SameCountDifferentNamesAndOrder) {
+    const std::string device = "root.cache_inval";
+    for (const auto& name : {"s0", "s1", "s2"}) {
+        ASSERT_EQ(
+            tsfile_writer_->register_timeseries(device, int32_schema(name)),
+            E_OK);
+    }
+
+    // Tablet 1: [s0, s1] at t=0.
+    {
+        std::vector<MeasurementSchema> schema_vec = {int32_schema("s0"),
+                                                     int32_schema("s1")};
+        Tablet tablet(
+            device,
+            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
+        ASSERT_EQ(tablet.add_timestamp(0, 0), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 0, 10), E_OK);  // s0 = 10
+        ASSERT_EQ(tablet.add_value(0, 1, 11), E_OK);  // s1 = 11
+        ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
+    }
+    // Tablet 2: same count, REVERSED order, at t=1.
+    {
+        std::vector<MeasurementSchema> schema_vec = {int32_schema("s1"),
+                                                     int32_schema("s0")};
+        Tablet tablet(
+            device,
+            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
+        ASSERT_EQ(tablet.add_timestamp(0, 1), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 0, 21), E_OK);  // s1 = 21
+        ASSERT_EQ(tablet.add_value(0, 1, 20), E_OK);  // s0 = 20
+        ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
+    }
+    // Tablet 3: same count, one column swapped for an unseen name, at t=2.
+    {
+        std::vector<MeasurementSchema> schema_vec = {int32_schema("s0"),
+                                                     int32_schema("s2")};
+        Tablet tablet(
+            device,
+            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
+        ASSERT_EQ(tablet.add_timestamp(0, 2), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 0, 30), E_OK);  // s0 = 30
+        ASSERT_EQ(tablet.add_value(0, 1, 32), E_OK);  // s2 = 32
+        ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
+    }
+    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+
+    std::vector<Path> select_list;
+    for (const auto& name : {"s0", "s1", "s2"}) {
+        select_list.push_back(make_path(device, name));
+    }
+    auto rows = query_all(select_list);
+    ASSERT_EQ(rows.size(), (size_t)3);
+    // t=0
+    EXPECT_EQ(rows[0][0], "0");
+    EXPECT_EQ(rows[0][1], "10");
+    EXPECT_EQ(rows[0][2], "11");
+    // t=1: swapped order must not swap values
+    EXPECT_EQ(rows[1][0], "1");
+    EXPECT_EQ(rows[1][1], "20");
+    EXPECT_EQ(rows[1][2], "21");
+    // t=2: s1 has no point at t=2
+    EXPECT_EQ(rows[2][0], "2");
+    EXPECT_EQ(rows[2][1], "30");
+    EXPECT_EQ(rows[2][3], "32");
+}
+
+// 3. A measurement missing at first write resolves to a NULL chunk writer
+// (column skipped). After it is registered, the same tablet schema must
+// write that column: the cache must not pin the stale NULL.
+TEST_F(SchemaCheckCacheTest, ColumnRegisteredAfterFirstWriteIsNotMasked) {
+    const std::string device = "root.cache_late_register";
+    ASSERT_EQ(tsfile_writer_->register_timeseries(device, int32_schema("s0")),
+              E_OK);
+    // Deliberately NOT registering s1 yet.
+
+    // First write: s1 unresolved -> NULL chunk writer, column skipped.
+    {
+        std::vector<MeasurementSchema> schema_vec = {int32_schema("s0"),
+                                                     int32_schema("s1")};
+        Tablet tablet(
+            device,
+            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
+        ASSERT_EQ(tablet.add_timestamp(0, 0), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 0, 100), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 1, 101), E_OK);
+        ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
+    }
+    // Now register s1 and write the same schema again.
+    ASSERT_EQ(tsfile_writer_->register_timeseries(device, int32_schema("s1")),
+              E_OK);
+    {
+        std::vector<MeasurementSchema> schema_vec = {int32_schema("s0"),
+                                                     int32_schema("s1")};
+        Tablet tablet(
+            device,
+            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
+        ASSERT_EQ(tablet.add_timestamp(0, 1), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 0, 200), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 1, 201), E_OK);
+        ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
+    }
+    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+
+    auto rows = query_all({make_path(device, "s1")});
+    // Without the fully-resolved guard the cached NULL would drop this
+    // column forever and this query would return zero rows.
+    ASSERT_EQ(rows.size(), (size_t)1);
+    EXPECT_EQ(rows[0][0], "1");
+    EXPECT_EQ(rows[0][1], "201");
+}
+
+// 4. Aligned path: same-schema repeated writes round-trip, and a reordered
+// tablet re-resolves instead of reusing positions.
+TEST_F(SchemaCheckCacheTest, AlignedRepeatedAndReordered) {
+    const std::string device = "root.cache_aligned";
+    for (const auto& name : {"a0", "a1"}) {
+        ASSERT_EQ(tsfile_writer_->register_aligned_timeseries(
+                      device, int32_schema(name)),
+                  E_OK);
+    }
+
+    const int num_tablets = 4;
+    for (int t = 0; t < num_tablets; t++) {
+        // Last tablet reverses the column order.
+        std::vector<MeasurementSchema> schema_vec;
+        if (t < num_tablets - 1) {
+            schema_vec = {int32_schema("a0"), int32_schema("a1")};
+        } else {
+            schema_vec = {int32_schema("a1"), int32_schema("a0")};
+        }
+        Tablet tablet(
+            device,
+            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
+        ASSERT_EQ(tablet.add_timestamp(0, 500 + t), E_OK);
+        if (t < num_tablets - 1) {
+            ASSERT_EQ(tablet.add_value(0, 0, t), E_OK);       // a0
+            ASSERT_EQ(tablet.add_value(0, 1, 10 + t), E_OK);  // a1
+        } else {
+            ASSERT_EQ(tablet.add_value(0, 0, 19), E_OK);  // a1
+            ASSERT_EQ(tablet.add_value(0, 1, 9), E_OK);   // a0
+        }
+        ASSERT_EQ(tsfile_writer_->write_tablet_aligned(tablet), E_OK);
+    }
+    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+
+    std::vector<Path> select_list;
+    for (const auto& name : {"a0", "a1"}) {
+        select_list.push_back(make_path(device, name));
+    }
+    auto rows = query_all(select_list);
+    ASSERT_EQ(rows.size(), (size_t)num_tablets);
+    for (int t = 0; t < num_tablets - 1; t++) {
+        EXPECT_EQ(rows[t][1], std::to_string(t));
+        EXPECT_EQ(rows[t][2], std::to_string(10 + t));
+    }
+    // Reordered final tablet: a0=9, a1=19.
+    EXPECT_EQ(rows[num_tablets - 1][1], "9");
+    EXPECT_EQ(rows[num_tablets - 1][2], "19");
+}
+
+// 5. Per-device caches are independent: two devices with identical
+// measurement names, interleaved writes, different values.
+TEST_F(SchemaCheckCacheTest, MultiDeviceCachesIndependent) {
+    const std::string devices[2] = {"root.cache_dev0", "root.cache_dev1"};
+    for (const auto& device : devices) {
+        for (const auto& name : {"m0", "m1"}) {
+            ASSERT_EQ(
+                tsfile_writer_->register_timeseries(device, int32_schema(name)),
+                E_OK);
+        }
+    }
+
+    for (int t = 0; t < 3; t++) {
+        for (int d = 0; d < 2; d++) {
+            std::vector<MeasurementSchema> schema_vec = {int32_schema("m0"),
+                                                         int32_schema("m1")};
+            Tablet tablet(
+                devices[d],
+                std::make_shared<std::vector<MeasurementSchema>>(schema_vec),
+                1);
+            ASSERT_EQ(tablet.add_timestamp(0, 700 + t), E_OK);
+            // d*1000 separates the two devices' value spaces.
+            ASSERT_EQ(tablet.add_value(0, 0, d * 1000 + t), E_OK);
+            ASSERT_EQ(tablet.add_value(0, 1, d * 1000 + 10 + t), E_OK);
+            ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
+        }
+    }
+    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+
+    for (int d = 0; d < 2; d++) {
+        auto rows = query_all(
+            {make_path(devices[d], "m0"), make_path(devices[d], "m1")});
+        ASSERT_EQ(rows.size(), (size_t)3);
+        for (int t = 0; t < 3; t++) {
+            EXPECT_EQ(rows[t][1], std::to_string(d * 1000 + t));
+            EXPECT_EQ(rows[t][2], std::to_string(d * 1000 + 10 + t));
+        }
+    }
+}
+
+}  // namespace

--- a/cpp/test/writer/tsfile_writer_schema_cache_test.cc
+++ b/cpp/test/writer/tsfile_writer_schema_cache_test.cc
@@ -17,18 +17,6 @@
  * under the License.
  */
 
-// Tests for the per-device schema-check cache in do_check_schema /
-// do_check_schema_aligned (issue #885). The cache resolves chunk writers and
-// data types once per device and reuses them while the tablet's measurement
-// NAME SEQUENCE is unchanged. These tests pin the behaviors the cache must
-// preserve:
-//  1. repeated same-schema writes round-trip every row (cache hit path);
-//  2. a same-column-count tablet with different names/order re-resolves and
-//     writes each value into the right column (cache invalidation);
-//  3. a column that was unregistered at first write is NOT masked by a cached
-//     NULL after it is registered (only fully-resolved results are cached);
-//  4. the aligned path keeps its own cache with the same guarantees;
-//  5. per-device caches never cross-wire two devices.
 #include <gtest/gtest.h>
 
 #include "writer/tsfile_writer.h"
@@ -40,6 +28,7 @@
 #endif
 
 #include <atomic>
+#include <chrono>
 #include <memory>
 #include <random>
 #include <sstream>
@@ -50,387 +39,388 @@
 #include "common/record.h"
 #include "common/schema.h"
 #include "common/tablet.h"
-#include "common/tsfile_common.h"
 #include "reader/qds_without_timegenerator.h"
 #include "reader/tsfile_reader.h"
 
-using namespace storage;
 using namespace common;
+using namespace storage;
 
 namespace {
 
 class SchemaCheckCacheTest : public ::testing::Test {
    protected:
     void SetUp() override {
-        libtsfile_init();
-        tsfile_writer_ = new TsFileWriter();
-        file_name_ = std::string("tsfile_schema_cache_test_") +
-                     generate_random_string(10) + std::string(".tsfile");
+        ASSERT_EQ(libtsfile_init(), E_OK);
+        writer_ = new TsFileWriter();
+        file_name_ = "tsfile_schema_cache_test_" + unique_suffix() + ".tsfile";
         remove(file_name_.c_str());
         int flags = O_WRONLY | O_CREAT | O_TRUNC;
 #ifdef _WIN32
         flags |= O_BINARY;
 #endif
-        ASSERT_EQ(tsfile_writer_->open(file_name_, flags, 0666), common::E_OK);
+        ASSERT_EQ(writer_->open(file_name_, flags, 0666), E_OK);
     }
+
     void TearDown() override {
-        delete tsfile_writer_;
-        ASSERT_EQ(0, remove(file_name_.c_str()));
+        delete writer_;
+        ASSERT_EQ(remove(file_name_.c_str()), 0);
         libtsfile_destroy();
     }
 
-    std::string file_name_;
-    TsFileWriter* tsfile_writer_ = nullptr;
-
-   public:
-    static std::string generate_random_string(int length) {
+    static std::string unique_suffix() {
         static std::atomic<uint64_t> counter{0};
-        std::mt19937 gen(static_cast<unsigned int>(
-            std::chrono::system_clock::now().time_since_epoch().count()));
-        std::uniform_int_distribution<> dis(0, 61);
-        const std::string chars =
-            "0123456789"
-            "abcdefghijklmnopqrstuvwxyz"
-            "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-        std::string random_string;
-        for (int i = 0; i < length; ++i) {
-            random_string += chars[dis(gen)];
-        }
 #ifdef _WIN32
         const auto process_id = static_cast<uint64_t>(_getpid());
 #else
         const auto process_id = static_cast<uint64_t>(getpid());
 #endif
-        random_string += "_" + std::to_string(process_id) + "_" +
-                         std::to_string(counter.fetch_add(1));
-        return random_string;
+        return std::to_string(process_id) + "_" +
+               std::to_string(counter.fetch_add(1));
     }
 
-    // Reads back (device, measurement) pairs and returns one row per
-    // timestamp: {timestamp, value-string per series}. Row count is asserted
-    // by the caller so dropped rows cannot pass silently.
-    std::vector<std::vector<std::string>> query_all(
-        const std::vector<Path>& select_list) {
-        storage::TsFileReader reader;
+    static MeasurementSchema schema(const std::string& name) {
+        return MeasurementSchema(name, TSDataType::INT32, TSEncoding::PLAIN,
+                                 CompressionType::UNCOMPRESSED);
+    }
+
+    static std::vector<MeasurementSchema> schemas(
+        const std::vector<std::string>& names) {
+        std::vector<MeasurementSchema> result;
+        for (const auto& name : names) {
+            result.push_back(schema(name));
+        }
+        return result;
+    }
+
+    static std::string field_to_string(Field* field) {
+        if (field->type_ == TEXT || field->type_ == STRING ||
+            field->type_ == BLOB) {
+            return std::string(field->value_.sval_);
+        }
+        std::stringstream stream;
+        switch (field->type_) {
+            case BOOLEAN:
+                stream << (field->value_.bval_ ? "true" : "false");
+                break;
+            case INT32:
+            case DATE:
+                stream << field->value_.ival_;
+                break;
+            case INT64:
+            case TIMESTAMP:
+                stream << field->value_.lval_;
+                break;
+            case FLOAT:
+                stream << field->value_.fval_;
+                break;
+            case DOUBLE:
+                stream << field->value_.dval_;
+                break;
+            case NULL_TYPE:
+                stream << "NULL";
+                break;
+            default:
+                ADD_FAILURE() << "Unexpected field type: " << field->type_;
+        }
+        return stream.str();
+    }
+
+    std::vector<std::vector<std::string>> read_rows(
+        const std::vector<Path>& paths) const {
+        TsFileReader reader;
         EXPECT_EQ(reader.open(file_name_), E_OK);
-        QueryExpression* query_expr =
-            QueryExpression::create(select_list, nullptr);
-        ResultSet* tmp_qds = nullptr;
-        EXPECT_EQ(reader.query(query_expr, tmp_qds), E_OK);
-        auto* qds = (QDSWithoutTimeGenerator*)tmp_qds;
+        QueryExpression* expression = QueryExpression::create(paths, nullptr);
+        ResultSet* result = nullptr;
+        EXPECT_EQ(reader.query(expression, result), E_OK);
+        auto* query = static_cast<QDSWithoutTimeGenerator*>(result);
 
         std::vector<std::vector<std::string>> rows;
         bool has_next = false;
-        while (IS_SUCC(qds->next(has_next)) && has_next) {
-            RowRecord* record = qds->get_row_record();
+        while (IS_SUCC(query->next(has_next)) && has_next) {
+            RowRecord* record = query->get_row_record();
             std::vector<std::string> row;
             row.push_back(std::to_string(record->get_timestamp()));
-            // field(0) is the timestamp; value fields start at 1.
             for (size_t i = 1; i < record->get_fields()->size(); ++i) {
                 row.push_back(field_to_string(record->get_field(i)));
             }
             rows.push_back(row);
         }
-        reader.destroy_query_data_set(qds);
+        reader.destroy_query_data_set(query);
+        reader.close();
         return rows;
     }
 
-    MeasurementSchema int32_schema(const std::string& name) {
-        return MeasurementSchema(name, TSDataType::INT32, TSEncoding::PLAIN,
-                                 CompressionType::UNCOMPRESSED);
+    static Path path(const std::string& device,
+                     const std::string& measurement) {
+        std::string device_copy = device;
+        std::string measurement_copy = measurement;
+        return Path(device_copy, measurement_copy);
     }
 
-    static std::string field_to_string(storage::Field* value) {
-        if (value->type_ == common::TEXT || value->type_ == STRING ||
-            value->type_ == BLOB) {
-            return std::string(value->value_.sval_);
-        }
-        std::stringstream ss;
-        switch (value->type_) {
-            case common::BOOLEAN:
-                ss << (value->value_.bval_ ? "true" : "false");
-                break;
-            case common::INT32:
-                ss << value->value_.ival_;
-                break;
-            case common::INT64:
-            case common::TIMESTAMP:
-                ss << value->value_.lval_;
-                break;
-            case common::FLOAT:
-                ss << value->value_.fval_;
-                break;
-            case common::DOUBLE:
-                ss << value->value_.dval_;
-                break;
-            case common::NULL_TYPE:
-                ss << "NULL";
-                break;
-            default:
-                ASSERT(false);
-                break;
-        }
-        return ss.str();
-    }
-
-    // Path's two-part ctor takes non-const std::string&, so route every
-    // construction through copies.
-    Path make_path(const std::string& device, const std::string& measurement) {
-        std::string dev = device;
-        std::string meas = measurement;
-        return Path(dev, meas);
-    }
+    TsFileWriter* writer_ = nullptr;
+    std::string file_name_;
 };
 
-// 1. Cache hit: the same tablet schema written repeatedly (with a flush in
-// between, so chunk writers survive a seal and are re-resolved from the
-// cache) must round-trip every row of every column.
-TEST_F(SchemaCheckCacheTest, RepeatedSameSchemaRoundTrip) {
+TEST_F(SchemaCheckCacheTest, RepeatedSameSchemaSurvivesFlush) {
     const std::string device = "root.cache_hit";
     const std::vector<std::string> names = {"s0", "s1", "s2"};
     for (const auto& name : names) {
-        ASSERT_EQ(
-            tsfile_writer_->register_timeseries(device, int32_schema(name)),
-            E_OK);
+        ASSERT_EQ(writer_->register_timeseries(device, schema(name)), E_OK);
     }
 
-    const int num_tablets = 5;
-    for (int t = 0; t < num_tablets; t++) {
-        std::vector<MeasurementSchema> schema_vec;
-        for (const auto& name : names) schema_vec.push_back(int32_schema(name));
+    for (int row = 0; row < 5; ++row) {
+        auto tablet_schema = schemas(names);
         Tablet tablet(
             device,
-            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
-        ASSERT_EQ(tablet.add_timestamp(0, 1000 + t), E_OK);
-        for (uint32_t j = 0; j < names.size(); j++) {
-            ASSERT_EQ(tablet.add_value(0, j, t * 100 + (int32_t)j), E_OK);
+            std::make_shared<std::vector<MeasurementSchema>>(tablet_schema), 1);
+        ASSERT_EQ(tablet.add_timestamp(0, 1000 + row), E_OK);
+        for (uint32_t column = 0; column < names.size(); ++column) {
+            ASSERT_EQ(tablet.add_value(
+                          0, column, static_cast<int32_t>(row * 100 + column)),
+                      E_OK);
         }
-        ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
-        if (t == 2) {
-            ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+        ASSERT_EQ(writer_->write_tablet(tablet), E_OK);
+        if (row == 2) {
+            ASSERT_EQ(writer_->flush(), E_OK);
         }
     }
-    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
-    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+    ASSERT_EQ(writer_->flush(), E_OK);
+    ASSERT_EQ(writer_->close(), E_OK);
 
-    std::vector<Path> select_list;
-    for (const auto& name : names)
-        select_list.push_back(make_path(device, name));
-    auto rows = query_all(select_list);
-    ASSERT_EQ(rows.size(), (size_t)num_tablets);
-    for (int t = 0; t < num_tablets; t++) {
-        ASSERT_EQ(rows[t][0], std::to_string(1000 + t));
-        for (uint32_t j = 0; j < names.size(); j++) {
-            ASSERT_EQ(rows[t][j + 1], std::to_string(t * 100 + j))
-                << "row " << t << " column " << j;
+    auto rows =
+        read_rows({path(device, "s0"), path(device, "s1"), path(device, "s2")});
+    ASSERT_EQ(rows.size(), 5u);
+    for (int row = 0; row < 5; ++row) {
+        EXPECT_EQ(rows[row][0], std::to_string(1000 + row));
+        for (int column = 0; column < 3; ++column) {
+            EXPECT_EQ(rows[row][column + 1],
+                      std::to_string(row * 100 + column));
         }
     }
 }
 
-// 2. Invalidation by name sequence: same column count, different names and
-// order. Values must land in the column their NAME says, not the position
-// the previous tablet used.
-TEST_F(SchemaCheckCacheTest, SameCountDifferentNamesAndOrder) {
-    const std::string device = "root.cache_inval";
+TEST_F(SchemaCheckCacheTest, SameCountDifferentNameOrderDoesNotCrossWire) {
+    const std::string device = "root.cache_reorder";
     for (const auto& name : {"s0", "s1", "s2"}) {
-        ASSERT_EQ(
-            tsfile_writer_->register_timeseries(device, int32_schema(name)),
-            E_OK);
+        ASSERT_EQ(writer_->register_timeseries(device, schema(name)), E_OK);
     }
 
-    // Tablet 1: [s0, s1] at t=0.
     {
-        std::vector<MeasurementSchema> schema_vec = {int32_schema("s0"),
-                                                     int32_schema("s1")};
+        auto tablet_schema = schemas({"s0", "s1"});
         Tablet tablet(
             device,
-            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
+            std::make_shared<std::vector<MeasurementSchema>>(tablet_schema), 1);
         ASSERT_EQ(tablet.add_timestamp(0, 0), E_OK);
-        ASSERT_EQ(tablet.add_value(0, 0, 10), E_OK);  // s0 = 10
-        ASSERT_EQ(tablet.add_value(0, 1, 11), E_OK);  // s1 = 11
-        ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 0, static_cast<int32_t>(10)), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 1, static_cast<int32_t>(11)), E_OK);
+        ASSERT_EQ(writer_->write_tablet(tablet), E_OK);
     }
-    // Tablet 2: same count, REVERSED order, at t=1.
     {
-        std::vector<MeasurementSchema> schema_vec = {int32_schema("s1"),
-                                                     int32_schema("s0")};
+        auto tablet_schema = schemas({"s1", "s0"});
         Tablet tablet(
             device,
-            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
+            std::make_shared<std::vector<MeasurementSchema>>(tablet_schema), 1);
         ASSERT_EQ(tablet.add_timestamp(0, 1), E_OK);
-        ASSERT_EQ(tablet.add_value(0, 0, 21), E_OK);  // s1 = 21
-        ASSERT_EQ(tablet.add_value(0, 1, 20), E_OK);  // s0 = 20
-        ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 0, static_cast<int32_t>(21)), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 1, static_cast<int32_t>(20)), E_OK);
+        ASSERT_EQ(writer_->write_tablet(tablet), E_OK);
     }
-    // Tablet 3: same count, one column swapped for an unseen name, at t=2.
     {
-        std::vector<MeasurementSchema> schema_vec = {int32_schema("s0"),
-                                                     int32_schema("s2")};
+        auto tablet_schema = schemas({"s0", "s2"});
         Tablet tablet(
             device,
-            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
+            std::make_shared<std::vector<MeasurementSchema>>(tablet_schema), 1);
         ASSERT_EQ(tablet.add_timestamp(0, 2), E_OK);
-        ASSERT_EQ(tablet.add_value(0, 0, 30), E_OK);  // s0 = 30
-        ASSERT_EQ(tablet.add_value(0, 1, 32), E_OK);  // s2 = 32
-        ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 0, static_cast<int32_t>(30)), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 1, static_cast<int32_t>(32)), E_OK);
+        ASSERT_EQ(writer_->write_tablet(tablet), E_OK);
     }
-    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
-    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+    ASSERT_EQ(writer_->flush(), E_OK);
+    ASSERT_EQ(writer_->close(), E_OK);
 
-    std::vector<Path> select_list;
-    for (const auto& name : {"s0", "s1", "s2"}) {
-        select_list.push_back(make_path(device, name));
-    }
-    auto rows = query_all(select_list);
-    ASSERT_EQ(rows.size(), (size_t)3);
-    // t=0
-    EXPECT_EQ(rows[0][0], "0");
+    auto rows =
+        read_rows({path(device, "s0"), path(device, "s1"), path(device, "s2")});
+    ASSERT_EQ(rows.size(), 3u);
     EXPECT_EQ(rows[0][1], "10");
     EXPECT_EQ(rows[0][2], "11");
-    // t=1: swapped order must not swap values
-    EXPECT_EQ(rows[1][0], "1");
     EXPECT_EQ(rows[1][1], "20");
     EXPECT_EQ(rows[1][2], "21");
-    // t=2: s1 has no point at t=2
-    EXPECT_EQ(rows[2][0], "2");
     EXPECT_EQ(rows[2][1], "30");
     EXPECT_EQ(rows[2][3], "32");
 }
 
-// 3. A measurement missing at first write resolves to a NULL chunk writer
-// (column skipped). After it is registered, the same tablet schema must
-// write that column: the cache must not pin the stale NULL.
-TEST_F(SchemaCheckCacheTest, ColumnRegisteredAfterFirstWriteIsNotMasked) {
+TEST_F(SchemaCheckCacheTest, LateRegistrationIsNotMaskedByCache) {
     const std::string device = "root.cache_late_register";
-    ASSERT_EQ(tsfile_writer_->register_timeseries(device, int32_schema("s0")),
-              E_OK);
-    // Deliberately NOT registering s1 yet.
+    ASSERT_EQ(writer_->register_timeseries(device, schema("s0")), E_OK);
 
-    // First write: s1 unresolved -> NULL chunk writer, column skipped.
-    {
-        std::vector<MeasurementSchema> schema_vec = {int32_schema("s0"),
-                                                     int32_schema("s1")};
-        Tablet tablet(
-            device,
-            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
-        ASSERT_EQ(tablet.add_timestamp(0, 0), E_OK);
-        ASSERT_EQ(tablet.add_value(0, 0, 100), E_OK);
-        ASSERT_EQ(tablet.add_value(0, 1, 101), E_OK);
-        ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
-    }
-    // Now register s1 and write the same schema again.
-    ASSERT_EQ(tsfile_writer_->register_timeseries(device, int32_schema("s1")),
-              E_OK);
-    {
-        std::vector<MeasurementSchema> schema_vec = {int32_schema("s0"),
-                                                     int32_schema("s1")};
-        Tablet tablet(
-            device,
-            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
-        ASSERT_EQ(tablet.add_timestamp(0, 1), E_OK);
-        ASSERT_EQ(tablet.add_value(0, 0, 200), E_OK);
-        ASSERT_EQ(tablet.add_value(0, 1, 201), E_OK);
-        ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
-    }
-    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
-    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+    auto first_schema = schemas({"s0", "s1"});
+    Tablet first(device,
+                 std::make_shared<std::vector<MeasurementSchema>>(first_schema),
+                 1);
+    ASSERT_EQ(first.add_timestamp(0, 0), E_OK);
+    ASSERT_EQ(first.add_value(0, 0, static_cast<int32_t>(100)), E_OK);
+    ASSERT_EQ(first.add_value(0, 1, static_cast<int32_t>(101)), E_OK);
+    ASSERT_EQ(writer_->write_tablet(first), E_OK);
 
-    auto rows = query_all({make_path(device, "s1")});
-    // Without the fully-resolved guard the cached NULL would drop this
-    // column forever and this query would return zero rows.
-    ASSERT_EQ(rows.size(), (size_t)1);
+    ASSERT_EQ(writer_->register_timeseries(device, schema("s1")), E_OK);
+    auto second_schema = schemas({"s0", "s1"});
+    Tablet second(
+        device, std::make_shared<std::vector<MeasurementSchema>>(second_schema),
+        1);
+    ASSERT_EQ(second.add_timestamp(0, 1), E_OK);
+    ASSERT_EQ(second.add_value(0, 0, static_cast<int32_t>(200)), E_OK);
+    ASSERT_EQ(second.add_value(0, 1, static_cast<int32_t>(201)), E_OK);
+    ASSERT_EQ(writer_->write_tablet(second), E_OK);
+
+    ASSERT_EQ(writer_->flush(), E_OK);
+    ASSERT_EQ(writer_->close(), E_OK);
+    auto rows = read_rows({path(device, "s1")});
+    ASSERT_EQ(rows.size(), 1u);
     EXPECT_EQ(rows[0][0], "1");
     EXPECT_EQ(rows[0][1], "201");
 }
 
-// 4. Aligned path: same-schema repeated writes round-trip, and a reordered
-// tablet re-resolves instead of reusing positions.
-TEST_F(SchemaCheckCacheTest, AlignedRepeatedAndReordered) {
+TEST_F(SchemaCheckCacheTest, AlignedCacheIsIndependentAndHandlesReorder) {
     const std::string device = "root.cache_aligned";
     for (const auto& name : {"a0", "a1"}) {
-        ASSERT_EQ(tsfile_writer_->register_aligned_timeseries(
-                      device, int32_schema(name)),
+        ASSERT_EQ(writer_->register_aligned_timeseries(device, schema(name)),
                   E_OK);
     }
 
-    const int num_tablets = 4;
-    for (int t = 0; t < num_tablets; t++) {
-        // Last tablet reverses the column order.
-        std::vector<MeasurementSchema> schema_vec;
-        if (t < num_tablets - 1) {
-            schema_vec = {int32_schema("a0"), int32_schema("a1")};
-        } else {
-            schema_vec = {int32_schema("a1"), int32_schema("a0")};
-        }
+    for (int row = 0; row < 4; ++row) {
+        const std::vector<std::string> names =
+            row == 3 ? std::vector<std::string>{"a1", "a0"}
+                     : std::vector<std::string>{"a0", "a1"};
+        auto tablet_schema = schemas(names);
         Tablet tablet(
             device,
-            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
-        ASSERT_EQ(tablet.add_timestamp(0, 500 + t), E_OK);
-        if (t < num_tablets - 1) {
-            ASSERT_EQ(tablet.add_value(0, 0, t), E_OK);       // a0
-            ASSERT_EQ(tablet.add_value(0, 1, 10 + t), E_OK);  // a1
+            std::make_shared<std::vector<MeasurementSchema>>(tablet_schema), 1);
+        ASSERT_EQ(tablet.add_timestamp(0, 500 + row), E_OK);
+        if (row == 3) {
+            ASSERT_EQ(tablet.add_value(0, 0, static_cast<int32_t>(19)), E_OK);
+            ASSERT_EQ(tablet.add_value(0, 1, static_cast<int32_t>(9)), E_OK);
         } else {
-            ASSERT_EQ(tablet.add_value(0, 0, 19), E_OK);  // a1
-            ASSERT_EQ(tablet.add_value(0, 1, 9), E_OK);   // a0
+            ASSERT_EQ(tablet.add_value(0, 0, row), E_OK);
+            ASSERT_EQ(tablet.add_value(0, 1, 10 + row), E_OK);
         }
-        ASSERT_EQ(tsfile_writer_->write_tablet_aligned(tablet), E_OK);
+        ASSERT_EQ(writer_->write_tablet_aligned(tablet), E_OK);
     }
-    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
-    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+    ASSERT_EQ(writer_->flush(), E_OK);
+    ASSERT_EQ(writer_->close(), E_OK);
 
-    std::vector<Path> select_list;
-    for (const auto& name : {"a0", "a1"}) {
-        select_list.push_back(make_path(device, name));
+    auto rows = read_rows({path(device, "a0"), path(device, "a1")});
+    ASSERT_EQ(rows.size(), 4u);
+    for (int row = 0; row < 3; ++row) {
+        EXPECT_EQ(rows[row][1], std::to_string(row));
+        EXPECT_EQ(rows[row][2], std::to_string(10 + row));
     }
-    auto rows = query_all(select_list);
-    ASSERT_EQ(rows.size(), (size_t)num_tablets);
-    for (int t = 0; t < num_tablets - 1; t++) {
-        EXPECT_EQ(rows[t][1], std::to_string(t));
-        EXPECT_EQ(rows[t][2], std::to_string(10 + t));
-    }
-    // Reordered final tablet: a0=9, a1=19.
-    EXPECT_EQ(rows[num_tablets - 1][1], "9");
-    EXPECT_EQ(rows[num_tablets - 1][2], "19");
+    EXPECT_EQ(rows[3][1], "9");
+    EXPECT_EQ(rows[3][2], "19");
 }
 
-// 5. Per-device caches are independent: two devices with identical
-// measurement names, interleaved writes, different values.
-TEST_F(SchemaCheckCacheTest, MultiDeviceCachesIndependent) {
-    const std::string devices[2] = {"root.cache_dev0", "root.cache_dev1"};
-    for (const auto& device : devices) {
-        for (const auto& name : {"m0", "m1"}) {
-            ASSERT_EQ(
-                tsfile_writer_->register_timeseries(device, int32_schema(name)),
-                E_OK);
-        }
+TEST_F(SchemaCheckCacheTest, InterleavedDevicesDoNotCrossWire) {
+    const std::string plain_device0 = "root.cache_plain0";
+    const std::string plain_device1 = "root.cache_plain1";
+    const std::string aligned_device = "root.cache_aligned_interleaved";
+    for (const auto& name : {"m0", "m1"}) {
+        ASSERT_EQ(writer_->register_timeseries(plain_device0, schema(name)),
+                  E_OK);
+        ASSERT_EQ(writer_->register_timeseries(plain_device1, schema(name)),
+                  E_OK);
+        ASSERT_EQ(
+            writer_->register_aligned_timeseries(aligned_device, schema(name)),
+            E_OK);
     }
 
-    for (int t = 0; t < 3; t++) {
-        for (int d = 0; d < 2; d++) {
-            std::vector<MeasurementSchema> schema_vec = {int32_schema("m0"),
-                                                         int32_schema("m1")};
-            Tablet tablet(
-                devices[d],
-                std::make_shared<std::vector<MeasurementSchema>>(schema_vec),
+    for (int row = 0; row < 3; ++row) {
+        for (const auto& device : {plain_device0, plain_device1}) {
+            auto plain_schema = schemas({"m0", "m1"});
+            Tablet plain_tablet(
+                device,
+                std::make_shared<std::vector<MeasurementSchema>>(plain_schema),
                 1);
-            ASSERT_EQ(tablet.add_timestamp(0, 700 + t), E_OK);
-            // d*1000 separates the two devices' value spaces.
-            ASSERT_EQ(tablet.add_value(0, 0, d * 1000 + t), E_OK);
-            ASSERT_EQ(tablet.add_value(0, 1, d * 1000 + 10 + t), E_OK);
-            ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
+            ASSERT_EQ(plain_tablet.add_timestamp(0, 700 + row), E_OK);
+            const int device_offset = device == plain_device0 ? 0 : 100;
+            ASSERT_EQ(plain_tablet.add_value(
+                          0, 0, static_cast<int32_t>(device_offset + row)),
+                      E_OK);
+            ASSERT_EQ(plain_tablet.add_value(
+                          0, 1, static_cast<int32_t>(device_offset + 10 + row)),
+                      E_OK);
+            ASSERT_EQ(writer_->write_tablet(plain_tablet), E_OK);
+        }
+
+        auto aligned_schema = schemas({"m0", "m1"});
+        Tablet aligned_tablet(
+            aligned_device,
+            std::make_shared<std::vector<MeasurementSchema>>(aligned_schema),
+            1);
+        ASSERT_EQ(aligned_tablet.add_timestamp(0, 700 + row), E_OK);
+        ASSERT_EQ(
+            aligned_tablet.add_value(0, 0, static_cast<int32_t>(1000 + row)),
+            E_OK);
+        ASSERT_EQ(
+            aligned_tablet.add_value(0, 1, static_cast<int32_t>(1010 + row)),
+            E_OK);
+        ASSERT_EQ(writer_->write_tablet_aligned(aligned_tablet), E_OK);
+    }
+
+    ASSERT_EQ(writer_->flush(), E_OK);
+    ASSERT_EQ(writer_->close(), E_OK);
+    for (const auto& device : {plain_device0, plain_device1}) {
+        auto rows = read_rows({path(device, "m0"), path(device, "m1")});
+        ASSERT_EQ(rows.size(), 3u);
+        const int device_offset = device == plain_device0 ? 0 : 100;
+        for (int row = 0; row < 3; ++row) {
+            EXPECT_EQ(rows[row][1], std::to_string(device_offset + row));
+            EXPECT_EQ(rows[row][2], std::to_string(device_offset + 10 + row));
         }
     }
-    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
-    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+    auto aligned_rows =
+        read_rows({path(aligned_device, "m0"), path(aligned_device, "m1")});
+    ASSERT_EQ(aligned_rows.size(), 3u);
+    for (int row = 0; row < 3; ++row) {
+        EXPECT_EQ(aligned_rows[row][1], std::to_string(1000 + row));
+        EXPECT_EQ(aligned_rows[row][2], std::to_string(1010 + row));
+    }
+}
 
-    for (int d = 0; d < 2; d++) {
-        auto rows = query_all(
-            {make_path(devices[d], "m0"), make_path(devices[d], "m1")});
-        ASSERT_EQ(rows.size(), (size_t)3);
-        for (int t = 0; t < 3; t++) {
-            EXPECT_EQ(rows[t][1], std::to_string(d * 1000 + t));
-            EXPECT_EQ(rows[t][2], std::to_string(d * 1000 + 10 + t));
-        }
+TEST_F(SchemaCheckCacheTest, RecordPathsUseIndependentCaches) {
+    const std::string plain_device = "root.cache_record_plain";
+    const std::string aligned_device = "root.cache_record_aligned";
+    for (const auto& name : {"m0", "m1"}) {
+        ASSERT_EQ(writer_->register_timeseries(plain_device, schema(name)),
+                  E_OK);
+        ASSERT_EQ(
+            writer_->register_aligned_timeseries(aligned_device, schema(name)),
+            E_OK);
+    }
+
+    for (int row = 0; row < 4; ++row) {
+        TsRecord plain_record(800 + row, plain_device);
+        plain_record.add_point("m0", static_cast<int32_t>(row));
+        plain_record.add_point("m1", static_cast<int32_t>(10 + row));
+        ASSERT_EQ(writer_->write_record(plain_record), E_OK);
+
+        TsRecord aligned_record(800 + row, aligned_device);
+        aligned_record.add_point("m0", static_cast<int32_t>(100 + row));
+        aligned_record.add_point("m1", static_cast<int32_t>(110 + row));
+        ASSERT_EQ(writer_->write_record_aligned(aligned_record), E_OK);
+    }
+
+    ASSERT_EQ(writer_->flush(), E_OK);
+    ASSERT_EQ(writer_->close(), E_OK);
+    auto plain_rows =
+        read_rows({path(plain_device, "m0"), path(plain_device, "m1")});
+    auto aligned_rows =
+        read_rows({path(aligned_device, "m0"), path(aligned_device, "m1")});
+    ASSERT_EQ(plain_rows.size(), 4u);
+    ASSERT_EQ(aligned_rows.size(), 4u);
+    for (int row = 0; row < 4; ++row) {
+        EXPECT_EQ(plain_rows[row][1], std::to_string(row));
+        EXPECT_EQ(plain_rows[row][2], std::to_string(10 + row));
+        EXPECT_EQ(aligned_rows[row][1], std::to_string(100 + row));
+        EXPECT_EQ(aligned_rows[row][2], std::to_string(110 + row));
     }
 }
 


### PR DESCRIPTION
Title:
perf(cpp): cache per-device schema check for repeated tablet writes (#885)

Body:
## Problem

Closes #885.

`TsFileWriter::do_check_schema` / `do_check_schema_aligned` re-resolve every
measurement name against `measurement_schema_map_` on **every**
`write_tablet` / `write_tablet_aligned` / `write_record` call, even though
the device schema is registered once and does not change during the file
lifecycle. For wide tablets written repeatedly this per-column string lookup
is a top CPU hotspot (profiling in #885).

## Change

Cache the resolved chunk writers and data types per device in
`MeasurementSchemaGroup` (`cpp/src/common/schema.h`), resolved once and
reused while the tablet's measurement **name sequence** is unchanged:

- **Cache key is the name sequence, not the column count.** Cached entries
  are reused by position, so the same count with a different name order (or
  one column swapped) would silently write values into the wrong column with
  the wrong data type. A mismatch drops the stale cache and re-resolves, so
  dynamic schemas keep the existing validation behavior.
- **Plain and aligned paths keep separate caches** (a shared flag would let
  whichever path runs first lock the other out permanently).
- **Only fully-resolved results are cached.** A NULL chunk writer for a
  not-yet-registered measurement must not be pinned, or the column would
  stay masked even after it is registered later.
- Cached entries are the same **non-owning** pointers the uncached path
  returns: `chunk_writer_` is only freed in `destroy()`, flush only resets
  it, and `register_timeseries` returns `E_ALREADY_EXIST` for an existing
  name instead of replacing the object, so a cached pointer cannot dangle.
- The written file is byte-identical to the uncached path.

`do_check_schema_table` (table model) is unchanged; this targets the tree
model paths named in #885.

## Tests

New suite `SchemaCheckCacheTest` (`cpp/test/writer/tsfile_writer_schema_cache_test.cc`):

1. `RepeatedSameSchemaRoundTrip` — hit path, incl. after a flush seals and
   resets the chunk writers; asserts every row and column (no dropped rows).
2. `SameCountDifferentNamesAndOrder` — same column count with a swapped /
   reordered name set re-resolves; values land in the column their name says.
3. `ColumnRegisteredAfterFirstWriteIsNotMasked` — the fully-resolved-only
   guard: a column unregistered at first write is written once registered.
4. `AlignedRepeatedAndReorder` — aligned path: own cache, hit + reorder.
5. `MultiDeviceCachesIndependent` — two devices with identical measurement
   names, interleaved writes, no cross-wiring.

Full suite: 830 tests, 827 passed, 3 skipped (environment-only skips:
external-index and cross-language fixture generators), 0 failures.

## Benchmark

A/B microbenchmark (not committed — happy to add it to the tree if wanted):
one device, 200 INT32/PLAIN columns, 2000 tablet writes × 1 row each (the
few-rows-wide-tablet shape from the issue), parallel write disabled, best of
5 rounds, MSVC 2019 x64:

| build | uncached (develop) | cached (this PR) | speedup | saved ns/col |
|-------|--------------------|------------------|---------|--------------|
| Release | 33.4 µs/write | 19.0 µs/write | **1.76×** | ~72 |
| Debug | 246.0 µs/write | 150.0 µs/write | 1.64× | ~480 |

The schema check was ~43% of the total `write_tablet` time in this shape.
With more rows per tablet the end-to-end percentage shrinks (the saving is
per write, the encode cost is per point), but the per-column lookup remains
the dominant fixed cost per call — which is what #885 profiles.

## Notes

- The benchmark above is a scratch local run; a permanent benchmark harness
can follow the direction from the maintainer feedback in #885.
