### PR TITLE
[Feature][C++][Python] Support seekable random-access TsFile sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ python/tsfile/*so*
 python/tsfile/*dll*
 python/tsfile/*dylib*
 python/tsfile/*.h
+!python/tsfile/python_random_access_file.h
 python/tsfile/*.cpp
 python/tsfile/**/*.cpp
 python/tsfile/**/*so*

--- a/cpp/src/file/random_access_file.cc
+++ b/cpp/src/file/random_access_file.cc
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "file/random_access_file.h"
+
+#include <cstring>
+
+#include "common/tsfile_common.h"
+#include "utils/errno_define.h"
+
+namespace storage {
+
+int validate_tsfile(RandomAccessFile& file, unsigned char* file_version) {
+    static const int64_t MIN_FILE_SIZE = 2 * MAGIC_STRING_TSFILE_LEN + 1;
+    if (!file.is_opened()) {
+        return common::E_FILE_READ_ERR;
+    }
+    if (file.file_size() < MIN_FILE_SIZE) {
+        return common::E_TSFILE_CORRUPTED;
+    }
+
+    char buffer[MAGIC_STRING_TSFILE_LEN];
+    int32_t read_size = 0;
+    int ret = file.read(0, buffer, MAGIC_STRING_TSFILE_LEN, read_size);
+    if (ret != common::E_OK) {
+        return ret;
+    }
+    if (read_size != MAGIC_STRING_TSFILE_LEN ||
+        std::memcmp(buffer, MAGIC_STRING_TSFILE, MAGIC_STRING_TSFILE_LEN) !=
+            0) {
+        return common::E_TSFILE_CORRUPTED;
+    }
+
+    char version = 0;
+    ret = file.read(MAGIC_STRING_TSFILE_LEN, &version, 1, read_size);
+    if (ret != common::E_OK) {
+        return ret;
+    }
+    if (read_size != 1) {
+        return common::E_TSFILE_CORRUPTED;
+    }
+    const unsigned char parsed_version = static_cast<unsigned char>(version);
+    if (parsed_version != 3 &&
+        parsed_version != static_cast<unsigned char>(VERSION_NUM_BYTE)) {
+        return common::E_UNSUPPORTED_VERSION;
+    }
+
+    ret = file.read(file.file_size() - MAGIC_STRING_TSFILE_LEN, buffer,
+                    MAGIC_STRING_TSFILE_LEN, read_size);
+    if (ret != common::E_OK) {
+        return ret;
+    }
+    if (read_size != MAGIC_STRING_TSFILE_LEN ||
+        std::memcmp(buffer, MAGIC_STRING_TSFILE, MAGIC_STRING_TSFILE_LEN) !=
+            0) {
+        return common::E_TSFILE_CORRUPTED;
+    }
+    if (file_version != nullptr) {
+        *file_version = parsed_version;
+    }
+    return common::E_OK;
+}
+
+}  // namespace storage

--- a/cpp/src/file/random_access_file.h
+++ b/cpp/src/file/random_access_file.h
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef FILE_RANDOM_ACCESS_FILE_H
+#define FILE_RANDOM_ACCESS_FILE_H
+
+#include <stdint.h>
+
+#include <string>
+
+namespace storage {
+
+/**
+ * A readable, seek-independent byte source used by the TsFile reader stack.
+ *
+ * Implementations must continue short underlying reads until the requested
+ * range is filled or EOF is reached. Concurrent read() calls must be safe
+ * after initialization; close() must not race with read() or generation().
+ */
+class RandomAccessFile {
+   public:
+    virtual ~RandomAccessFile() = default;
+
+    virtual bool is_opened() const = 0;
+    virtual int64_t file_size() const = 0;
+    virtual const std::string& file_path() const = 0;
+    virtual int generation(uint64_t& size, uint64_t& fingerprint) const = 0;
+
+    /** Read up to @p size bytes at @p offset without exposing a cursor. */
+    virtual int read(int64_t offset, char* buffer, int32_t size,
+                     int32_t& read_size) = 0;
+    virtual void close() = 0;
+};
+
+int validate_tsfile(RandomAccessFile& file,
+                    unsigned char* file_version = nullptr);
+
+}  // namespace storage
+
+#endif  // FILE_RANDOM_ACCESS_FILE_H

