### PR TITLE
fix(python): preserve null dataset field values

### DIFF
--- a/python/tests/test_tsfile_dataset.py
+++ b/python/tests/test_tsfile_dataset.py
@@ -227,6 +227,31 @@ def _write_weather_timestamp_field_file(path, start):
         )
 
 
+def _write_weather_nullable_boolean_timestamp_file(path, start):
+    schema = TableSchema(
+        "weather",
+        [
+            ColumnSchema("device", TSDataType.STRING, ColumnCategory.TAG),
+            ColumnSchema("online", TSDataType.BOOLEAN, ColumnCategory.FIELD),
+            ColumnSchema("observed_at", TSDataType.TIMESTAMP, ColumnCategory.FIELD),
+        ],
+    )
+    with TsFileTableWriter(str(path), schema) as writer:
+        writer.write_dataframe(
+            pd.DataFrame(
+                {
+                    "time": [start, start + 1, start + 2],
+                    "device": ["device_a", "device_a", "device_a"],
+                    "online": pd.array([True, pd.NA, False], dtype="boolean"),
+                    "observed_at": pd.array(
+                        [1_700_000_000_000, pd.NA, 1_700_000_000_002],
+                        dtype="Int64",
+                    ),
+                }
+            )
+        )
+
+
 def _write_multi_tag_file(path):
     schema = TableSchema(
         "weather",
@@ -1214,6 +1239,30 @@ def test_dataset_table_model_exposes_timestamp_fields_as_float64(
         np.testing.assert_array_equal(
             values, np.array([1_700_000_000_000.0, 1_700_000_000_001.0])
         )
+
+
+def test_dataset_nullable_numeric_compatible_fields_use_nan(
+    tmp_path, dataframe_use_index
+):
+    path = tmp_path / "weather_nullable.tsfile"
+    _write_weather_nullable_boolean_timestamp_file(path, 0)
+    expected = {
+        "weather.device_a.online": np.array([1.0, np.nan, 0.0]),
+        "weather.device_a.observed_at": np.array(
+            [1_700_000_000_000.0, np.nan, 1_700_000_000_002.0]
+        ),
+    }
+
+    with TsFileDataFrame(
+        str(path), show_progress=False, use_index=dataframe_use_index
+    ) as tsdf:
+        for series_name, values in expected.items():
+            np.testing.assert_equal(tsdf[series_name][:], values)
+
+        aligned = tsdf.loc[:, list(expected)]
+        by_name = dict(zip(aligned.series_names, aligned.values.T))
+        for series_name, values in expected.items():
+            np.testing.assert_equal(by_name[series_name], values)
 
 
 def test_dataset_close_waits_for_an_active_public_query(tmp_path, monkeypatch):

--- a/python/tsfile/dataset/_arrow.py
+++ b/python/tsfile/dataset/_arrow.py
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+"""Internal Arrow conversion helpers for dataset readers."""
+
+import numpy as np
+
+
+def arrow_column_to_float64(column):
+    """Convert a numeric-compatible Arrow column and preserve its nulls."""
+    values = np.asarray(
+        column.to_numpy(zero_copy_only=False),
+        dtype=np.float64,
+    )
+    if column.null_count:
+        # Arrow timestamps become NumPy NaT, whose float64 representation is
+        # INT64_MIN. Reapply Arrow's authoritative null mask for every type.
+        values = values.copy()
+        values[column.is_null().to_numpy(zero_copy_only=False)] = np.nan
+    return values

--- a/python/tsfile/dataset/reader.py
+++ b/python/tsfile/dataset/reader.py
@@ -27,6 +27,7 @@ import numpy as np
 from ..constants import ColumnCategory, NUMERIC_DATASET_FIELD_TYPES, TSDataType
 from ..tag_filter import tag_eq, tag_is_null
 from ..tsfile_reader import TsFileReaderPy
+from ._arrow import arrow_column_to_float64
 from .metadata import (
     MetadataCatalog,
     MODEL_TABLE,
@@ -550,10 +551,9 @@ class TsFileSeriesReader:
                     if arrow_table.num_rows == 0:
                         continue
                     timestamp_parts.append(arrow_table.column("time").to_numpy())
-                    raw_values = arrow_table.column(field_name).to_numpy(
-                        zero_copy_only=False
+                    value_parts.append(
+                        arrow_column_to_float64(arrow_table.column(field_name))
                     )
-                    value_parts.append(np.asarray(raw_values, dtype=np.float64))
                     produced_this_call += arrow_table.num_rows
 
             if produced_this_call == 0:
@@ -723,10 +723,9 @@ class TsFileSeriesReader:
 
                 timestamp_parts.append(arrow_table.column("time").to_numpy())
                 for field_column in field_columns:
-                    raw_values = arrow_table.column(field_column).to_numpy()
                     try:
                         field_parts[field_column].append(
-                            np.asarray(raw_values, dtype=np.float64)
+                            arrow_column_to_float64(arrow_table.column(field_column))
                         )
                     except (TypeError, ValueError) as e:
                         raise TypeError(

--- a/python/tsfile/dataset/runtime.py
+++ b/python/tsfile/dataset/runtime.py
@@ -33,6 +33,7 @@ import numpy as np
 from ..constants import NUMERIC_DATASET_FIELD_TYPES, TSDataType
 from ..tag_filter import tag_eq, tag_is_null
 from ..tsfile_reader import TsFileReaderPy
+from ._arrow import arrow_column_to_float64
 from .index import (
     COLUMN_NAME_INDEX,
     COLUMN_SCHEMA,
@@ -846,12 +847,7 @@ class RuntimeSeriesReader:
                         dtype=np.int64,
                     )
                 )
-                value_parts.append(
-                    np.asarray(
-                        arrow_batch.column(1).to_numpy(zero_copy_only=False),
-                        dtype=np.float64,
-                    )
-                )
+                value_parts.append(arrow_column_to_float64(arrow_batch.column(1)))
         if not timestamp_parts:
             return np.array([], dtype=np.int64), np.array([], dtype=np.float64)
         if len(timestamp_parts) == 1:
@@ -880,12 +876,7 @@ class RuntimeSeriesReader:
                 )
                 for column_index, name in enumerate(column_names, start=1):
                     value_parts[name].append(
-                        np.asarray(
-                            arrow_batch.column(column_index).to_numpy(
-                                zero_copy_only=False
-                            ),
-                            dtype=np.float64,
-                        )
+                        arrow_column_to_float64(arrow_batch.column(column_index))
                     )
         if not timestamp_parts:
             return np.array([], dtype=np.int64), {


### PR DESCRIPTION
## Summary

This PR fixes null handling for numeric-compatible fields in `TsFileDataFrame`.

When a nullable `TIMESTAMP` field was read through PyArrow, its null value was converted to NumPy `NaT`. Casting that array directly to `float64` produced `INT64_MIN` (`-9.223372e18`) instead of the expected `NaN`.

## Changes

- Add a shared Arrow-to-`float64` conversion helper.
- Reapply Arrow's authoritative null bitmap after conversion so null values are represented as `np.nan`.
- Use the shared conversion in both:
  - the non-indexed dataset reader;
  - the indexed runtime reader, including single-series and multi-series reads.
- Add regression coverage for nullable `BOOLEAN` and `TIMESTAMP` fields with:
  - `use_index=False`;
  - `use_index=True`;
  - single-series reads;
  - aligned multi-series reads.

The C++ Arrow layer already reports the correct types and null bitmap, so no C++ changes are required.

This is a follow-up to #935.

## Test

```shell
python -X faulthandler -m pytest tests -q