### PR TITLE
Fix VectorMeasurementSchema stream deserialization

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/write/schema/VectorMeasurementSchema.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/schema/VectorMeasurementSchema.java
@@ -30,6 +30,8 @@ import org.apache.tsfile.utils.RamUsageEstimator;
 import org.apache.tsfile.utils.ReadWriteIOUtils;
 import org.apache.tsfile.utils.StringContainer;
 
+import java.io.DataInputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -420,9 +422,11 @@ public class VectorMeasurementSchema
     vectorMeasurementSchema.unifiedCompressor = ReadWriteIOUtils.readByte(inputStream);
     if (vectorMeasurementSchema.unifiedCompressor == NO_UNIFIED_COMPRESSOR) {
       byte[] compressors = new byte[measurementSize + 1];
-      int read = inputStream.read(compressors);
-      if (read != measurementSize) {
-        throw new IOException(Messages.get("error.write.schema_vector_unexpected_end_of_stream"));
+      try {
+        new DataInputStream(inputStream).readFully(compressors);
+      } catch (EOFException e) {
+        throw new IOException(
+            Messages.get("error.write.schema_vector_unexpected_end_of_stream"), e);
       }
       vectorMeasurementSchema.compressors = compressors;
     }

--- a/java/tsfile/src/test/java/org/apache/tsfile/write/writer/MeasurementSchemaSerializeTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/write/writer/MeasurementSchemaSerializeTest.java
@@ -19,17 +19,23 @@
 package org.apache.tsfile.write.writer;
 
 import org.apache.tsfile.enums.TSDataType;
+import org.apache.tsfile.file.metadata.enums.CompressionType;
 import org.apache.tsfile.file.metadata.enums.TSEncoding;
 import org.apache.tsfile.write.schema.MeasurementSchema;
+import org.apache.tsfile.write.schema.VectorMeasurementSchema;
 
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class MeasurementSchemaSerializeTest {
 
@@ -53,5 +59,106 @@ public class MeasurementSchemaSerializeTest {
     ByteArrayInputStream inputStream = new ByteArrayInputStream(byteBuffer.array());
     MeasurementSchema measurementSchema = MeasurementSchema.deserializeFrom(inputStream);
     assertEquals(standard, measurementSchema);
+  }
+
+  @Test
+  public void deserializeVectorWithUnifiedCompressorFromInputStreamTest() throws IOException {
+    VectorMeasurementSchema standard = createVectorSchema(CompressionType.LZ4);
+    ByteArrayInputStream inputStream = serializeToInputStream(standard);
+
+    VectorMeasurementSchema measurementSchema =
+        VectorMeasurementSchema.deserializeFrom(inputStream);
+
+    assertVectorSchemaEquals(standard, measurementSchema);
+    assertEquals(-1, inputStream.read());
+  }
+
+  @Test
+  public void deserializeVectorWithPerColumnCompressorsFromInputStreamTest() throws IOException {
+    VectorMeasurementSchema standard = createVectorSchemaWithPerColumnCompressors();
+    ByteArrayInputStream inputStream = serializeToInputStream(standard);
+
+    VectorMeasurementSchema measurementSchema =
+        VectorMeasurementSchema.deserializeFrom(inputStream);
+
+    assertVectorSchemaEquals(standard, measurementSchema);
+    assertEquals(-1, inputStream.read());
+  }
+
+  @Test
+  public void deserializeVectorWithPerColumnCompressorsFromShortReadInputStreamTest()
+      throws IOException {
+    VectorMeasurementSchema standard = createVectorSchemaWithPerColumnCompressors();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    standard.serializeTo(outputStream);
+    byte[] serialized = outputStream.toByteArray();
+    int compressorListStart = serialized.length - standard.getSubMeasurementsCount() - 1;
+    int shortReadBoundary = compressorListStart + 1;
+    InputStream inputStream =
+        new SequenceInputStream(
+            new ByteArrayInputStream(Arrays.copyOf(serialized, shortReadBoundary)),
+            new ByteArrayInputStream(
+                Arrays.copyOfRange(serialized, shortReadBoundary, serialized.length)));
+
+    VectorMeasurementSchema measurementSchema =
+        VectorMeasurementSchema.deserializeFrom(inputStream);
+
+    assertVectorSchemaEquals(standard, measurementSchema);
+    assertEquals(-1, inputStream.read());
+  }
+
+  @Test
+  public void deserializeVectorRejectsTruncatedPerColumnCompressors() throws IOException {
+    VectorMeasurementSchema standard = createVectorSchemaWithPerColumnCompressors();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    standard.serializeTo(outputStream);
+    byte[] serialized = outputStream.toByteArray();
+    ByteArrayInputStream inputStream =
+        new ByteArrayInputStream(Arrays.copyOf(serialized, serialized.length - 1));
+
+    assertThrows(IOException.class, () -> VectorMeasurementSchema.deserializeFrom(inputStream));
+  }
+
+  private static VectorMeasurementSchema createVectorSchema(CompressionType compressionType) {
+    return new VectorMeasurementSchema(
+        "device",
+        new String[] {"sensor_1", "sensor_2"},
+        new TSDataType[] {TSDataType.FLOAT, TSDataType.INT64},
+        new TSEncoding[] {TSEncoding.RLE, TSEncoding.TS_2DIFF},
+        compressionType);
+  }
+
+  private static VectorMeasurementSchema createVectorSchemaWithPerColumnCompressors() {
+    return new VectorMeasurementSchema(
+        "device",
+        new String[] {"sensor_1", "sensor_2"},
+        new TSDataType[] {TSDataType.FLOAT, TSDataType.INT64},
+        new TSEncoding[] {TSEncoding.RLE, TSEncoding.TS_2DIFF},
+        new byte[] {
+          CompressionType.LZ4.serialize(),
+          CompressionType.SNAPPY.serialize(),
+          CompressionType.GZIP.serialize()
+        });
+  }
+
+  private static ByteArrayInputStream serializeToInputStream(VectorMeasurementSchema schema)
+      throws IOException {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    schema.serializeTo(outputStream);
+    return new ByteArrayInputStream(outputStream.toByteArray());
+  }
+
+  private static void assertVectorSchemaEquals(
+      VectorMeasurementSchema expected, VectorMeasurementSchema actual) {
+    assertEquals(expected.getMeasurementName(), actual.getMeasurementName());
+    assertEquals(expected.getSubMeasurementsList(), actual.getSubMeasurementsList());
+    assertEquals(
+        expected.getSubMeasurementsTSDataTypeList(), actual.getSubMeasurementsTSDataTypeList());
+    assertEquals(
+        expected.getSubMeasurementsTSEncodingList(), actual.getSubMeasurementsTSEncodingList());
+    assertEquals(expected.getTimeCompressor(), actual.getTimeCompressor());
+    for (int i = 0; i < expected.getSubMeasurementsCount(); i++) {
+      assertEquals(expected.getValueCompressor(i), actual.getValueCompressor(i));
+    }
   }
 }


### PR DESCRIPTION
## Summary

- fix VectorMeasurementSchema.deserializeFrom(InputStream) to read the complete time/value compressor list
- preserve unified-compressor behavior and reject truncated per-column compressor data
- add regression coverage for round trips, short reads, and truncated streams

## Compatibility

- no public API or serialized-format changes
- valid existing serialized schemas remain readable
- streams with truncated compressor data now fail fast instead of being accepted or decoded incorrectly

## Testing

- ./mvnw test -P with-java -pl java/tsfile -am