--- a/cpp/src/file/read_file.cc
+++ b/cpp/src/file/read_file.cc
@@ -370,58 +370,7 @@ void ReadFile::unmap_file() {
 }
 
 int ReadFile::check_file_magic() {
-    int ret = E_OK;
-    if (file_size_ < MIN_FILE_SIZE) {
-        ret = E_TSFILE_CORRUPTED;
-        LOGE("tsfile" << file_path_.c_str()
-                      << "is corrupted, file_size=" << file_size_);
-    } else {
-        char buf[MAGIC_STRING_TSFILE_LEN];
-        int32_t read_len = 0;
-        // file header magic
-        memset(buf, 0, MAGIC_STRING_TSFILE_LEN);
-        if (RET_FAIL(read(0, buf, MAGIC_STRING_TSFILE_LEN, read_len))) {
-        } else if (read_len != MAGIC_STRING_TSFILE_LEN) {
-            ret = E_TSFILE_CORRUPTED;
-        } else if (memcmp(buf, MAGIC_STRING_TSFILE, MAGIC_STRING_TSFILE_LEN) !=
-                   0) {
-            ret = E_TSFILE_CORRUPTED;
-        }
-        if (IS_FAIL(ret)) {
-            return ret;
-        }
-
-        char version = 0;
-        if (RET_FAIL(read(MAGIC_STRING_TSFILE_LEN, &version, 1, read_len))) {
-        } else if (read_len != 1) {
-            ret = E_TSFILE_CORRUPTED;
-        } else {
-            file_version_ = static_cast<unsigned char>(version);
-            // Version 3 remains readable for backward compatibility; version
-            // 4 is the current writer format.  Other values are not safely
-            // interpretable and must be reported as an input failure before
-            // metadata parsing begins.
-            if (file_version_ != 3 &&
-                file_version_ != static_cast<unsigned char>(VERSION_NUM_BYTE)) {
-                ret = E_UNSUPPORTED_VERSION;
-            }
-        }
-        if (IS_FAIL(ret)) {
-            return ret;
-        }
-
-        // file footer magic
-        memset(buf, 0, MAGIC_STRING_TSFILE_LEN);
-        if (RET_FAIL(read(file_size_ - MAGIC_STRING_TSFILE_LEN, buf,
-                          MAGIC_STRING_TSFILE_LEN, read_len))) {
-        } else if (read_len != MAGIC_STRING_TSFILE_LEN) {
-            ret = E_TSFILE_CORRUPTED;
-        } else if (memcmp(buf, MAGIC_STRING_TSFILE, MAGIC_STRING_TSFILE_LEN) !=
-                   0) {
-            ret = E_TSFILE_CORRUPTED;
-        }
-    }
-    return ret;
+    return validate_tsfile(*this, &file_version_);
 }
 
 int ReadFile::read(int64_t offset, char* buf, int32_t buf_size,

--- a/cpp/src/file/read_file.h
+++ b/cpp/src/file/read_file.h
@@ -26,26 +26,29 @@
 #include <string>
 
 #include "common/config/config.h"
+#include "file/random_access_file.h"
 #include "utils/errno_define.h"
 #include "utils/util_define.h"
 
 namespace storage {
 
-class ReadFile {
+class ReadFile : public RandomAccessFile {
    public:
     ReadFile();
-    ~ReadFile() { destroy(); }
+    ~ReadFile() override { destroy(); }
     ReadFile(const ReadFile&) = delete;
     ReadFile& operator=(const ReadFile&) = delete;
 
     void destroy() { close(); }
 
     int open(const std::string& file_path);
-    FORCE_INLINE bool is_opened() const {
+    FORCE_INLINE bool is_opened() const override {
         return fd_ >= 0 || mapped_data_ != nullptr;
     }
-    FORCE_INLINE int64_t file_size() const { return file_size_; }
-    FORCE_INLINE const std::string& file_path() const { return file_path_; }
+    FORCE_INLINE int64_t file_size() const override { return file_size_; }
+    FORCE_INLINE const std::string& file_path() const override {
+        return file_path_;
+    }
     FORCE_INLINE unsigned char file_version() const { return file_version_; }
     FORCE_INLINE common::FileReadBackend active_backend() const {
         return active_backend_;
@@ -55,17 +58,17 @@ class ReadFile {
      * MMAP readers return the generation captured before closing the file
      * descriptor.
      */
-    int generation(uint64_t& size, uint64_t& fingerprint) const;
+    int generation(uint64_t& size, uint64_t& fingerprint) const override;
 
     /*
      * try to reader @buf_size bytes from @offset of this file
      * into @buf. @read_len return the actual len reader.
      */
     int read(int64_t offset, char* buf, int32_t buf_size,
-             int32_t& ret_read_len);
+             int32_t& ret_read_len) override;
     // open()/close() must not race with read() or generation(). Concurrent
     // reads are supported after the file has been opened.
-    void close();
+    void close() override;
 
    private:
     int get_file_size(int64_t& file_size);

--- a/cpp/src/file/tsfile_io_reader.cc
+++ b/cpp/src/file/tsfile_io_reader.cc
@@ -22,6 +22,7 @@
 #include <limits>
 
 #include "common/allocator/alloc_base.h"
+#include "file/read_file.h"
 #include "reader/prepared_series.h"
 
 using namespace common;
@@ -29,14 +30,15 @@ using namespace common;
 namespace storage {
 int TsFileIOReader::init(const std::string& file_path) {
     int ret = E_OK;
-    read_file_ = new ReadFile;
+    ReadFile* local_file = new ReadFile;
+    read_file_ = local_file;
     read_file_created_ = true;
-    if (RET_FAIL(read_file_->open(file_path))) {
+    if (RET_FAIL(local_file->open(file_path))) {
     }
     return ret;
 }
 
-int TsFileIOReader::init(ReadFile* read_file) {
+int TsFileIOReader::init(RandomAccessFile* read_file) {
     if (IS_NULL(read_file)) {
         ASSERT(false);
         return E_INVALID_ARG;
@@ -49,7 +51,7 @@ int TsFileIOReader::init(ReadFile* read_file) {
 void TsFileIOReader::reset() {
     if (read_file_ != nullptr) {
         if (read_file_created_) {
-            read_file_->destroy();
+            read_file_->close();
             delete read_file_;
         }
         read_file_ = nullptr;
@@ -92,7 +94,7 @@ int TsFileIOReader::alloc_ssi(std::shared_ptr<IDeviceID> device_id,
 }
 
 namespace {
-int load_exact_timeseries_index(ReadFile* read_file, uint64_t offset,
+int load_exact_timeseries_index(RandomAccessFile* read_file, uint64_t offset,
                                 uint32_t length, PageArena& arena,
                                 TimeseriesIndex*& index) {
     if (read_file == nullptr || length == 0 ||
@@ -1344,7 +1346,7 @@ int TsFileIOReader::get_next_page(TsBlock *ret_tsblock)
 }
 
 int TsFileIOReader::init_first_chunk_reader(ChunkMeta *cm,
-                                            ReadFile *read_file,
+                                            RandomAccessFile *read_file,
                                             const ColumnDesc &col_desc)
 {
   ASSERT(!chunk_reader_.has_more_data());

--- a/cpp/src/file/tsfile_io_reader.h
+++ b/cpp/src/file/tsfile_io_reader.h
@@ -26,7 +26,7 @@
 #include <unordered_set>
 
 #include "common/tsblock/tsblock.h"
-#include "file/read_file.h"
+#include "file/random_access_file.h"
 #include "reader/chunk_reader.h"
 #include "reader/filter/filter.h"
 #include "reader/tsfile_series_scan_iterator.h"
@@ -55,7 +55,7 @@ class TsFileIOReader {
         device_node_cache_pa_.init(512, common::MOD_TSFILE_READER);
     }
 
-    // Free only the ReadFile we own (created by init(const std::string&)).
+    // Free only the local source we own (created by init(const std::string&)).
     // Without an explicit destructor that raw pointer leaks whenever a
     // TsFileIOReader value goes out of scope without an explicit reset() (e.g.
     // a stack instance in a test).  We deliberately do NOT call reset() here:
@@ -68,7 +68,7 @@ class TsFileIOReader {
     // reset() leaves read_file_ == nullptr, so this never double-frees.
     ~TsFileIOReader() {
         if (read_file_created_ && read_file_ != nullptr) {
-            read_file_->destroy();
+            read_file_->close();
             delete read_file_;
             read_file_ = nullptr;
         }
@@ -76,7 +76,7 @@ class TsFileIOReader {
 
     int init(const std::string& file_path);
 
-    int init(ReadFile* read_file);
+    int init(RandomAccessFile* read_file);
 
     void reset();
 
@@ -111,6 +111,12 @@ class TsFileIOReader {
     void revert_ssi(TsFileSeriesScanIterator* ssi);
 
     std::string get_file_path() const { return read_file_->file_path(); }
+
+    int get_tsfile_meta(TsFileMeta*& tsfile_meta) {
+        const int ret = load_tsfile_meta_if_necessary();
+        tsfile_meta = ret == common::E_OK ? &tsfile_meta_ : nullptr;
+        return ret;
+    }
 
     TsFileMeta* get_tsfile_meta() {
         load_tsfile_meta_if_necessary();
@@ -233,7 +239,7 @@ class TsFileIOReader {
     static std::string device_node_cache_key(
         const std::shared_ptr<IDeviceID>& device_id);
 
-    ReadFile* read_file_;
+    RandomAccessFile* read_file_;
     common::PageArena tsfile_meta_page_arena_;
     TsFileMeta tsfile_meta_;
     bool tsfile_meta_ready_;

--- a/cpp/src/reader/aligned_chunk_reader.cc
+++ b/cpp/src/reader/aligned_chunk_reader.cc
@@ -33,7 +33,7 @@
 using namespace common;
 namespace storage {
 
-int AlignedChunkReader::init(ReadFile* read_file, String m_name,
+int AlignedChunkReader::init(RandomAccessFile* read_file, String m_name,
                              TSDataType data_type, Filter* time_filter) {
     read_file_ = read_file;
     measurement_name_.shallow_copy_from(m_name);
@@ -1384,7 +1384,8 @@ int AlignedChunkReader::decode_time_page_with(const ChunkPageInfo& page_info,
         if (heap) common::mem_free(compressed_buf);
         return ret;
     }
-    // ReadFile::read() returns E_OK + short read_len on EOF; uncompressing
+    // RandomAccessFile::read() returns E_OK + short read_len on EOF;
+    // uncompressing
     // page_info.time_compressed_size from a buffer with uninitialised tail
     // bytes would feed garbage to the decompressor.
     if (read_len != static_cast<int32_t>(page_info.time_compressed_size)) {

--- a/cpp/src/reader/aligned_chunk_reader.h
+++ b/cpp/src/reader/aligned_chunk_reader.h
@@ -24,7 +24,7 @@
 #include "common/tsfile_common.h"
 #include "compress/compressor.h"
 #include "encoding/decoder.h"
-#include "file/read_file.h"
+#include "file/random_access_file.h"
 #include "reader/filter/filter.h"
 #include "reader/ichunk_reader.h"
 
@@ -120,7 +120,7 @@ class AlignedChunkReader : public IChunkReader {
           time_uncompressed_buf_(nullptr),
           value_uncompressed_buf_(nullptr),
           cur_value_index(-1) {}
-    int init(ReadFile* read_file, common::String m_name,
+    int init(RandomAccessFile* read_file, common::String m_name,
              common::TSDataType data_type, Filter* time_filter) override;
     void reset() override;
     void destroy() override;
@@ -276,7 +276,7 @@ class AlignedChunkReader : public IChunkReader {
                               int32_t row_limit) const;
 
    private:
-    ReadFile* read_file_;
+    RandomAccessFile* read_file_;
     // ── Single-value mode fields (kept for backward compat) ──────────────
     ChunkMeta* time_chunk_meta_;
     ChunkMeta* value_chunk_meta_;

--- a/cpp/src/reader/chunk_reader.cc
+++ b/cpp/src/reader/chunk_reader.cc
@@ -27,8 +27,8 @@
 using namespace common;
 namespace storage {
 
-int ChunkReader::init(ReadFile* read_file, String m_name, TSDataType data_type,
-                      Filter* time_filter) {
+int ChunkReader::init(RandomAccessFile* read_file, String m_name,
+                      TSDataType data_type, Filter* time_filter) {
     read_file_ = read_file;
     measurement_name_.shallow_copy_from(m_name);
     time_decoder_ = DecoderFactory::alloc_time_decoder();

--- a/cpp/src/reader/chunk_reader.h
+++ b/cpp/src/reader/chunk_reader.h
@@ -24,7 +24,7 @@
 #include "common/tsfile_common.h"
 #include "compress/compressor.h"
 #include "encoding/decoder.h"
-#include "file/read_file.h"
+#include "file/random_access_file.h"
 #include "reader/filter/filter.h"
 #include "reader/ichunk_reader.h"
 
@@ -48,7 +48,7 @@ class ChunkReader : public IChunkReader {
           time_in_(),
           value_in_(),
           uncompressed_buf_(nullptr) {}
-    int init(ReadFile* read_file, common::String m_name,
+    int init(RandomAccessFile* read_file, common::String m_name,
              common::TSDataType data_type, Filter* time_filter) override;
     void reset() override;
     void destroy() override;
@@ -127,7 +127,7 @@ class ChunkReader : public IChunkReader {
                                             Filter* filter);
 
    private:
-    ReadFile* read_file_;
+    RandomAccessFile* read_file_;
     ChunkMeta* chunk_meta_;
     common::String measurement_name_;
     ChunkHeader chunk_header_;

--- a/cpp/src/reader/ichunk_reader.h
+++ b/cpp/src/reader/ichunk_reader.h
@@ -23,7 +23,7 @@
 #include "common/allocator/my_string.h"
 #include "compress/compressor.h"
 #include "encoding/decoder.h"
-#include "file/read_file.h"
+#include "file/random_access_file.h"
 #include "reader/filter/filter.h"
 
 namespace storage {
@@ -31,7 +31,7 @@ namespace storage {
 class IChunkReader {
    public:
     IChunkReader() {}
-    virtual int init(ReadFile* read_file, common::String m_name,
+    virtual int init(RandomAccessFile* read_file, common::String m_name,
                      common::TSDataType data_type, Filter* time_filter) {
         return common::E_OK;
     }

--- a/cpp/src/reader/query_executor.h
+++ b/cpp/src/reader/query_executor.h
@@ -23,7 +23,7 @@
 
 #include "common/row_record.h"
 #include "expression.h"
-#include "file/read_file.h"
+#include "file/random_access_file.h"
 #include "reader/tsfile_series_scan_iterator.h"
 
 namespace storage {
@@ -40,7 +40,8 @@ class QueryExecutor {
         }
     }
 
-    // virtual int init(QueryExpression *query_expr, ReadFile *read_file) {
+    // virtual int init(QueryExpression *query_expr,
+    //                  RandomAccessFile *read_file) {
     // ASSERT(false); return 0; };
 
     virtual RowRecord* execute() {

--- a/cpp/src/reader/table_query_executor.h
+++ b/cpp/src/reader/table_query_executor.h
@@ -21,6 +21,7 @@
 
 #include "common/schema.h"
 #include "expression.h"
+#include "file/random_access_file.h"
 #include "imeta_data_querier.h"
 #include "reader/block/device_ordered_tsblock_reader.h"
 #include "reader/block/tsblock_reader.h"
@@ -46,7 +47,7 @@ class TableQueryExecutor {
           table_query_ordering_(table_query_ordering),
           block_size_(block_size),
           return_mode_(RETURN_ROW) {}
-    TableQueryExecutor(ReadFile* read_file, const int batch_size = -1) {
+    TableQueryExecutor(RandomAccessFile* read_file, const int batch_size = -1) {
         tsfile_io_reader_ = new TsFileIOReader();
         tsfile_io_reader_->init(read_file);
         meta_data_querier_ = new MetadataQuerier(tsfile_io_reader_);

--- a/cpp/src/reader/tsfile_executor.cc
+++ b/cpp/src/reader/tsfile_executor.cc
@@ -42,7 +42,7 @@ TsFileExecutor::TsFileExecutor()
 
 TsFileExecutor::~TsFileExecutor() {}
 
-int TsFileExecutor::init(ReadFile* read_file) {
+int TsFileExecutor::init(RandomAccessFile* read_file) {
     int ret = E_OK;
     io_reader_.reset();
     if (RET_FAIL(io_reader_.init(read_file))) {

--- a/cpp/src/reader/tsfile_executor.h
+++ b/cpp/src/reader/tsfile_executor.h
@@ -22,7 +22,7 @@
 #include <map>
 #include <memory>
 
-#include "file/read_file.h"
+#include "file/random_access_file.h"
 #include "query_executor.h"
 #include "result_set.h"
 
@@ -33,7 +33,7 @@ class TsFileExecutor  // : public QueryExecutor
    public:
     TsFileExecutor();
     ~TsFileExecutor();
-    int init(ReadFile* read_file);
+    int init(RandomAccessFile* read_file);
     int init(const std::string& file_path);
     int execute(QueryExpression* query_expr, ResultSet*& ret_qds);
     int execute(QueryExpression* query_expr, ResultSet*& ret_qds, int offset,
@@ -54,6 +54,9 @@ class TsFileExecutor  // : public QueryExecutor
         int64_t start_time, int64_t end_time, int offset, int limit,
         ResultSet*& ret_qds);
     void destroy_query_data_set(ResultSet* qds);
+    int get_tsfile_meta(TsFileMeta*& tsfile_meta) {
+        return io_reader_.get_tsfile_meta(tsfile_meta);
+    }
     TsFileMeta* get_tsfile_meta() { return io_reader_.get_tsfile_meta(); }
     TsFileIOReader* get_tsfile_io_reader() { return &io_reader_; }
 

--- a/cpp/src/reader/tsfile_reader.cc
+++ b/cpp/src/reader/tsfile_reader.cc
@@ -19,8 +19,10 @@
 #include "tsfile_reader.h"
 
 #include <stdexcept>
+#include <utility>
 
 #include "common/schema.h"
+#include "file/read_file.h"
 #include "filter/time_operator.h"
 #include "tsfile_executor.h"
 
@@ -50,7 +52,7 @@ int parse_paths(const std::vector<std::string>& path_list,
 
 int get_all_device_entries(std::vector<DeviceMetaEntry>& entries,
                            std::shared_ptr<MetaIndexNode> index_node,
-                           ReadFile* read_file, PageArena& pa) {
+                           RandomAccessFile* read_file, PageArena& pa) {
     int ret = E_OK;
     if (index_node == nullptr) {
         return ret;
@@ -109,28 +111,84 @@ namespace storage {
 TsFileReader::TsFileReader()
     : read_file_(nullptr),
       tsfile_executor_(nullptr),
-      table_query_executor_(nullptr) {
-    tsfile_reader_meta_pa_.init(512, MOD_TSFILE_READER);
+      table_query_executor_(nullptr),
+      tsfile_reader_meta_pa_(new common::PageArena()) {
+    tsfile_reader_meta_pa_->init(512, MOD_TSFILE_READER);
 }
 
 TsFileReader::~TsFileReader() { close(); }
 
+TsFileReader::TsFileReader(TsFileReader&& other) noexcept
+    : read_file_(std::move(other.read_file_)),
+      tsfile_executor_(other.tsfile_executor_),
+      table_query_executor_(other.table_query_executor_),
+      table_query_executor_batch_size_(other.table_query_executor_batch_size_),
+      file_version_(other.file_version_),
+      tsfile_reader_meta_pa_(std::move(other.tsfile_reader_meta_pa_)) {
+    other.tsfile_executor_ = nullptr;
+    other.table_query_executor_ = nullptr;
+    other.table_query_executor_batch_size_ = -1;
+    other.file_version_ = 0;
+}
+
+TsFileReader& TsFileReader::operator=(TsFileReader&& other) noexcept {
+    if (this != &other) {
+        close();
+        read_file_ = std::move(other.read_file_);
+        tsfile_executor_ = other.tsfile_executor_;
+        table_query_executor_ = other.table_query_executor_;
+        table_query_executor_batch_size_ =
+            other.table_query_executor_batch_size_;
+        file_version_ = other.file_version_;
+        tsfile_reader_meta_pa_ = std::move(other.tsfile_reader_meta_pa_);
+
+        other.tsfile_executor_ = nullptr;
+        other.table_query_executor_ = nullptr;
+        other.table_query_executor_batch_size_ = -1;
+        other.file_version_ = 0;
+    }
+    return *this;
+}
+
 int TsFileReader::open(const std::string& file_path) {
+    std::unique_ptr<ReadFile> read_file(new ReadFile());
     int ret = E_OK;
-    read_file_ = new storage::ReadFile;
-    tsfile_executor_ = new storage::TsFileExecutor();
     // Keep reader diagnostics in the caller's error channel.  Printing here
     // would leak an unstructured line to process stdout/stderr before the CLI
     // can attach its stable error text and exit code.
-    if (RET_FAIL(read_file_->open(file_path))) {
-    } else if (RET_FAIL(tsfile_executor_->init(read_file_))) {
+    if (RET_FAIL(read_file->open(file_path))) {
+        return ret;
+    }
+    const unsigned char file_version = read_file->file_version();
+    return open_source(std::move(read_file), file_version);
+}
+
+int TsFileReader::open(std::unique_ptr<RandomAccessFile> read_file) {
+    if (read_file == nullptr || !read_file->is_opened()) {
+        return E_INVALID_ARG;
+    }
+    unsigned char file_version = 0;
+    const int ret = validate_tsfile(*read_file, &file_version);
+    if (ret != E_OK) {
+        return ret;
+    }
+    return open_source(std::move(read_file), file_version);
+}
+
+int TsFileReader::open_source(std::unique_ptr<RandomAccessFile> read_file,
+                              unsigned char file_version) {
+    close();
+    read_file_ = std::move(read_file);
+    file_version_ = file_version;
+    tsfile_executor_ = new storage::TsFileExecutor();
+    const int ret = tsfile_executor_->init(read_file_.get());
+    if (ret != E_OK) {
+        close();
     }
     return ret;
 }
 
-unsigned char TsFileReader::get_file_version() const {
-    return read_file_ == nullptr ? 0 : read_file_->file_version();
-}
+unsigned char TsFileReader::get_file_version() const { return file_version_; }
 
 int TsFileReader::ensure_table_query_executor(int batch_size) {
     if (table_query_executor_ != nullptr &&
@@ -143,7 +201,8 @@ int TsFileReader::ensure_table_query_executor(int batch_size) {
         table_query_executor_ = nullptr;
     }
 
-    table_query_executor_ = new TableQueryExecutor(read_file_, batch_size);
+    table_query_executor_ =
+        new TableQueryExecutor(read_file_.get(), batch_size);
     table_query_executor_batch_size_ = batch_size;
     return E_OK;
 }
@@ -160,9 +219,9 @@ int TsFileReader::close() {
     }
     if (read_file_ != nullptr) {
         read_file_->close();
-        delete read_file_;
-        read_file_ = nullptr;
+        read_file_.reset();
     }
+    file_version_ = 0;
     return ret;
 }
 
@@ -201,9 +260,9 @@ int TsFileReader::query(const std::string& table_name,
                         ResultSet*& result_set, Filter* tag_filter,
                         int batch_size) {
     int ret = E_OK;
-    TsFileMeta* tsfile_meta = tsfile_executor_->get_tsfile_meta();
-    if (tsfile_meta == nullptr) {
-        return E_FILE_READ_ERR;
+    TsFileMeta* tsfile_meta = nullptr;
+    if (RET_FAIL(tsfile_executor_->get_tsfile_meta(tsfile_meta))) {
+        return ret;
     }
     std::shared_ptr<TableSchema> table_schema =
         tsfile_meta->table_schemas_.at(to_lower(table_name));
@@ -271,9 +330,9 @@ int TsFileReader::queryByRow(const std::string& table_name,
                              int offset, int limit, ResultSet*& result_set,
                              Filter* tag_filter, int batch_size) {
     int ret = E_OK;
-    TsFileMeta* tsfile_meta = tsfile_executor_->get_tsfile_meta();
-    if (tsfile_meta == nullptr) {
-        return E_FILE_READ_ERR;
+    TsFileMeta* tsfile_meta = nullptr;
+    if (RET_FAIL(tsfile_executor_->get_tsfile_meta(tsfile_meta))) {
+        return ret;
     }
     auto it = tsfile_meta->table_schemas_.find(to_lower(table_name));
     if (it == tsfile_meta->table_schemas_.end() || it->second == nullptr) {
@@ -292,9 +351,9 @@ int TsFileReader::query_table_on_tree(
     const std::vector<std::string>& measurement_names, int64_t star_time,
     int64_t end_time, ResultSet*& result_set) {
     int ret = E_OK;
-    TsFileMeta* tsfile_meta = tsfile_executor_->get_tsfile_meta();
-    if (tsfile_meta == nullptr) {
-        return E_FILE_READ_ERR;
+    TsFileMeta* tsfile_meta = nullptr;
+    if (RET_FAIL(tsfile_executor_->get_tsfile_meta(tsfile_meta))) {
+        return ret;
     }
     auto device_ids = this->get_all_device_ids();
     std::vector<std::shared_ptr<IDeviceID>> satisfied_device_ids;
@@ -493,7 +552,7 @@ int TsFileReader::get_timeseries_metadata_impl(
     if (RET_FAIL(
             tsfile_executor_->get_tsfile_io_reader()
                 ->get_device_timeseries_meta_without_chunk_meta(
-                    device_id, timeseries_indexs, tsfile_reader_meta_pa_))) {
+                    device_id, timeseries_indexs, *tsfile_reader_meta_pa_))) {
     } else {
         for (auto timeseries_index : timeseries_indexs) {
             result.emplace_back(std::shared_ptr<ITimeseriesIndex>(
@@ -512,8 +571,8 @@ DeviceTimeseriesMetadataMap TsFileReader::get_timeseries_metadata(
     // duplicates the per-device payload).  Callers that need to retain prior
     // results past this call must copy them out before invoking again — the
     // shared_ptrs handed back use a noop deleter pointing into this arena.
-    tsfile_reader_meta_pa_.destroy();
-    tsfile_reader_meta_pa_.init(512, MOD_TSFILE_READER);
+    tsfile_reader_meta_pa_->destroy();
+    tsfile_reader_meta_pa_->init(512, MOD_TSFILE_READER);
     DeviceTimeseriesMetadataMap result;
     for (const auto& device_id : device_ids) {
         std::vector<std::shared_ptr<ITimeseriesIndex>> list;
@@ -533,15 +592,15 @@ DeviceTimeseriesMetadataMap TsFileReader::get_timeseries_metadata() {
     }
 
     // Same arena-reset rationale as the device_ids overload above.
-    tsfile_reader_meta_pa_.destroy();
-    tsfile_reader_meta_pa_.init(512, MOD_TSFILE_READER);
+    tsfile_reader_meta_pa_->destroy();
+    tsfile_reader_meta_pa_->init(512, MOD_TSFILE_READER);
 
     PageArena pa;
     pa.init(512, MOD_TSFILE_READER);
     std::vector<DeviceMetaEntry> entries;
     for (auto& table_entry : tsfile_meta->table_metadata_index_node_map_) {
-        if (get_all_device_entries(entries, table_entry.second, read_file_,
-                                   pa) != E_OK) {
+        if (get_all_device_entries(entries, table_entry.second,
+                                   read_file_.get(), pa) != E_OK) {
             return result;
         }
     }
@@ -552,7 +611,7 @@ DeviceTimeseriesMetadataMap TsFileReader::get_timeseries_metadata() {
         if (tsfile_executor_->get_tsfile_io_reader()
                 ->get_device_timeseries_meta_by_offset(
                     device_entry.start_offset, device_entry.end_offset,
-                    raw_ts_indexes, tsfile_reader_meta_pa_) == E_OK) {
+                    raw_ts_indexes, *tsfile_reader_meta_pa_) == E_OK) {
             std::vector<std::shared_ptr<ITimeseriesIndex>> list;
             for (auto ts_idx : raw_ts_indexes) {
                 list.emplace_back(

--- a/cpp/src/reader/tsfile_reader.h
+++ b/cpp/src/reader/tsfile_reader.h
@@ -20,15 +20,16 @@
 #ifndef READER_TSFILE_READER_H
 #define READER_TSFILE_READER_H
 
+#include <memory>
+
 #include "common/row_record.h"
 #include "common/tsfile_common.h"
 #include "expression.h"
-#include "file/read_file.h"
+#include "file/random_access_file.h"
 #include "reader/prepared_series.h"
 #include "reader/table_query_executor.h"
 namespace storage {
 class TsFileExecutor;
-class ReadFile;
 class ResultSet;
 struct MeasurementSchema;
 }  // namespace storage
@@ -49,6 +50,10 @@ class TsFileReader {
    public:
     TsFileReader();
     ~TsFileReader();
+    TsFileReader(const TsFileReader&) = delete;
+    TsFileReader& operator=(const TsFileReader&) = delete;
+    TsFileReader(TsFileReader&& other) noexcept;
+    TsFileReader& operator=(TsFileReader&& other) noexcept;
     /**
      * @brief open the tsfile
      *
@@ -56,6 +61,12 @@ class TsFileReader {
      * @return Returns 0 on success, or a non-zero error code on failure.
      */
     int open(const std::string& file_path);
+    /**
+     * @brief open an initialized random-access source
+     *
+     * The reader takes ownership of @p read_file.
+     */
+    int open(std::unique_ptr<RandomAccessFile> read_file);
     /**
      * @brief close the tsfile, this method should be called after the
      * query is finished
@@ -252,6 +263,8 @@ class TsFileReader {
     std::vector<std::shared_ptr<TableSchema>> get_all_table_schemas();
 
    private:
+    int open_source(std::unique_ptr<RandomAccessFile> read_file,
+                    unsigned char file_version);
     int ensure_table_query_executor(int batch_size);
     int get_timeseries_metadata_impl(
         std::shared_ptr<IDeviceID> device_id,
@@ -259,11 +272,12 @@ class TsFileReader {
     int get_all_devices(std::vector<std::shared_ptr<IDeviceID>>& device_ids,
                         std::shared_ptr<MetaIndexNode> index_node,
                         common::PageArena& pa);
-    storage::ReadFile* read_file_;
+    std::unique_ptr<storage::RandomAccessFile> read_file_;
     storage::TsFileExecutor* tsfile_executor_;
     storage::TableQueryExecutor* table_query_executor_;
     int table_query_executor_batch_size_ = -1;
-    common::PageArena tsfile_reader_meta_pa_;
+    unsigned char file_version_ = 0;
+    std::unique_ptr<common::PageArena> tsfile_reader_meta_pa_;
     // Test-only hook for the unbounded-arena-growth regression check.
     friend class TsFileReaderMetaArenaTest;
 };

--- a/cpp/src/reader/tsfile_series_scan_iterator.cc
+++ b/cpp/src/reader/tsfile_series_scan_iterator.cc
@@ -32,8 +32,9 @@ using namespace common;
 namespace storage {
 
 int TsFileSeriesScanIterator::init_prepared(
-    const std::shared_ptr<PreparedSeries>& prepared, ReadFile* read_file,
-    Filter* time_filter, common::PageArena& data_pa) {
+    const std::shared_ptr<PreparedSeries>& prepared,
+    RandomAccessFile* read_file, Filter* time_filter,
+    common::PageArena& data_pa) {
     if (prepared == nullptr || prepared->index() == nullptr ||
         read_file == nullptr) {
         return E_INVALID_ARG;
@@ -68,7 +69,8 @@ int TsFileSeriesScanIterator::init_prepared(
 
 int TsFileSeriesScanIterator::init_prepared_multi(
     const std::vector<std::shared_ptr<PreparedSeries>>& prepared,
-    ReadFile* read_file, Filter* time_filter, common::PageArena& data_pa) {
+    RandomAccessFile* read_file, Filter* time_filter,
+    common::PageArena& data_pa) {
     if (prepared.empty() || prepared.front() == nullptr ||
         read_file == nullptr) {
         return E_INVALID_ARG;

--- a/cpp/src/reader/tsfile_series_scan_iterator.h
+++ b/cpp/src/reader/tsfile_series_scan_iterator.h
@@ -26,7 +26,7 @@
 
 #include "aligned_chunk_reader.h"
 #include "common/tsblock/tsblock.h"
-#include "file/read_file.h"
+#include "file/random_access_file.h"
 #include "file/tsfile_io_reader.h"
 #include "reader/chunk_reader.h"
 #include "reader/filter/filter.h"
@@ -59,7 +59,7 @@ class TsFileSeriesScanIterator {
           row_limit_(-1) {}
     ~TsFileSeriesScanIterator() { destroy(); }
     int init(std::shared_ptr<IDeviceID> device_id,
-             const std::string& measurement_name, ReadFile* read_file,
+             const std::string& measurement_name, RandomAccessFile* read_file,
              Filter* time_filter, common::PageArena& data_pa) {
         ASSERT(read_file != nullptr);
         device_id_ = device_id;
@@ -70,11 +70,12 @@ class TsFileSeriesScanIterator {
         return common::E_OK;
     }
     int init_prepared(const std::shared_ptr<PreparedSeries>& prepared,
-                      ReadFile* read_file, Filter* time_filter,
+                      RandomAccessFile* read_file, Filter* time_filter,
                       common::PageArena& data_pa);
     int init_prepared_multi(
         const std::vector<std::shared_ptr<PreparedSeries>>& prepared,
-        ReadFile* read_file, Filter* time_filter, common::PageArena& data_pa);
+        RandomAccessFile* read_file, Filter* time_filter,
+        common::PageArena& data_pa);
     void destroy();
 
     /**
@@ -205,7 +206,7 @@ class TsFileSeriesScanIterator {
     common::TsBlock* alloc_tsblock_multi();
 
    private:
-    ReadFile* read_file_;
+    RandomAccessFile* read_file_;
     std::shared_ptr<IDeviceID> device_id_;
     std::string measurement_name_;
 

--- a/cpp/test/reader/chunk_reader_resource_test.cc
+++ b/cpp/test/reader/chunk_reader_resource_test.cc
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "common/allocator/alloc_base.h"
+#include "file/read_file.h"
 #include "reader/aligned_chunk_reader.h"
 
 namespace storage {

--- a/cpp/test/reader/table_view/table_model_encoding_compression_compatibility_test.cc
+++ b/cpp/test/reader/table_view/table_model_encoding_compression_compatibility_test.cc
@@ -46,6 +46,7 @@
 #include "common/db_common.h"
 #include "common/schema.h"
 #include "common/tablet.h"
+#include "file/read_file.h"
 #include "file/tsfile_io_reader.h"
 #include "file/write_file.h"
 #include "reader/table_result_set.h"

--- a/cpp/test/reader/tsfile_reader_test.cc
+++ b/cpp/test/reader/tsfile_reader_test.cc
@@ -22,7 +22,10 @@
 #include <sys/stat.h>
 
 #include <cmath>
+#include <cstring>
+#include <fstream>
 #include <map>
+#include <memory>
 #include <numeric>
 #include <random>
 #include <unordered_map>
@@ -32,6 +35,7 @@
 #include "common/schema.h"
 #include "common/tablet.h"
 #include "common/tsblock/tsblock.h"
+#include "file/random_access_file.h"
 #include "file/tsfile_io_reader.h"
 #include "file/tsfile_io_writer.h"
 #include "file/write_file.h"
@@ -138,6 +142,131 @@ class TsFileReaderTest : public ::testing::Test {
         }
     }
 };
+
+namespace {
+
+class InMemoryRandomAccessFile : public RandomAccessFile {
+   public:
+    explicit InMemoryRandomAccessFile(std::vector<char> bytes)
+        : bytes_(std::move(bytes)), opened_(true), name_("memory://test") {}
+
+    bool is_opened() const override { return opened_; }
+
+    int64_t file_size() const override {
+        return static_cast<int64_t>(bytes_.size());
+    }
+
+    const std::string& file_path() const override { return name_; }
+
+    int generation(uint64_t& size, uint64_t& fingerprint) const override {
+        if (!opened_) {
+            return E_FILE_READ_ERR;
+        }
+        size = bytes_.size();
+        fingerprint = 0;
+        return E_OK;
+    }
+
+    int read(int64_t offset, char* buffer, int32_t size,
+             int32_t& read_size) override {
+        read_size = 0;
+        if (!opened_ || offset < 0 || size < 0 ||
+            (buffer == nullptr && size > 0)) {
+            return E_INVALID_ARG;
+        }
+        if (size == 0 || static_cast<size_t>(offset) >= bytes_.size()) {
+            return E_OK;
+        }
+        const size_t available = bytes_.size() - static_cast<size_t>(offset);
+        read_size = static_cast<int32_t>(
+            std::min(available, static_cast<size_t>(size)));
+        std::memcpy(buffer, bytes_.data() + offset,
+                    static_cast<size_t>(read_size));
+        return E_OK;
+    }
+
+    void close() override { opened_ = false; }
+
+   private:
+    std::vector<char> bytes_;
+    bool opened_;
+    std::string name_;
+};
+
+}  // namespace
+
+TEST_F(TsFileReaderTest, ReadsThroughRandomAccessFile) {
+    const std::string device = "root.sg.device";
+    const std::string measurement = "temperature";
+    ASSERT_EQ(tsfile_writer_->register_timeseries(
+                  device, MeasurementSchema(measurement, TSDataType::INT32,
+                                            TSEncoding::PLAIN,
+                                            CompressionType::UNCOMPRESSED)),
+              E_OK);
+    TsRecord record(100, device);
+    record.add_point(measurement, static_cast<int32_t>(42));
+    ASSERT_EQ(tsfile_writer_->write_record(record), E_OK);
+    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+
+    std::ifstream input(file_name_, std::ios::binary);
+    ASSERT_TRUE(input.is_open());
+    std::vector<char> bytes((std::istreambuf_iterator<char>(input)),
+                            std::istreambuf_iterator<char>());
+    ASSERT_FALSE(bytes.empty());
+
+    std::unique_ptr<RandomAccessFile> source(
+        new InMemoryRandomAccessFile(std::move(bytes)));
+    TsFileReader reader;
+    ASSERT_EQ(reader.open(std::move(source)), E_OK);
+    EXPECT_EQ(reader.get_file_version(),
+              static_cast<unsigned char>(VERSION_NUM_BYTE));
+
+    std::vector<std::string> paths = {device + "." + measurement};
+    ResultSet* result = nullptr;
+    ASSERT_EQ(reader.query(paths, 0, 200, result), E_OK);
+    ASSERT_NE(result, nullptr);
+    bool has_next = false;
+    ASSERT_EQ(result->next(has_next), E_OK);
+    ASSERT_TRUE(has_next);
+    EXPECT_EQ(result->get_value<int32_t>(2), 42);
+    ASSERT_EQ(result->next(has_next), E_OK);
+    EXPECT_FALSE(has_next);
+
+    reader.destroy_query_data_set(result);
+    reader.close();
+}
+
+TEST_F(TsFileReaderTest, MoveTransfersAnOpenReader) {
+    const std::string device = "root.sg.move_device";
+    const std::string measurement = "temperature";
+    ASSERT_EQ(tsfile_writer_->register_timeseries(
+                  device, MeasurementSchema(measurement, TSDataType::INT32,
+                                            TSEncoding::PLAIN,
+                                            CompressionType::UNCOMPRESSED)),
+              E_OK);
+    TsRecord record(100, device);
+    record.add_point(measurement, static_cast<int32_t>(42));
+    ASSERT_EQ(tsfile_writer_->write_record(record), E_OK);
+    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+
+    TsFileReader original;
+    ASSERT_EQ(original.open(file_name_), E_OK);
+    TsFileReader moved = std::move(original);
+    TsFileReader reader;
+    reader = std::move(moved);
+
+    std::vector<std::string> paths = {device + "." + measurement};
+    ResultSet* result = nullptr;
+    ASSERT_EQ(reader.query(paths, 0, 200, result), E_OK);
+    ASSERT_NE(result, nullptr);
+    bool has_next = false;
+    ASSERT_EQ(result->next(has_next), E_OK);
+    ASSERT_TRUE(has_next);
+    EXPECT_EQ(result->get_value<int32_t>(2), 42);
+    reader.destroy_query_data_set(result);
+}
 
 TEST_F(TsFileReaderTest, ResultSetMetadata) {
     std::string device_path = "device1";
@@ -1607,7 +1736,7 @@ namespace storage {
 class TsFileReaderMetaArenaTest {
    public:
     static int64_t arena_used(const storage::TsFileReader& r) {
-        return r.tsfile_reader_meta_pa_.get_total_used_bytes();
+        return r.tsfile_reader_meta_pa_->get_total_used_bytes();
     }
 };
 }  // namespace storage

--- a/python/README-zh.md
+++ b/python/README-zh.md
@@ -104,3 +104,21 @@ set_tsfile_config({"file_read_backend_": FileReadBackend.AUTO})
 
 该配置只影响之后打开的 reader。通过内存映射后端打开文件期间，请勿修改或
 截断该文件。
+
+## 可定位的二进制文件对象
+
+`TsFileReader` 也可以直接接收可定位的二进制文件对象。因此，通过 `fsspec`
+等库打开远程文件后，无需先把整个文件复制到本地即可读取。
+
+```python
+import fsspec
+from tsfile import TsFileReader
+
+with fsspec.open("s3://bucket/example.tsfile", "rb") as source:
+    with TsFileReader(source) as reader:
+        result = reader.query_table("table_name", ["column_name"])
+```
+
+文件对象必须提供 `seek()`、`tell()` 和带明确长度的二进制 `read(size)`。
+该对象仍由调用方管理：`TsFileReader` 会在使用期间保持其存活、恢复其游标位置，
+但不会关闭它。本地 `FileReadBackend` 配置不适用于文件对象。

--- a/python/README.md
+++ b/python/README.md
@@ -99,3 +99,23 @@ set_tsfile_config({"file_read_backend_": FileReadBackend.AUTO})
 
 The setting only affects readers opened afterward. Do not modify or truncate a
 file while it is open through the memory-mapped backend.
+
+## Seekable binary file objects
+
+`TsFileReader` also accepts a seekable binary file object. This allows remote
+files opened by libraries such as `fsspec` to be read without first copying the
+whole file to local storage.
+
+```python
+import fsspec
+from tsfile import TsFileReader
+
+with fsspec.open("s3://bucket/example.tsfile", "rb") as source:
+    with TsFileReader(source) as reader:
+        result = reader.query_table("table_name", ["column_name"])
+```
+
+The object must provide `seek()`, `tell()`, and explicitly sized binary
+`read(size)` operations. The caller owns the object: `TsFileReader` keeps it
+alive while in use, preserves its cursor position, and does not close it.
+The local `FileReadBackend` setting does not apply to file objects.

--- a/python/pom.xml
+++ b/python/pom.xml
@@ -196,6 +196,9 @@
                                 <include>*.h</include>
                                 <include>*.cpp</include>
                             </includes>
+                            <excludes>
+                                <exclude>python_random_access_file.h</exclude>
+                            </excludes>
                         </fileset>
                         <fileset>
                             <directory>tsfile.egg-info</directory>

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -65,6 +65,7 @@ include = ["tsfile*"]
 
 [tool.setuptools.package-data]
 tsfile = [
+    "python_random_access_file.h",
     "*.pxd",
     "*.pxi",
     "*.so",

--- a/python/setup.py
+++ b/python/setup.py
@@ -274,7 +274,12 @@ merge_common.update(
 exts = [
     Extension("tsfile.dataset._merge", ["tsfile/dataset/_merge.pyx"], **merge_common),
     Extension("tsfile.tsfile_py_cpp", ["tsfile/tsfile_py_cpp.pyx"], **common),
-    Extension("tsfile.tsfile_reader", ["tsfile/tsfile_reader.pyx"], **common),
+    Extension(
+        "tsfile.tsfile_reader",
+        ["tsfile/tsfile_reader.pyx", "tsfile/python_random_access_file.cc"],
+        depends=["tsfile/python_random_access_file.h"],
+        **common,
+    ),
     Extension("tsfile.tsfile_writer", ["tsfile/tsfile_writer.pyx"], **common),
 ]
 

--- a/python/tests/test_file_like_reader.py
+++ b/python/tests/test_file_like_reader.py
@@ -1,0 +1,203 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import gc
+import io
+import subprocess
+import sys
+import weakref
+from pathlib import Path
+
+import pytest
+
+from tsfile import TsFileReader
+from tsfile.exceptions import FileReadError
+
+RESOURCES = Path(__file__).parent / "resources"
+
+
+class TrackingBytesIO(io.BytesIO):
+    def __init__(self, data: bytes, max_chunk_size: int | None = None):
+        super().__init__(data)
+        self.max_chunk_size = max_chunk_size
+        self.read_sizes = []
+        self.close_calls = 0
+
+    def read(self, size=-1):
+        if size < 0:
+            raise AssertionError("TsFileReader must use explicitly sized reads")
+        self.read_sizes.append(size)
+        if self.max_chunk_size is not None:
+            size = min(size, self.max_chunk_size)
+        return super().read(size)
+
+    def close(self):
+        self.close_calls += 1
+        super().close()
+
+
+def collect_table_rows(source):
+    with TsFileReader(source) as reader:
+        result = reader.query_table("test", ["s0", "s2"])
+        try:
+            rows = []
+            while result.next():
+                rows.append(tuple(result.get_value_by_index(i) for i in range(1, 4)))
+            return rows
+        finally:
+            result.close()
+
+
+def collect_tree_rows(source):
+    with TsFileReader(source) as reader:
+        result = reader.query_timeseries(
+            "root.ln.wf01.wt01",
+            ["temperature", "status"],
+            0,
+            (1 << 63) - 1,
+        )
+        try:
+            rows = []
+            while result.next():
+                rows.append(tuple(result.get_value_by_index(i) for i in range(1, 4)))
+            return rows
+        finally:
+            result.close()
+
+
+def test_seekable_binary_source_matches_local_table_query_and_preserves_cursor():
+    path = RESOURCES / "simple_table_t1.tsfile"
+    expected = collect_table_rows(str(path))
+    source = TrackingBytesIO(path.read_bytes(), max_chunk_size=7)
+    source.seek(11)
+
+    actual = collect_table_rows(source)
+
+    assert actual == expected
+    assert source.tell() == 11
+    assert source.read_sizes
+    assert source.close_calls == 0
+
+
+def test_file_like_source_initializes_native_runtime_in_fresh_process():
+    path = RESOURCES / "simple_table_t1.tsfile"
+    script = """
+import io
+import sys
+from pathlib import Path
+
+from tsfile import TsFileReader
+
+source = io.BytesIO(Path(sys.argv[1]).read_bytes())
+source.seek(11)
+with TsFileReader(source) as reader:
+    result = reader.query_table("test", ["s0"])
+    try:
+        assert result.next()
+        assert result.get_value_by_index(1) == 1760106020000
+        assert result.get_value_by_index(2) == "a"
+    finally:
+        result.close()
+assert source.tell() == 11
+"""
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(path)],
+        cwd=Path(__file__).parents[1],
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_reader_keeps_source_alive_until_close_without_closing_it():
+    path = RESOURCES / "simple_table_t1.tsfile"
+    source = TrackingBytesIO(path.read_bytes())
+    source_ref = weakref.ref(source)
+    reader = TsFileReader(source)
+
+    del source
+    gc.collect()
+    assert source_ref() is not None
+
+    reader.close()
+    gc.collect()
+    assert source_ref() is None
+
+
+def test_seekable_binary_source_supports_tree_queries():
+    path = RESOURCES / "simple_tree.tsfile"
+    expected = collect_tree_rows(str(path))
+    source = TrackingBytesIO(path.read_bytes(), max_chunk_size=5)
+
+    assert collect_tree_rows(source) == expected
+
+
+def test_non_file_object_is_rejected():
+    with pytest.raises(TypeError, match="seekable binary file object"):
+        TsFileReader(object())
+
+
+def test_source_read_error_during_open_preserves_cursor():
+    path = RESOURCES / "simple_table_t1.tsfile"
+
+    class FailingBytesIO(TrackingBytesIO):
+        fail_reads = False
+
+        def read(self, size=-1):
+            if self.fail_reads:
+                raise OSError("remote read failed")
+            return super().read(size)
+
+    source = FailingBytesIO(path.read_bytes())
+    source.seek(13)
+    source.fail_reads = True
+
+    with pytest.raises(FileReadError):
+        TsFileReader(source)
+
+    assert source.tell() == 13
+    assert source.close_calls == 0
+
+
+def test_source_read_error_during_query_preserves_cursor_and_source():
+    path = RESOURCES / "simple_table_t1.tsfile"
+
+    class FailingBytesIO(TrackingBytesIO):
+        fail_reads = False
+
+        def read(self, size=-1):
+            if self.fail_reads:
+                raise OSError("remote read failed")
+            return super().read(size)
+
+    source = FailingBytesIO(path.read_bytes())
+    source.seek(17)
+
+    with TsFileReader(source) as reader:
+        source.fail_reads = True
+        with pytest.raises(FileReadError):
+            result = reader.query_table("test", ["s0"])
+            try:
+                result.next()
+            finally:
+                result.close()
+
+    assert source.tell() == 17
+    assert source.close_calls == 0

--- a/python/tsfile/python_random_access_file.cc
+++ b/python/tsfile/python_random_access_file.cc
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "python_random_access_file.h"
+
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <new>
+#include <string>
+#include <utility>
+
+#include "file/random_access_file.h"
+#include "reader/tsfile_reader.h"
+#include "utils/errno_define.h"
+
+namespace {
+
+class PythonSourceLock {
+   public:
+    explicit PythonSourceLock(std::mutex& mutex)
+        : gil_state_(PyGILState_Ensure()), lock_(mutex, std::defer_lock) {
+        PyThreadState* thread_state = PyEval_SaveThread();
+        lock_.lock();
+        PyEval_RestoreThread(thread_state);
+    }
+
+    ~PythonSourceLock() {
+        lock_.unlock();
+        PyGILState_Release(gil_state_);
+    }
+
+   private:
+    PyGILState_STATE gil_state_;
+    std::unique_lock<std::mutex> lock_;
+};
+
+bool has_callable_attribute(PyObject* source, const char* name) {
+    PyObject* attribute = PyObject_GetAttrString(source, name);
+    if (attribute == nullptr) {
+        PyErr_Clear();
+        return false;
+    }
+    const bool callable = PyCallable_Check(attribute) != 0;
+    Py_DECREF(attribute);
+    return callable;
+}
+
+bool seek_to(PyObject* source, int64_t offset, int whence) {
+    PyObject* result = PyObject_CallMethod(
+        source, "seek", "Li", static_cast<long long>(offset), whence);
+    if (result == nullptr) {
+        return false;
+    }
+    Py_DECREF(result);
+    return true;
+}
+
+bool tell_position(PyObject* source, int64_t& position) {
+    PyObject* result =
+        PyObject_CallMethod(source, const_cast<char*>("tell"), nullptr);
+    if (result == nullptr) {
+        return false;
+    }
+    const long long value = PyLong_AsLongLong(result);
+    Py_DECREF(result);
+    if (value == -1 && PyErr_Occurred()) {
+        return false;
+    }
+    position = static_cast<int64_t>(value);
+    return true;
+}
+
+void restore_position_preserving_error(PyObject* source, int64_t position) {
+    PyObject* error_type = nullptr;
+    PyObject* error_value = nullptr;
+    PyObject* traceback = nullptr;
+    PyErr_Fetch(&error_type, &error_value, &traceback);
+    if (!seek_to(source, position, 0)) {
+        PyErr_Clear();
+    }
+    PyErr_Restore(error_type, error_value, traceback);
+}
+
+std::string source_name(PyObject* source) {
+    std::string name("<python-file>");
+    PyObject* value = PyObject_GetAttrString(source, "name");
+    if (value == nullptr) {
+        PyErr_Clear();
+        return name;
+    }
+    if (PyUnicode_Check(value)) {
+        const char* text = PyUnicode_AsUTF8(value);
+        if (text != nullptr) {
+            name.assign(text);
+        } else {
+            PyErr_Clear();
+        }
+    } else if (PyBytes_Check(value)) {
+        char* text = nullptr;
+        Py_ssize_t length = 0;
+        if (PyBytes_AsStringAndSize(value, &text, &length) == 0) {
+            name.assign(text, static_cast<size_t>(length));
+        } else {
+            PyErr_Clear();
+        }
+    }
+    Py_DECREF(value);
+    return name;
+}
+
+class PythonRandomAccessFile : public storage::RandomAccessFile {
+   public:
+    PythonRandomAccessFile(PyObject* source, int64_t size, std::string name)
+        : source_(source), size_(size), name_(std::move(name)) {
+        Py_INCREF(source_);
+    }
+
+    ~PythonRandomAccessFile() override { close(); }
+
+    bool is_opened() const override {
+        PythonSourceLock lock(mutex_);
+        return source_ != nullptr;
+    }
+
+    int64_t file_size() const override { return size_; }
+
+    const std::string& file_path() const override { return name_; }
+
+    int generation(uint64_t& size, uint64_t& fingerprint) const override {
+        PythonSourceLock lock(mutex_);
+        if (source_ == nullptr) {
+            return common::E_FILE_READ_ERR;
+        }
+        size = static_cast<uint64_t>(size_);
+        fingerprint = 0;
+        return common::E_OK;
+    }
+
+    int read(int64_t offset, char* buffer, int32_t size,
+             int32_t& read_size) override {
+        read_size = 0;
+        if (offset < 0 || size < 0 || (buffer == nullptr && size > 0)) {
+            return common::E_INVALID_ARG;
+        }
+
+        PythonSourceLock lock(mutex_);
+        if (source_ == nullptr) {
+            return common::E_FILE_READ_ERR;
+        }
+        if (size == 0 || offset >= size_) {
+            return common::E_OK;
+        }
+
+        const int64_t available = size_ - offset;
+        const int32_t requested = static_cast<int32_t>(
+            std::min<int64_t>(available, static_cast<int64_t>(size)));
+
+        int ret = common::E_OK;
+        int64_t saved_position = 0;
+        const bool has_saved_position = tell_position(source_, saved_position);
+        if (!has_saved_position || !seek_to(source_, offset, 0)) {
+            PyErr_Clear();
+            ret = common::E_FILE_READ_ERR;
+        }
+
+        while (ret == common::E_OK && read_size < requested) {
+            const int32_t remaining = requested - read_size;
+            PyObject* chunk =
+                PyObject_CallMethod(source_, "read", "i", remaining);
+            if (chunk == nullptr) {
+                PyErr_Clear();
+                ret = common::E_FILE_READ_ERR;
+                break;
+            }
+
+            Py_buffer view;
+            if (PyObject_GetBuffer(chunk, &view, PyBUF_CONTIG_RO) != 0) {
+                PyErr_Clear();
+                Py_DECREF(chunk);
+                ret = common::E_FILE_READ_ERR;
+                break;
+            }
+            if (view.len < 0 || view.len > remaining) {
+                ret = common::E_FILE_READ_ERR;
+            } else if (view.len == 0) {
+                PyBuffer_Release(&view);
+                Py_DECREF(chunk);
+                break;
+            } else {
+                std::memcpy(buffer + read_size, view.buf,
+                            static_cast<size_t>(view.len));
+                read_size += static_cast<int32_t>(view.len);
+            }
+            PyBuffer_Release(&view);
+            Py_DECREF(chunk);
+        }
+
+        if (has_saved_position && !seek_to(source_, saved_position, 0)) {
+            PyErr_Clear();
+            ret = common::E_FILE_READ_ERR;
+        }
+        return ret;
+    }
+
+    void close() override {
+        PythonSourceLock lock(mutex_);
+        if (source_ == nullptr) {
+            return;
+        }
+        Py_DECREF(source_);
+        source_ = nullptr;
+    }
+
+   private:
+    PyObject* source_;
+    int64_t size_;
+    std::string name_;
+    mutable std::mutex mutex_;
+};
+
+}  // namespace
+
+void* create_tsfile_reader_from_python_file(PyObject* source,
+                                            int32_t* error_code) {
+    if (error_code == nullptr) {
+        PyErr_SetString(PyExc_ValueError, "error_code must not be null");
+        return nullptr;
+    }
+    *error_code = common::E_OK;
+    if (source == nullptr || !has_callable_attribute(source, "seek") ||
+        !has_callable_attribute(source, "tell") ||
+        !has_callable_attribute(source, "read")) {
+        *error_code = common::E_INVALID_ARG;
+        PyErr_SetString(PyExc_TypeError,
+                        "source must be a seekable binary file object");
+        return nullptr;
+    }
+
+    int64_t original_position = 0;
+    if (!tell_position(source, original_position)) {
+        *error_code = common::E_FILE_OPEN_ERR;
+        return nullptr;
+    }
+    if (!seek_to(source, 0, 2)) {
+        *error_code = common::E_FILE_OPEN_ERR;
+        restore_position_preserving_error(source, original_position);
+        return nullptr;
+    }
+
+    int64_t size = 0;
+    if (!tell_position(source, size)) {
+        *error_code = common::E_FILE_OPEN_ERR;
+        restore_position_preserving_error(source, original_position);
+        return nullptr;
+    }
+    if (!seek_to(source, original_position, 0)) {
+        *error_code = common::E_FILE_OPEN_ERR;
+        return nullptr;
+    }
+    if (size < 0) {
+        *error_code = common::E_INVALID_ARG;
+        PyErr_SetString(PyExc_ValueError,
+                        "source returned a negative file size");
+        return nullptr;
+    }
+
+    try {
+        *error_code = storage::libtsfile_init();
+        if (*error_code != common::E_OK) {
+            return nullptr;
+        }
+        std::unique_ptr<storage::RandomAccessFile> random_access_file(
+            new PythonRandomAccessFile(source, size, source_name(source)));
+        std::unique_ptr<storage::TsFileReader> reader(
+            new storage::TsFileReader());
+        *error_code = reader->open(std::move(random_access_file));
+        if (*error_code != common::E_OK) {
+            return nullptr;
+        }
+        return reader.release();
+    } catch (const std::bad_alloc&) {
+        *error_code = common::E_OOM;
+    } catch (...) {
+        *error_code = common::E_FILE_OPEN_ERR;
+    }
+    return nullptr;
+}

--- a/python/tsfile/python_random_access_file.h
+++ b/python/tsfile/python_random_access_file.h
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef PYTHON_TSFILE_PYTHON_RANDOM_ACCESS_FILE_H
+#define PYTHON_TSFILE_PYTHON_RANDOM_ACCESS_FILE_H
+
+#include <Python.h>
+#include <stdint.h>
+
+void* create_tsfile_reader_from_python_file(PyObject* source,
+                                            int32_t* error_code);
+
+#endif  // PYTHON_TSFILE_PYTHON_RANDOM_ACCESS_FILE_H

--- a/python/tsfile/tsfile_reader.pyx
+++ b/python/tsfile/tsfile_reader.pyx
@@ -25,6 +25,7 @@ import pandas as pd
 from libc.string cimport strlen
 from libc.stdlib cimport free, malloc
 from cpython.bytes cimport PyBytes_FromStringAndSize
+from cpython.ref cimport PyObject
 from libc.string cimport memset
 import pyarrow as pa
 from libc.stdint cimport INT64_MIN, INT64_MAX, uint32_t, uintptr_t
@@ -36,6 +37,10 @@ from tsfile.tag_filter import ComparisonTagFilter, BetweenTagFilter, AndTagFilte
 from .date_utils import parse_int_to_date
 from .tsfile_cpp cimport *
 from .tsfile_py_cpp cimport *
+
+cdef extern from "python_random_access_file.h":
+    TsFileReader create_tsfile_reader_from_python_file(
+        PyObject* source, int32_t* error_code) except? NULL
 
 cdef class ResultSetPy:
     """
@@ -344,7 +349,7 @@ cdef class PreparedSeriesPy:
 
 cdef class TsFileReaderPy:
     """
-    Cython wrapper class for interacting with TsFileReader C implementation.
+    Cython wrapper class for interacting with the native TsFileReader.
 
     Provides a Pythonic interface to read and query time series data from TsFiles.
     """
@@ -355,16 +360,22 @@ cdef class TsFileReaderPy:
     cdef TsFileReader reader
     cdef object activate_result_set_list
 
-    def __init__(self, pathname):
+    def __init__(self, source):
         """
-        Initialize a TsFile reader for the specified file path.
+        Initialize a TsFile reader from a path or seekable binary file object.
         """
         self.reader = NULL
         self.activate_result_set_list = weakref.WeakSet()
-        self.init_reader(pathname)
+        self.init_reader(source)
 
-    cdef init_reader(self, pathname):
-        self.reader = tsfile_reader_new_c(pathname)
+    cdef init_reader(self, source):
+        cdef ErrorCode error_code = 0
+        if isinstance(source, str):
+            self.reader = tsfile_reader_new_c(source)
+            return
+        self.reader = create_tsfile_reader_from_python_file(
+            <PyObject*>source, &error_code)
+        check_error(error_code)
 
     def query_table(self, table_name : str, column_names : List[str],
                     start_time : int = INT64_MIN, end_time : int = INT64_MAX,


### PR DESCRIPTION
## Summary

- introduce a C++ `RandomAccessFile` abstraction while keeping local paths on `ReadFile`
- allow Python `TsFileReader` to consume seekable binary file objects without changing the path-only C API
- preserve caller ownership and cursor state, and propagate remote read failures through the existing error model
- package the private Python bridge and document `fsspec` usage

## Testing

- `./mvnw clean verify -P with-python`
- C++ test binary: 922 passed, 3 skipped
- Python tests: 246 passed
- real Hugging Face `HfFileSystem.open()` comparison: 19,701 rows and 29 columns matched a local copy exactly
- file-object cursor, lifetime, short-read, open-error, query-error, and reader-move coverage

Fixes #930
