### PR TITLE
ci: pin pnpm/action-setup to ASF allowlist SHA and fix policy issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,11 +19,7 @@
 
 version: 2
 updates:
-- package-ecosystem: maven
-  directory: /
-  schedule:
-    interval: monthly
-- package-ecosystem: github-actions
-  directory: /
-  schedule:
-    interval: monthly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 name: Greetings
 
-on: [issues, pull_request_target]
+on: [issues]
 
 jobs:
   greeting:
@@ -11,4 +11,3 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         issue-message: 'Hi, this is your first issue in the Apache TsFile project. Thanks for your report. Welcome to join the community!'
-        pr-message: 'Hi, this is your first pull request in the Apache TsFile project. Thanks for your contribution! TsFile will be better because of you.'

--- a/.github/workflows/site-build.yaml
+++ b/.github/workflows/site-build.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           package_json_file: 'package.json'
           run_install: true
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           package_json_file: 'package.json'
           run_install: true


### PR DESCRIPTION
## Summary

Align `docs/dev` CI config with the ASF GitHub Actions policy.

1. **Pin `pnpm/action-setup` to the ASF allowlist SHA** (`site-build.yaml`, 2 jobs)
   - `pnpm/action-setup@v4` -> `pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10`
   - This SHA is the only `pnpm/action-setup` entry in [apache/infrastructure-actions/actions.yml](https://github.com/apache/infrastructure-actions/blob/main/actions.yml).
   - Node 20 from `actions/setup-node@v4` satisfies the action v6 requirement (Node >= 20).

2. **Dependabot** (`.github/dependabot.yml`)
   - `github-actions` ecosystem interval changed `monthly` -> `weekly`.
   - Removed the `maven` entry: the `docs/dev` branch has no `pom.xml`, so Dependabot can never resolve it on this branch.

3. **Remove `pull_request_target` from greetings** (`greetings.yml`)
   - The policy states: *"You MUST NOT use pull_request_target as a trigger on ANY action that exports ANY confidential credentials or tokens such as GITHUB_TOKEN"*.
   - The workflow previously ran on `pull_request_target` and passed `GITHUB_TOKEN` to `actions/first-interaction`, so the PR trigger was dropped; the first-issue greeting on `issues` is unchanged.

## Policy audit

- All other `uses:` are `actions/*` official actions (checkout, setup-node, first-interaction) -> exempt from the allowlist.
- No `container:` image references.
- Concurrency: `site-build.yaml` has a `concurrency` group with `cancel-in-progress`; 2 jobs, no matrix -> well below the 20-job MUST limit.

Ref: https://infra.apache.org/github-actions-policy.html