### PR TITLE
perf(cpp): share a writer-owned schema cache across tree and table writes

### DIFF
--- a/cpp/src/common/schema.h
+++ b/cpp/src/common/schema.h
@@ -28,6 +28,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "common/db_common.h"
 #include "writer/time_chunk_writer.h"
@@ -173,6 +174,8 @@ struct MeasurementSchemaGroup {
     // measurement_name -> MeasurementSchema
     MeasurementSchemaMap measurement_schema_map_;
     bool is_aligned_ = false;
+    // New aligned fields cannot be inserted into already flushed chunks.
+    bool has_flushed_ = false;
     TimeChunkWriter* time_chunk_writer_ = nullptr;
     int64_t last_time_ = INT64_MIN;
 

--- a/cpp/src/common/tsfile_common.h
+++ b/cpp/src/common/tsfile_common.h
@@ -78,6 +78,10 @@ struct PageHeader {
         int ret = common::E_OK;
         if (RET_FAIL(common::SerializationUtil::read_var_uint(
                 uncompressed_size_, in))) {
+        } else if (uncompressed_size_ == 0) {
+            // An empty aligned value page contains only this zero varint.
+            compressed_size_ = 0;
+            return common::E_OK;
         } else if (RET_FAIL(common::SerializationUtil::read_var_uint(
                        compressed_size_, in))) {
         } else if (deserialize_stat) {

--- a/cpp/src/file/restorable_tsfile_io_writer.cc
+++ b/cpp/src/file/restorable_tsfile_io_writer.cc
@@ -263,6 +263,16 @@ static int recover_chunk_statistic(
                                  kTimeChunkTypeMask) != 0;
     PageHeader ph;
     int ret = ph.deserialize_from(bs, false, chdr.data_type_);
+    const unsigned char column_type =
+        static_cast<unsigned char>(chdr.chunk_type_) &
+        (kTimeChunkTypeMask | VALUE_COLUMN_MASK);
+    if (ret == common::E_OK && column_type == VALUE_COLUMN_MASK &&
+        ph.uncompressed_size_ == 0 && bs.remaining_size() == 0) {
+        // A late-registered aligned field can contain one empty page encoded
+        // as a single zero varint. It contributes no values to the statistic,
+        // but its metadata and the following chunks must survive recovery.
+        return common::E_OK;
+    }
     if (ret != common::E_OK || ph.compressed_size_ == 0 ||
         bs.remaining_size() < ph.compressed_size_) {
         // Align with Java selfCheck behavior: malformed/incomplete page in this

--- a/cpp/src/reader/aligned_chunk_reader.cc
+++ b/cpp/src/reader/aligned_chunk_reader.cc
@@ -611,6 +611,9 @@ int AlignedChunkReader::decode_cur_value_page_data() {
     uint32_t value_buf_size = 0;
 
     if (cur_value_page_header_.compressed_size_ == 0) {
+        value_page_col_notnull_bitmap_.clear();
+        cur_value_index = -1;
+        value_decoder_->reset();
         value_in_.wrap_from(value_buf, 0);
         return E_OK;
     }

--- a/cpp/src/writer/tsfile_writer.cc
+++ b/cpp/src/writer/tsfile_writer.cc
@@ -21,6 +21,7 @@
 
 #include <chrono>
 #include <iomanip>
+#include <unordered_set>
 
 #include "chunk_writer.h"
 #include "common/config/config.h"
@@ -83,6 +84,9 @@ TsFileWriter::TsFileWriter()
 TsFileWriter::~TsFileWriter() { destroy(); }
 
 void TsFileWriter::destroy() {
+    cached_device_schema_ = nullptr;
+    cached_measurement_schemas_.reset();
+    schema_cache_.clear();
     if (write_file_created_ && write_file_ != nullptr) {
         delete write_file_;
         write_file_ = nullptr;
@@ -189,6 +193,8 @@ int TsFileWriter::init(RestorableTsFileIOWriter* rw) {
                 rw->is_device_aligned(device_id->get_table_name());
             schemas_.insert(std::make_pair(device_id, group));
         }
+
+        group->has_flushed_ = true;
 
         // Add measurement schemas from this CGM (skip time column: empty name).
         for (auto iter = cgm->chunk_meta_list_.begin();
@@ -300,10 +306,12 @@ int TsFileWriter::open(const std::string& file_path) {
 
 int TsFileWriter::register_aligned_timeseries(
     const std::string& device_id, const MeasurementSchema& measurement_schema) {
-    MeasurementSchema* ms = new MeasurementSchema(
+    std::unique_ptr<MeasurementSchema> ms(new MeasurementSchema(
         measurement_schema.measurement_name_, measurement_schema.data_type_,
-        measurement_schema.encoding_, measurement_schema.compression_type_);
-    return register_timeseries(device_id, ms, true);
+        measurement_schema.encoding_, measurement_schema.compression_type_));
+    int ret = register_timeseries(device_id, ms.get(), true);
+    if (IS_SUCC(ret)) ms.release();
+    return ret;
 }
 
 int TsFileWriter::register_aligned_timeseries(
@@ -321,10 +329,12 @@ int TsFileWriter::register_aligned_timeseries(
 
 int TsFileWriter::register_timeseries(
     const std::string& device_id, const MeasurementSchema& measurement_schema) {
-    MeasurementSchema* ms = new MeasurementSchema(
+    std::unique_ptr<MeasurementSchema> ms(new MeasurementSchema(
         measurement_schema.measurement_name_, measurement_schema.data_type_,
-        measurement_schema.encoding_, measurement_schema.compression_type_);
-    return register_timeseries(device_id, ms, false);
+        measurement_schema.encoding_, measurement_schema.compression_type_));
+    int ret = register_timeseries(device_id, ms.get(), false);
+    if (IS_SUCC(ret)) ms.release();
+    return ret;
 }
 
 int TsFileWriter::register_timeseries(const std::string& device_path,
@@ -336,10 +346,27 @@ int TsFileWriter::register_timeseries(const std::string& device_path,
     if (device_iter != schemas_.end()) {
         MeasurementSchemaMap& msm =
             device_iter->second->measurement_schema_map_;
+        if (device_iter->second->is_aligned_ &&
+            device_iter->second->has_flushed_ &&
+            msm.find(measurement_schema->measurement_name_) == msm.end()) {
+            return E_NOT_SUPPORT;
+        }
         MeasurementSchemaMapInsertResult ins_res = msm.insert(std::make_pair(
             measurement_schema->measurement_name_, measurement_schema));
         if (UNLIKELY(!ins_res.second)) {
             return E_ALREADY_EXIST;
+        }
+        auto* time_writer = device_iter->second->time_chunk_writer_;
+        if (device_iter->second->is_aligned_ && time_writer != nullptr &&
+            time_writer->hasData()) {
+            // Registration can be followed immediately by flush, without
+            // another write to trigger schema resolution.
+            int ret =
+                init_aligned_value_writer(measurement_schema, time_writer);
+            if (IS_FAIL(ret)) {
+                msm.erase(ins_res.first);
+                return ret;
+            }
         }
     } else {
         MeasurementSchemaGroup* ms_group = new MeasurementSchemaGroup;
@@ -464,6 +491,96 @@ std::shared_ptr<TableSchema> TsFileWriter::get_table_schema(
     return it->second;
 }
 
+void TsFileWriter::prepare_schema_cache(MeasurementSchemaGroup* device_schema,
+                                        uint32_t measurement_count) {
+    if (cached_device_schema_ != device_schema) {
+        if (!schema_cache_.tryGetRef(device_schema,
+                                     cached_measurement_schemas_)) {
+            cached_measurement_schemas_ =
+                std::make_shared<CachedMeasurementSchemas>();
+            schema_cache_.insert(device_schema, cached_measurement_schemas_);
+        }
+        cached_device_schema_ = device_schema;
+    }
+    auto& cache = *cached_measurement_schemas_;
+    if (cache.supplied.size() != measurement_count ||
+        cache.registered_count !=
+            device_schema->measurement_schema_map_.size()) {
+        cache.changed = true;
+    }
+    cache.supplied.resize(measurement_count, nullptr);
+}
+
+MeasurementSchema* TsFileWriter::get_cached_measurement_schema(
+    const std::string& measurement_name, uint32_t column_index) {
+    MeasurementSchema*& cached =
+        cached_measurement_schemas_->supplied[column_index];
+    // Compare the actual name at each position, including when the number of
+    // columns changes. A null entry must be looked up again: its measurement
+    // may have been registered since the previous write.
+    if (cached == nullptr || cached->measurement_name_ != measurement_name) {
+        const auto& schemas = cached_device_schema_->measurement_schema_map_;
+        auto it = schemas.find(measurement_name);
+        MeasurementSchema* resolved =
+            it == schemas.end() ? nullptr : it->second;
+        if (cached != resolved) cached_measurement_schemas_->changed = true;
+        cached = resolved;
+    }
+    return cached;
+}
+
+int TsFileWriter::init_aligned_value_writer(MeasurementSchema* schema,
+                                            TimeChunkWriter* time_writer) {
+    if (schema->value_chunk_writer_ != nullptr) return E_OK;
+    std::unique_ptr<ValueChunkWriter> writer(new ValueChunkWriter);
+    int ret = writer->init(schema->measurement_name_, schema->data_type_,
+                           schema->encoding_, schema->compression_type_);
+    if (IS_FAIL(ret)) return ret;
+    // A field registered before the first flush may still be new to an open
+    // chunk. Match all previously sealed pages and the current page's rows.
+    for (int32_t page = 0; page < time_writer->num_of_pages(); ++page) {
+        if (RET_FAIL(writer->write_empty_page())) return ret;
+    }
+    writer->set_enable_page_seal_if_full(false);
+    if (RET_FAIL(writer->write_nulls(time_writer->get_point_numer())))
+        return ret;
+    writer->set_enable_page_seal_if_full(true);
+    schema->value_chunk_writer_ = writer.release();
+    return E_OK;
+}
+
+int TsFileWriter::append_omitted_aligned_writers(
+    SimpleVector<ValueChunkWriter*>& value_writers) {
+    auto& cache = *cached_measurement_schemas_;
+    if (cache.changed) {
+        std::unordered_set<MeasurementSchema*> supplied;
+        for (auto* schema : cache.supplied) {
+            if (schema != nullptr && !supplied.insert(schema).second) {
+                // Repeating a field would write two values for one time row.
+                return E_INVALID_ARG;
+            }
+        }
+        cache.omitted.clear();
+        for (const auto& entry :
+             cached_device_schema_->measurement_schema_map_) {
+            if (supplied.count(entry.second) == 0) {
+                cache.omitted.push_back(entry.second);
+            }
+        }
+        cache.registered_count =
+            cached_device_schema_->measurement_schema_map_.size();
+        cache.changed = false;
+    }
+    int ret = E_OK;
+    for (auto* schema : cache.omitted) {
+        if (RET_FAIL(init_aligned_value_writer(
+                schema, cached_device_schema_->time_chunk_writer_)))
+            return ret;
+        value_writers.push_back(schema->value_chunk_writer_);
+    }
+    return ret;
+}
+
 template <typename MeasurementNamesGetter>
 int TsFileWriter::do_check_schema(
     std::shared_ptr<IDeviceID> device_id,
@@ -477,18 +594,15 @@ int TsFileWriter::do_check_schema(
         IS_NULL(device_schema = dev_it->second)) {
         return E_DEVICE_NOT_EXIST;
     }
-    MeasurementSchemaMap& msm = device_schema->measurement_schema_map_;
     uint32_t measurement_count = measurement_names.get_count();
-    // chunk_writers.reserve(measurement_count);
+    prepare_schema_cache(device_schema, measurement_count);
     for (uint32_t i = 0; i < measurement_count; i++) {
-        auto ms_iter = msm.find(measurement_names.next());
-        if (UNLIKELY(ms_iter == msm.end())) {
+        MeasurementSchema* ms =
+            get_cached_measurement_schema(measurement_names.next(), i);
+        if (UNLIKELY(ms == nullptr)) {
             chunk_writers.push_back(NULL);
             data_types.push_back(common::NULL_TYPE);
         } else {
-            // In Java we will check data_type. But in C++, no check here.
-            // Because checks are performed at the chunk layer and page layer
-            MeasurementSchema* ms = ms_iter->second;
             if (IS_NULL(ms->chunk_writer_)) {
                 ms->chunk_writer_ = new ChunkWriter;
                 ret = ms->chunk_writer_->init(ms->measurement_name_,
@@ -537,43 +651,23 @@ int TsFileWriter::do_check_schema_aligned(
             g_config_value_.time_compress_type_);
     }
     time_chunk_writer = device_schema->time_chunk_writer_;
-    MeasurementSchemaMap& msm = device_schema->measurement_schema_map_;
     uint32_t measurement_count = measurement_names.get_count();
+    prepare_schema_cache(device_schema, measurement_count);
     for (uint32_t i = 0; i < measurement_count; i++) {
-        auto ms_iter = msm.find(measurement_names.next());
-        if (UNLIKELY(ms_iter == msm.end())) {
+        MeasurementSchema* ms =
+            get_cached_measurement_schema(measurement_names.next(), i);
+        if (UNLIKELY(ms == nullptr)) {
             value_chunk_writers.push_back(NULL);
             data_types.push_back(common::NULL_TYPE);
         } else {
-            // Here we may check data_type against ms_iter. But in Java
-            // libtsfile, no check here.
-            MeasurementSchema* ms = ms_iter->second;
-            if (IS_NULL(ms->value_chunk_writer_)) {
-                ms->value_chunk_writer_ = new ValueChunkWriter;
-                ret = ms->value_chunk_writer_->init(
-                    ms->measurement_name_, ms->data_type_, ms->encoding_,
-                    ms->compression_type_);
-                if (IS_SUCC(ret)) {
-                    value_chunk_writers.push_back(ms->value_chunk_writer_);
-                } else {
-                    value_chunk_writers.push_back(NULL);
-                    for (size_t chunk_writer_idx = 0;
-                         chunk_writer_idx < value_chunk_writers.size();
-                         chunk_writer_idx++) {
-                        if (!value_chunk_writers[chunk_writer_idx]) {
-                            delete value_chunk_writers[chunk_writer_idx];
-                        }
-                    }
-                    ret = common::E_INVALID_ARG;
-                    return ret;
-                }
-            } else {
-                value_chunk_writers.push_back(ms->value_chunk_writer_);
+            if (RET_FAIL(init_aligned_value_writer(ms, time_chunk_writer))) {
+                return ret;
             }
+            value_chunk_writers.push_back(ms->value_chunk_writer_);
             data_types.push_back(ms->data_type_);
         }
     }
-    return ret;
+    return append_omitted_aligned_writers(value_chunk_writers);
 }
 
 int TsFileWriter::do_check_schema_table(
@@ -634,44 +728,30 @@ int TsFileWriter::do_check_schema_table(
 
     uint32_t column_cnt = tablet.get_column_count();
     time_chunk_writer = device_schema->time_chunk_writer_;
-    MeasurementSchemaMap& msm = device_schema->measurement_schema_map_;
-
+    uint32_t field_count = 0;
+    for (uint32_t i = 0; i < column_cnt; ++i) {
+        if (tablet.column_categories_.at(i) == common::ColumnCategory::FIELD) {
+            ++field_count;
+        }
+    }
+    prepare_schema_cache(device_schema, field_count);
+    uint32_t field_index = 0;
     for (uint32_t i = 0; i < column_cnt; i++) {
         if (tablet.column_categories_.at(i) != common::ColumnCategory::FIELD) {
             continue;
         }
-        auto ms_iter = msm.find(tablet.get_column_name(i));
-        if (UNLIKELY(ms_iter == msm.end())) {
+        MeasurementSchema* ms = get_cached_measurement_schema(
+            tablet.get_column_name(i), field_index++);
+        if (UNLIKELY(ms == nullptr)) {
             value_chunk_writers.push_back(NULL);
         } else {
-            // Here we may check data_type against ms_iter. But in Java
-            // libtsfile, no check here.
-            MeasurementSchema* ms = ms_iter->second;
-            if (IS_NULL(ms->value_chunk_writer_)) {
-                ms->value_chunk_writer_ = new ValueChunkWriter;
-                ret = ms->value_chunk_writer_->init(
-                    ms->measurement_name_, ms->data_type_, ms->encoding_,
-                    ms->compression_type_);
-                if (IS_SUCC(ret)) {
-                    value_chunk_writers.push_back(ms->value_chunk_writer_);
-                } else {
-                    value_chunk_writers.push_back(NULL);
-                    for (size_t chunk_writer_idx = 0;
-                         chunk_writer_idx < value_chunk_writers.size();
-                         chunk_writer_idx++) {
-                        if (!value_chunk_writers[chunk_writer_idx]) {
-                            delete value_chunk_writers[chunk_writer_idx];
-                        }
-                    }
-                    ret = common::E_INVALID_ARG;
-                    return ret;
-                }
-            } else {
-                value_chunk_writers.push_back(ms->value_chunk_writer_);
+            if (RET_FAIL(init_aligned_value_writer(ms, time_chunk_writer))) {
+                return ret;
             }
+            value_chunk_writers.push_back(ms->value_chunk_writer_);
         }
     }
-    return ret;
+    return append_omitted_aligned_writers(value_chunk_writers);
 }
 
 int64_t TsFileWriter::calculate_mem_size_for_all_group() {
@@ -805,7 +885,7 @@ int TsFileWriter::write_record_aligned(const TsRecord& record) {
                                          data_types))) {
         return ret;
     }
-    if (value_chunk_writers.size() != record.points_.size()) {
+    if (value_chunk_writers.size() < record.points_.size()) {
         return E_INVALID_ARG;
     }
     // Snapshot page counters before the write so we can detect any column
@@ -829,8 +909,11 @@ int TsFileWriter::write_record_aligned(const TsRecord& record) {
         if (IS_NULL(value_chunk_writer)) {
             continue;
         }
-        if (RET_FAIL(write_point_aligned(value_chunk_writer, record.timestamp_,
-                                         data_types[c], record.points_[c]))) {
+        ret = c < record.points_.size()
+                  ? write_point_aligned(value_chunk_writer, record.timestamp_,
+                                        data_types[c], record.points_[c])
+                  : value_chunk_writer->write_null();
+        if (IS_FAIL(ret)) {
             // Time wrote the row but at least one value column failed
             // mid-record; the per-column row counts no longer agree.
             // Mark the writer unrecoverable so flush/close refuses to
@@ -1027,7 +1110,7 @@ int TsFileWriter::write_tablet_aligned(const Tablet& tablet) {
         restore_seal();
         return ret;
     }
-    ASSERT(value_chunk_writers.size() == tablet.get_column_count());
+    ASSERT(value_chunk_writers.size() >= tablet.get_column_count());
     for (uint32_t c = 0; c < value_chunk_writers.size(); c++) {
         ValueChunkWriter* value_chunk_writer = value_chunk_writers[c];
         if (IS_NULL(value_chunk_writer)) {
@@ -1265,6 +1348,12 @@ int TsFileWriter::write_table(Tablet& tablet) {
                         }
                         field_col_count++;
                     }
+                }
+                for (uint32_t i = field_col_count;
+                     i < value_chunk_writers.size(); ++i) {
+                    ctx.value_tasks.push_back(
+                        {value_chunk_writers[i],
+                         static_cast<uint32_t>(tablet.get_column_count())});
                 }
                 device_ctxs.push_back(std::move(ctx));
                 idx_it = device_ctx_index
@@ -1758,6 +1847,10 @@ int TsFileWriter::value_write_column_batch(ValueChunkWriter* value_chunk_writer,
                                            uint32_t start_idx,
                                            uint32_t end_idx) {
     int ret = E_OK;
+    if (col_idx >= static_cast<int>(tablet.get_column_count())) {
+        return value_chunk_writer->write_nulls(
+            std::min(end_idx, tablet.max_row_num_) - start_idx);
+    }
     common::TSDataType data_type = tablet.schema_vec_->at(col_idx).data_type_;
     int64_t* timestamps = tablet.timestamps_;
     Tablet::ValueMatrixEntry col_values = tablet.value_matrix_[col_idx];
@@ -1941,6 +2034,7 @@ int TsFileWriter::flush_chunk_group_encoded(MeasurementSchemaGroup* chunk_group,
         }
     }
 
+    if (IS_SUCC(ret)) chunk_group->has_flushed_ = true;
     return ret;
 }
 
@@ -1981,6 +2075,7 @@ int TsFileWriter::flush_chunk_group(MeasurementSchemaGroup* chunk_group,
         }
     }
 
+    if (IS_SUCC(ret)) chunk_group->has_flushed_ = true;
     return ret;
 }
 

--- a/cpp/src/writer/tsfile_writer.h
+++ b/cpp/src/writer/tsfile_writer.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <vector>
 
+#include "common/cache/lru_cache.h"
 #include "common/container/simple_vector.h"
 #include "common/device_id.h"
 #include "common/record.h"
@@ -69,6 +70,9 @@ class TsFileWriter {
     int register_timeseries(
         const std::string& device_path,
         const std::vector<MeasurementSchema*>& measurement_schema_vec);
+    // New aligned fields may be added before the device's first flush.
+    // Adding one afterwards returns E_NOT_SUPPORT: historical chunk positions
+    // cannot be backfilled. Existing fields can still be omitted on writes.
     int register_aligned_timeseries(
         const std::string& device_id,
         const MeasurementSchema& measurement_schema);
@@ -150,6 +154,15 @@ class TsFileWriter {
                            common::BitMap& col_notnull_bitmap,
                            uint32_t start_idx, uint32_t end_idx);
 
+    void prepare_schema_cache(MeasurementSchemaGroup* device_schema,
+                              uint32_t measurement_count);
+    MeasurementSchema* get_cached_measurement_schema(
+        const std::string& measurement_name, uint32_t column_index);
+    int init_aligned_value_writer(MeasurementSchema* schema,
+                                  TimeChunkWriter* time_writer);
+    int append_omitted_aligned_writers(
+        common::SimpleVector<ValueChunkWriter*>& value_writers);
+
     template <typename MeasurementNamesGetter>
     int do_check_schema(
         std::shared_ptr<IDeviceID> device_id,
@@ -188,6 +201,24 @@ class TsFileWriter {
     storage::TsFileIOWriter* io_writer_;
     // device_id -> MeasurementSchemaGroup
     DeviceSchemasMap schemas_;
+    // One bounded LRU cache per writer, shared by tree records/tablets and
+    // table FIELD columns. Cache schemas rather than chunk writers so the
+    // plain and aligned paths can reuse the same entries. At most 64 devices
+    // retain positional arrays; capacity within each array follows its widest
+    // write. Entries borrow schemas_ storage, which survives flush().
+    struct CachedMeasurementSchemas {
+        std::vector<MeasurementSchema*> supplied;
+        std::vector<MeasurementSchema*> omitted;
+        size_t registered_count = 0;
+        bool changed = true;
+    };
+    common::Cache<MeasurementSchemaGroup*,
+                  std::shared_ptr<CachedMeasurementSchemas>>
+        schema_cache_{64, 0};
+    // The most recent entry avoids even an LRU lookup for repeated writes to
+    // one device. It is released together with the LRU before schemas_.
+    MeasurementSchemaGroup* cached_device_schema_ = nullptr;
+    std::shared_ptr<CachedMeasurementSchemas> cached_measurement_schemas_;
     bool start_file_done_;
     // record count since last flush
     int64_t record_count_since_last_flush_;

--- a/cpp/src/writer/value_chunk_writer.cc
+++ b/cpp/src/writer/value_chunk_writer.cc
@@ -159,6 +159,10 @@ void ValueChunkWriter::save_first_page_data(
 int ValueChunkWriter::write_first_page_data(ByteStream& pages_data,
                                             bool with_statistic) {
     int ret = E_OK;
+    // An empty page consists only of the zero-size header already written.
+    if (first_page_statistic_ == nullptr) {
+        return ret;
+    }
     if (with_statistic &&
         RET_FAIL(first_page_statistic_->serialize_to(pages_data))) {
     } else if (RET_FAIL(
@@ -168,21 +172,51 @@ int ValueChunkWriter::write_first_page_data(ByteStream& pages_data,
     return ret;
 }
 
+int ValueChunkWriter::write_nulls(uint32_t count) {
+    int ret = E_OK;
+    const uint32_t page_cap =
+        std::max<uint32_t>(1, g_config_value_.page_writer_max_point_num_);
+    while (count > 0) {
+        uint32_t points = get_point_numer();
+        if (points >= page_cap) {
+            if (RET_FAIL(seal_cur_page(false))) return ret;
+            points = 0;
+        }
+        const uint32_t batch = std::min(count, page_cap - points);
+        value_page_writer_.write_nulls(batch);
+        count -= batch;
+        if (RET_FAIL(seal_cur_page_if_full())) return ret;
+    }
+    return ret;
+}
+
+int ValueChunkWriter::write_empty_page() {
+    int ret = E_OK;
+    if (has_current_page_data()) return E_INVALID_ARG;
+    if (num_of_pages_ == 1 && RET_FAIL(write_first_page_data(chunk_data_))) {
+        return ret;
+    }
+    free_first_writer_data();
+    if (RET_FAIL(SerializationUtil::write_var_uint(0, chunk_data_))) {
+        return ret;
+    }
+    ++num_of_pages_;
+    return ret;
+}
+
 int ValueChunkWriter::end_encode_chunk() {
     int ret = E_OK;
     if (has_current_page_data()) {
         ret = seal_cur_page(/*end_chunk*/ true);
-        if (E_OK == ret) {
-            chunk_header_.data_size_ = chunk_data_.total_size();
-            chunk_header_.num_of_pages_ = num_of_pages_;
-        }
     } else if (first_page_statistic_ != nullptr) {
         ret = write_first_page_data(chunk_data_, false);
         if (E_OK == ret) {
             free_first_writer_data();
-            chunk_header_.data_size_ = chunk_data_.total_size();
-            chunk_header_.num_of_pages_ = num_of_pages_;
         }
+    }
+    if (IS_SUCC(ret)) {
+        chunk_header_.data_size_ = chunk_data_.total_size();
+        chunk_header_.num_of_pages_ = num_of_pages_;
     }
 #if DEBUG_SE
     std::cout << "end_encode_chunk: num_of_pages_=" << num_of_pages_

--- a/cpp/src/writer/value_chunk_writer.h
+++ b/cpp/src/writer/value_chunk_writer.h
@@ -174,6 +174,14 @@ class ValueChunkWriter {
         return ret;
     }
 
+    // Match scalar value writes: append first, then check the page boundary.
+    int write_null() {
+        value_page_writer_.write_nulls(1);
+        return seal_cur_page_if_full();
+    }
+    int write_nulls(uint32_t count);
+    // Backfill a sealed time page when a field is registered mid-chunk.
+    int write_empty_page();
     int end_encode_chunk();
     common::ByteStream& get_chunk_data() { return chunk_data_; }
     Statistic* get_chunk_statistic() { return chunk_statistic_; }

--- a/cpp/src/writer/value_page_writer.h
+++ b/cpp/src/writer/value_page_writer.h
@@ -150,6 +150,13 @@ class ValuePageWriter {
         VPW_DO_WRITE_FOR_TYPE(isnull);
     }
 
+    // Nulls occupy time positions but do not update the value statistics.
+    void write_nulls(uint32_t count) {
+        col_notnull_bitmap_.resize((static_cast<size_t>(size_) + count + 7) / 8,
+                                   0);
+        size_ += count;
+    }
+
     // Batch write for aligned/table model.
     // In the tablet bitmap: bit=1 means null, bit=0 means not null.
     // In VPW_DO_WRITE_FOR_TYPE: ISNULL=true skips encoding.

--- a/cpp/test/writer/tsfile_writer_schema_cache_test.cc
+++ b/cpp/test/writer/tsfile_writer_schema_cache_test.cc
@@ -1,0 +1,1039 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Writer-owned schema lookup cache (issue #885): tree records/tablets and
+// table FIELD columns share one positional cache. Exercise repeated writes,
+// name/width changes, late registration, device/writer isolation and lifecycle
+// changes by checking the values and timestamps read from the resulting files.
+#include <gtest/gtest.h>
+
+#include "writer/tsfile_writer.h"
+
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+#include <atomic>
+#include <fstream>
+#include <memory>
+#include <random>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "common/path.h"
+#include "common/record.h"
+#include "common/schema.h"
+#include "common/tablet.h"
+#include "common/tsfile_common.h"
+#include "file/restorable_tsfile_io_writer.h"
+#include "file/write_file.h"
+#include "reader/qds_without_timegenerator.h"
+#include "reader/tsfile_reader.h"
+
+using namespace storage;
+using namespace common;
+
+namespace {
+
+class SchemaCheckCacheTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        libtsfile_init();
+        tsfile_writer_ = new TsFileWriter();
+        file_name_ = std::string("tsfile_schema_cache_test_") +
+                     generate_random_string(10) + std::string(".tsfile");
+        remove(file_name_.c_str());
+        int flags = O_WRONLY | O_CREAT | O_TRUNC;
+#ifdef _WIN32
+        flags |= O_BINARY;
+#endif
+        ASSERT_EQ(tsfile_writer_->open(file_name_, flags, 0666), common::E_OK);
+    }
+    void TearDown() override {
+        delete tsfile_writer_;
+        ASSERT_EQ(0, remove(file_name_.c_str()));
+        libtsfile_destroy();
+    }
+
+    std::string file_name_;
+    TsFileWriter* tsfile_writer_ = nullptr;
+
+   public:
+    static std::string generate_random_string(int length) {
+        static std::atomic<uint64_t> counter{0};
+        std::mt19937 gen(static_cast<unsigned int>(
+            std::chrono::system_clock::now().time_since_epoch().count()));
+        std::uniform_int_distribution<> dis(0, 61);
+        const std::string chars =
+            "0123456789"
+            "abcdefghijklmnopqrstuvwxyz"
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        std::string random_string;
+        for (int i = 0; i < length; ++i) {
+            random_string += chars[dis(gen)];
+        }
+#ifdef _WIN32
+        const auto process_id = static_cast<uint64_t>(_getpid());
+#else
+        const auto process_id = static_cast<uint64_t>(getpid());
+#endif
+        random_string += "_" + std::to_string(process_id) + "_" +
+                         std::to_string(counter.fetch_add(1));
+        return random_string;
+    }
+
+    // Reads back (device, measurement) pairs and returns one row per
+    // timestamp: {timestamp, value-string per series}. Row count is asserted
+    // by the caller so dropped rows cannot pass silently.
+    std::vector<std::vector<std::string>> query_all(
+        const std::vector<Path>& select_list,
+        const std::string& file_name = "") {
+        storage::TsFileReader reader;
+        EXPECT_EQ(reader.open(file_name.empty() ? file_name_ : file_name),
+                  E_OK);
+        QueryExpression* query_expr =
+            QueryExpression::create(select_list, nullptr);
+        ResultSet* tmp_qds = nullptr;
+        EXPECT_EQ(reader.query(query_expr, tmp_qds), E_OK);
+        auto* qds = (QDSWithoutTimeGenerator*)tmp_qds;
+
+        std::vector<std::vector<std::string>> rows;
+        bool has_next = false;
+        int ret = E_OK;
+        while (IS_SUCC(ret = qds->next(has_next)) && has_next) {
+            RowRecord* record = qds->get_row_record();
+            std::vector<std::string> row;
+            row.push_back(std::to_string(record->get_timestamp()));
+            // field(0) is the timestamp; value fields start at 1.
+            for (size_t i = 1; i < record->get_fields()->size(); ++i) {
+                row.push_back(field_to_string(record->get_field(i)));
+            }
+            rows.push_back(row);
+        }
+        EXPECT_EQ(ret, E_OK);
+        reader.destroy_query_data_set(qds);
+        return rows;
+    }
+
+    MeasurementSchema int32_schema(const std::string& name) {
+        return MeasurementSchema(name, TSDataType::INT32, TSEncoding::PLAIN,
+                                 CompressionType::UNCOMPRESSED);
+    }
+
+    static std::string field_to_string(storage::Field* value) {
+        if (value->type_ == common::TEXT || value->type_ == STRING ||
+            value->type_ == BLOB) {
+            return std::string(value->value_.sval_);
+        }
+        std::stringstream ss;
+        switch (value->type_) {
+            case common::BOOLEAN:
+                ss << (value->value_.bval_ ? "true" : "false");
+                break;
+            case common::INT32:
+                ss << value->value_.ival_;
+                break;
+            case common::INT64:
+            case common::TIMESTAMP:
+                ss << value->value_.lval_;
+                break;
+            case common::FLOAT:
+                ss << value->value_.fval_;
+                break;
+            case common::DOUBLE:
+                ss << value->value_.dval_;
+                break;
+            case common::NULL_TYPE:
+                ss << "NULL";
+                break;
+            default:
+                ASSERT(false);
+                break;
+        }
+        return ss.str();
+    }
+
+    // Path's two-part ctor takes non-const std::string&, so route every
+    // construction through copies.
+    Path make_path(const std::string& device, const std::string& measurement) {
+        std::string dev = device;
+        std::string meas = measurement;
+        return Path(dev, meas);
+    }
+};
+
+// 1. Cache hit: the same tablet schema written repeatedly (with a flush in
+// between, so chunk writers survive a seal and are re-resolved from the
+// cache) must round-trip every row of every column.
+TEST_F(SchemaCheckCacheTest, RepeatedSameSchemaRoundTrip) {
+    const std::string device = "root.cache_hit";
+    const std::vector<std::string> names = {"s0", "s1", "s2"};
+    for (const auto& name : names) {
+        ASSERT_EQ(
+            tsfile_writer_->register_timeseries(device, int32_schema(name)),
+            E_OK);
+    }
+
+    const int num_tablets = 5;
+    for (int t = 0; t < num_tablets; t++) {
+        std::vector<MeasurementSchema> schema_vec;
+        for (const auto& name : names) schema_vec.push_back(int32_schema(name));
+        Tablet tablet(
+            device,
+            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
+        ASSERT_EQ(tablet.add_timestamp(0, 1000 + t), E_OK);
+        for (uint32_t j = 0; j < names.size(); j++) {
+            ASSERT_EQ(tablet.add_value(0, j, t * 100 + (int32_t)j), E_OK);
+        }
+        ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
+        if (t == 2) {
+            ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+        }
+    }
+    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+
+    std::vector<Path> select_list;
+    for (const auto& name : names)
+        select_list.push_back(make_path(device, name));
+    auto rows = query_all(select_list);
+    ASSERT_EQ(rows.size(), (size_t)num_tablets);
+    for (int t = 0; t < num_tablets; t++) {
+        ASSERT_EQ(rows[t][0], std::to_string(1000 + t));
+        for (uint32_t j = 0; j < names.size(); j++) {
+            ASSERT_EQ(rows[t][j + 1], std::to_string(t * 100 + j))
+                << "row " << t << " column " << j;
+        }
+    }
+}
+
+// 2. Invalidation by name sequence: same column count, different names and
+// order. Values must land in the column their NAME says, not the position
+// the previous tablet used.
+TEST_F(SchemaCheckCacheTest, SameCountDifferentNamesAndOrder) {
+    const std::string device = "root.cache_inval";
+    for (const auto& name : {"s0", "s1", "s2"}) {
+        ASSERT_EQ(
+            tsfile_writer_->register_timeseries(device, int32_schema(name)),
+            E_OK);
+    }
+
+    // Tablet 1: [s0, s1] at t=0.
+    {
+        std::vector<MeasurementSchema> schema_vec = {int32_schema("s0"),
+                                                     int32_schema("s1")};
+        Tablet tablet(
+            device,
+            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
+        ASSERT_EQ(tablet.add_timestamp(0, 0), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 0, 10), E_OK);  // s0 = 10
+        ASSERT_EQ(tablet.add_value(0, 1, 11), E_OK);  // s1 = 11
+        ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
+    }
+    // Tablet 2: same count, REVERSED order, at t=1.
+    {
+        std::vector<MeasurementSchema> schema_vec = {int32_schema("s1"),
+                                                     int32_schema("s0")};
+        Tablet tablet(
+            device,
+            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
+        ASSERT_EQ(tablet.add_timestamp(0, 1), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 0, 21), E_OK);  // s1 = 21
+        ASSERT_EQ(tablet.add_value(0, 1, 20), E_OK);  // s0 = 20
+        ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
+    }
+    // Tablet 3: same count, one column swapped for an unseen name, at t=2.
+    {
+        std::vector<MeasurementSchema> schema_vec = {int32_schema("s0"),
+                                                     int32_schema("s2")};
+        Tablet tablet(
+            device,
+            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
+        ASSERT_EQ(tablet.add_timestamp(0, 2), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 0, 30), E_OK);  // s0 = 30
+        ASSERT_EQ(tablet.add_value(0, 1, 32), E_OK);  // s2 = 32
+        ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
+    }
+    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+
+    std::vector<Path> select_list;
+    for (const auto& name : {"s0", "s1", "s2"}) {
+        select_list.push_back(make_path(device, name));
+    }
+    auto rows = query_all(select_list);
+    ASSERT_EQ(rows.size(), (size_t)3);
+    // t=0
+    EXPECT_EQ(rows[0][0], "0");
+    EXPECT_EQ(rows[0][1], "10");
+    EXPECT_EQ(rows[0][2], "11");
+    // t=1: swapped order must not swap values
+    EXPECT_EQ(rows[1][0], "1");
+    EXPECT_EQ(rows[1][1], "20");
+    EXPECT_EQ(rows[1][2], "21");
+    // t=2: s1 has no point at t=2
+    EXPECT_EQ(rows[2][0], "2");
+    EXPECT_EQ(rows[2][1], "30");
+    EXPECT_EQ(rows[2][3], "32");
+}
+
+// 3. A measurement missing at first write resolves to a NULL chunk writer
+// (column skipped). After it is registered, the same tablet schema must
+// write that column: the cache must not pin the stale NULL.
+TEST_F(SchemaCheckCacheTest, ColumnRegisteredAfterFirstWriteIsNotMasked) {
+    const std::string device = "root.cache_late_register";
+    ASSERT_EQ(tsfile_writer_->register_timeseries(device, int32_schema("s0")),
+              E_OK);
+    // Deliberately NOT registering s1 yet.
+
+    // First write: s1 unresolved -> NULL chunk writer, column skipped.
+    {
+        std::vector<MeasurementSchema> schema_vec = {int32_schema("s0"),
+                                                     int32_schema("s1")};
+        Tablet tablet(
+            device,
+            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
+        ASSERT_EQ(tablet.add_timestamp(0, 0), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 0, 100), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 1, 101), E_OK);
+        ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
+    }
+    // Now register s1 and write the same schema again.
+    ASSERT_EQ(tsfile_writer_->register_timeseries(device, int32_schema("s1")),
+              E_OK);
+    {
+        std::vector<MeasurementSchema> schema_vec = {int32_schema("s0"),
+                                                     int32_schema("s1")};
+        Tablet tablet(
+            device,
+            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
+        ASSERT_EQ(tablet.add_timestamp(0, 1), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 0, 200), E_OK);
+        ASSERT_EQ(tablet.add_value(0, 1, 201), E_OK);
+        ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
+    }
+    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+
+    auto rows = query_all({make_path(device, "s1")});
+    // Without the fully-resolved guard the cached NULL would drop this
+    // column forever and this query would return zero rows.
+    ASSERT_EQ(rows.size(), (size_t)1);
+    EXPECT_EQ(rows[0][0], "1");
+    EXPECT_EQ(rows[0][1], "201");
+}
+
+// 4. Aligned path: same-schema repeated writes round-trip, and a reordered
+// tablet re-resolves instead of reusing positions.
+TEST_F(SchemaCheckCacheTest, AlignedRepeatedAndReordered) {
+    const std::string device = "root.cache_aligned";
+    for (const auto& name : {"a0", "a1"}) {
+        ASSERT_EQ(tsfile_writer_->register_aligned_timeseries(
+                      device, int32_schema(name)),
+                  E_OK);
+    }
+
+    const int num_tablets = 4;
+    for (int t = 0; t < num_tablets; t++) {
+        // Last tablet reverses the column order.
+        std::vector<MeasurementSchema> schema_vec;
+        if (t < num_tablets - 1) {
+            schema_vec = {int32_schema("a0"), int32_schema("a1")};
+        } else {
+            schema_vec = {int32_schema("a1"), int32_schema("a0")};
+        }
+        Tablet tablet(
+            device,
+            std::make_shared<std::vector<MeasurementSchema>>(schema_vec), 1);
+        ASSERT_EQ(tablet.add_timestamp(0, 500 + t), E_OK);
+        if (t < num_tablets - 1) {
+            ASSERT_EQ(tablet.add_value(0, 0, t), E_OK);       // a0
+            ASSERT_EQ(tablet.add_value(0, 1, 10 + t), E_OK);  // a1
+        } else {
+            ASSERT_EQ(tablet.add_value(0, 0, 19), E_OK);  // a1
+            ASSERT_EQ(tablet.add_value(0, 1, 9), E_OK);   // a0
+        }
+        ASSERT_EQ(tsfile_writer_->write_tablet_aligned(tablet), E_OK);
+    }
+    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+
+    std::vector<Path> select_list;
+    for (const auto& name : {"a0", "a1"}) {
+        select_list.push_back(make_path(device, name));
+    }
+    auto rows = query_all(select_list);
+    ASSERT_EQ(rows.size(), (size_t)num_tablets);
+    for (int t = 0; t < num_tablets - 1; t++) {
+        EXPECT_EQ(rows[t][1], std::to_string(t));
+        EXPECT_EQ(rows[t][2], std::to_string(10 + t));
+    }
+    // Reordered final tablet: a0=9, a1=19.
+    EXPECT_EQ(rows[num_tablets - 1][1], "9");
+    EXPECT_EQ(rows[num_tablets - 1][2], "19");
+}
+
+// 5. Switching devices must discard pointers from the previous device even
+// when their measurement names are identical.
+TEST_F(SchemaCheckCacheTest, MultiDeviceCachesIndependent) {
+    const std::string devices[2] = {"root.cache_dev0", "root.cache_dev1"};
+    for (const auto& device : devices) {
+        for (const auto& name : {"m0", "m1"}) {
+            ASSERT_EQ(
+                tsfile_writer_->register_timeseries(device, int32_schema(name)),
+                E_OK);
+        }
+    }
+
+    for (int t = 0; t < 3; t++) {
+        for (int d = 0; d < 2; d++) {
+            std::vector<MeasurementSchema> schema_vec = {int32_schema("m0"),
+                                                         int32_schema("m1")};
+            Tablet tablet(
+                devices[d],
+                std::make_shared<std::vector<MeasurementSchema>>(schema_vec),
+                1);
+            ASSERT_EQ(tablet.add_timestamp(0, 700 + t), E_OK);
+            // d*1000 separates the two devices' value spaces.
+            ASSERT_EQ(tablet.add_value(0, 0, d * 1000 + t), E_OK);
+            ASSERT_EQ(tablet.add_value(0, 1, d * 1000 + 10 + t), E_OK);
+            ASSERT_EQ(tsfile_writer_->write_tablet(tablet), E_OK);
+        }
+    }
+    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+
+    for (int d = 0; d < 2; d++) {
+        auto rows = query_all(
+            {make_path(devices[d], "m0"), make_path(devices[d], "m1")});
+        ASSERT_EQ(rows.size(), (size_t)3);
+        for (int t = 0; t < 3; t++) {
+            EXPECT_EQ(rows[t][1], std::to_string(d * 1000 + t));
+            EXPECT_EQ(rows[t][2], std::to_string(d * 1000 + 10 + t));
+        }
+    }
+}
+
+class TreeSchemaCacheTest : public SchemaCheckCacheTest,
+                            public ::testing::WithParamInterface<bool> {};
+
+TEST_P(TreeSchemaCacheTest, ChangingWidthsAcrossRecordsAndTablets) {
+    const std::string device = "root.cache_width";
+    const std::vector<std::string> names = {"i", "d", "l", "unregistered"};
+    const std::vector<TSDataType> types = {INT32, DOUBLE, INT64, INT32};
+    for (size_t i = 0; i < 3; ++i) {
+        MeasurementSchema schema(names[i], types[i], PLAIN, UNCOMPRESSED);
+        ASSERT_EQ(
+            GetParam()
+                ? tsfile_writer_->register_aligned_timeseries(device, schema)
+                : tsfile_writer_->register_timeseries(device, schema),
+            E_OK);
+    }
+    std::vector<std::vector<int>> orders = {{0, 1, 2}, {1}, {2, 0},
+                                            {2, 1, 0}, {0}, {0, 1, 2}};
+    std::vector<std::vector<std::string>> expected;
+    int64_t time = 0;
+    for (const auto& order : orders) {
+        std::vector<std::string> cols;
+        std::vector<TSDataType> col_types;
+        for (int i : order) {
+            cols.push_back(names[i]);
+            col_types.push_back(types[i]);
+        }
+        // Same schema first as a record, then as a tablet: both callers share
+        // the cache but must preserve the registered type and column order.
+        for (int repeat = 0; repeat < 2; ++repeat, ++time) {
+            Tablet tablet(device, &cols, &col_types, 1);
+            TsRecord record(device, time);
+            ASSERT_EQ(tablet.add_timestamp(0, time), E_OK);
+            std::vector<std::string> row = {std::to_string(time), "NULL",
+                                            "NULL", "NULL"};
+            for (int i : order) {
+                if (i == 0) {
+                    ASSERT_EQ(record.add_point(names[i], int32_t(10 + time)),
+                              E_OK);
+                    ASSERT_EQ(tablet.add_value(0, names[i], int32_t(10 + time)),
+                              E_OK);
+                    row[i + 1] = std::to_string(10 + time);
+                } else if (i == 1) {
+                    ASSERT_EQ(record.add_point(names[i], double(20.5 + time)),
+                              E_OK);
+                    ASSERT_EQ(
+                        tablet.add_value(0, names[i], double(20.5 + time)),
+                        E_OK);
+                    std::ostringstream value;
+                    value << 20.5 + time;
+                    row[i + 1] = value.str();
+                } else if (i == 2) {
+                    ASSERT_EQ(record.add_point(names[i],
+                                               int64_t(5000000000LL + time)),
+                              E_OK);
+                    ASSERT_EQ(tablet.add_value(0, names[i],
+                                               int64_t(5000000000LL + time)),
+                              E_OK);
+                    row[i + 1] = std::to_string(5000000000LL + time);
+                } else {
+                    ASSERT_EQ(record.add_point(names[i], int32_t(7)), E_OK);
+                    ASSERT_EQ(tablet.add_value(0, names[i], int32_t(7)), E_OK);
+                }
+            }
+            ASSERT_EQ(repeat == 0 ? tsfile_writer_->write_tree(record)
+                                  : tsfile_writer_->write_tree(tablet),
+                      E_OK);
+            expected.push_back(row);
+        }
+        // A field omitted for an entire chunk must retain its time position.
+        ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    }
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+    EXPECT_EQ(query_all({make_path(device, "i"), make_path(device, "d"),
+                         make_path(device, "l")}),
+              expected);
+}
+
+TEST_P(TreeSchemaCacheTest, WritersWithSameNamesKeepTheirOwnTypesAndValues) {
+    const std::string second_file = file_name_ + ".second";
+    const std::string device = "root.same";
+    {
+        TsFileWriter second;
+        ASSERT_EQ(second.open(second_file), E_OK);
+        MeasurementSchema small("s", INT32, PLAIN, UNCOMPRESSED);
+        MeasurementSchema wide("s", INT64, PLAIN, UNCOMPRESSED);
+        ASSERT_EQ(
+            GetParam()
+                ? tsfile_writer_->register_aligned_timeseries(device, small)
+                : tsfile_writer_->register_timeseries(device, small),
+            E_OK);
+        ASSERT_EQ(GetParam() ? second.register_aligned_timeseries(device, wide)
+                             : second.register_timeseries(device, wide),
+                  E_OK);
+        for (int t = 0; t < 4; ++t) {
+            TsRecord first_record(device, t);
+            TsRecord second_record(device, t);
+            ASSERT_EQ(first_record.add_point("s", int32_t(10 + t)), E_OK);
+            ASSERT_EQ(second_record.add_point("s", int64_t(5000000000LL + t)),
+                      E_OK);
+            ASSERT_EQ(tsfile_writer_->write_tree(first_record), E_OK);
+            ASSERT_EQ(second.write_tree(second_record), E_OK);
+        }
+        ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+        ASSERT_EQ(tsfile_writer_->close(), E_OK);
+        ASSERT_EQ(second.flush(), E_OK);
+        ASSERT_EQ(second.close(), E_OK);
+    }
+    EXPECT_EQ(query_all({make_path(device, "s")}),
+              (std::vector<std::vector<std::string>>{
+                  {"0", "10"}, {"1", "11"}, {"2", "12"}, {"3", "13"}}));
+    EXPECT_EQ(query_all({make_path(device, "s")}, second_file),
+              (std::vector<std::vector<std::string>>{{"0", "5000000000"},
+                                                     {"1", "5000000001"},
+                                                     {"2", "5000000002"},
+                                                     {"3", "5000000003"}}));
+    EXPECT_EQ(remove(second_file.c_str()), 0);
+}
+
+TEST_P(TreeSchemaCacheTest, DestroyAndInitDoNotReuseOldSchemaPointers) {
+    const std::string device = "root.reused";
+    MeasurementSchema first("s", INT32, PLAIN, UNCOMPRESSED);
+    ASSERT_EQ(GetParam()
+                  ? tsfile_writer_->register_aligned_timeseries(device, first)
+                  : tsfile_writer_->register_timeseries(device, first),
+              E_OK);
+    TsRecord record(device, 1);
+    ASSERT_EQ(record.add_point("s", int32_t(1)), E_OK);
+    ASSERT_EQ(tsfile_writer_->write_tree(record), E_OK);
+    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+    tsfile_writer_->destroy();
+    ASSERT_EQ(remove(file_name_.c_str()), 0);
+    WriteFile file;
+    ASSERT_EQ(file.create(file_name_, O_RDWR | O_CREAT | O_TRUNC, 0666), E_OK);
+    ASSERT_EQ(tsfile_writer_->init(&file), E_OK);
+    MeasurementSchema second("s", INT64, PLAIN, UNCOMPRESSED);
+    ASSERT_EQ(GetParam()
+                  ? tsfile_writer_->register_aligned_timeseries(device, second)
+                  : tsfile_writer_->register_timeseries(device, second),
+              E_OK);
+    TsRecord next(device, 0);
+    ASSERT_EQ(next.add_point("s", int64_t(5000000000LL)), E_OK);
+    ASSERT_EQ(tsfile_writer_->write_tree(next), E_OK);
+    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+    tsfile_writer_->destroy();
+    EXPECT_EQ(query_all({make_path(device, "s")}),
+              (std::vector<std::vector<std::string>>{{"0", "5000000000"}}));
+}
+
+TEST_P(TreeSchemaCacheTest, EvictedDevicesCanBeWrittenAgain) {
+    const int device_count = 80;  // Exceeds the writer's bounded cache.
+    for (int d = 0; d < device_count; ++d) {
+        const std::string device = "root.eviction.d" + std::to_string(d);
+        ASSERT_EQ(GetParam() ? tsfile_writer_->register_aligned_timeseries(
+                                   device, int32_schema("s"))
+                             : tsfile_writer_->register_timeseries(
+                                   device, int32_schema("s")),
+                  E_OK);
+    }
+    for (int t = 0; t < 2; ++t) {
+        for (int d = 0; d < device_count; ++d) {
+            const std::string device = "root.eviction.d" + std::to_string(d);
+            TsRecord record(device, t);
+            ASSERT_EQ(record.add_point("s", int32_t(t * 1000 + d)), E_OK);
+            ASSERT_EQ(tsfile_writer_->write_tree(record), E_OK);
+        }
+        ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    }
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+    for (int d = 0; d < device_count; ++d) {
+        EXPECT_EQ(
+            query_all({make_path("root.eviction.d" + std::to_string(d), "s")}),
+            (std::vector<std::vector<std::string>>{
+                {"0", std::to_string(d)}, {"1", std::to_string(1000 + d)}}));
+    }
+}
+
+TEST_F(SchemaCheckCacheTest, TableWriteContextsSurviveCacheEviction) {
+    const std::vector<ColumnSchema> columns = {
+        ColumnSchema("tag", STRING, UNCOMPRESSED, PLAIN, ColumnCategory::TAG),
+        ColumnSchema("i", INT32, UNCOMPRESSED, PLAIN, ColumnCategory::FIELD),
+        ColumnSchema("l", INT64, UNCOMPRESSED, PLAIN, ColumnCategory::FIELD)};
+    auto schema = std::make_shared<TableSchema>("eviction", columns);
+    ASSERT_EQ(tsfile_writer_->register_table(schema), E_OK);
+    const int device_count = 80;
+    for (int batch = 0; batch < 2; ++batch) {
+        Tablet tablet("eviction", schema->get_measurement_names(),
+                      schema->get_data_types(), schema->get_column_categories(),
+                      device_count);
+        for (int d = 0; d < device_count; ++d) {
+            const std::string name = "d" + std::to_string(d);
+            String tag(const_cast<char*>(name.data()), name.size());
+            const int64_t time = batch * 1000 + d;
+            ASSERT_EQ(tablet.add_timestamp(d, time), E_OK);
+            ASSERT_EQ(tablet.add_value(d, "tag", tag), E_OK);
+            ASSERT_EQ(tablet.add_value(d, "i", int32_t(d)), E_OK);
+            ASSERT_EQ(tablet.add_value(d, "l", int64_t(5000000000LL + time)),
+                      E_OK);
+        }
+        // The first device's cache entry is evicted before its saved write
+        // context is consumed; the actual schema/chunk writers must survive.
+        ASSERT_EQ(tsfile_writer_->write_table(tablet), E_OK);
+        ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    }
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+    TsFileReader reader;
+    ASSERT_EQ(reader.open(file_name_), E_OK);
+    ResultSet* result = nullptr;
+    ASSERT_EQ(reader.query("eviction", {"tag", "i", "l"}, INT64_MIN, INT64_MAX,
+                           result),
+              E_OK);
+    std::set<int64_t> seen;
+    bool has_next = false;
+    int ret = E_OK;
+    while ((ret = result->next(has_next)) == E_OK && has_next) {
+        const int64_t time = result->get_value<int64_t>(1);
+        EXPECT_TRUE(time / 1000 == 0 || time / 1000 == 1);
+        EXPECT_GE(time % 1000, 0);
+        EXPECT_LT(time % 1000, device_count);
+        EXPECT_TRUE(seen.insert(time).second);
+        const auto* tag = result->get_value<String*>(2);
+        EXPECT_EQ(std::string(tag->buf_, tag->len_),
+                  "d" + std::to_string(time % 1000));
+        EXPECT_EQ(result->get_value<int32_t>(3), time % 1000);
+        EXPECT_EQ(result->get_value<int64_t>(4), 5000000000LL + time);
+    }
+    EXPECT_EQ(ret, E_OK);
+    EXPECT_EQ(seen.size(), 2U * device_count);
+    reader.destroy_query_data_set(result);
+}
+
+INSTANTIATE_TEST_SUITE_P(PlainAndAligned, TreeSchemaCacheTest,
+                         ::testing::Bool());
+
+TEST_F(SchemaCheckCacheTest,
+       TableFieldsReorderAcrossDevicesTablesAndTreeWrites) {
+    const std::vector<ColumnSchema> columns = {
+        ColumnSchema("tag", STRING, UNCOMPRESSED, PLAIN, ColumnCategory::TAG),
+        ColumnSchema("i", INT32, UNCOMPRESSED, PLAIN, ColumnCategory::FIELD),
+        ColumnSchema("l", INT64, UNCOMPRESSED, PLAIN, ColumnCategory::FIELD)};
+    for (const auto& table : {"cache_a", "cache_b"}) {
+        ASSERT_EQ(tsfile_writer_->register_table(
+                      std::make_shared<TableSchema>(table, columns)),
+                  E_OK);
+    }
+    ASSERT_EQ(
+        tsfile_writer_->register_timeseries("root.tree", int32_schema("i")),
+        E_OK);
+    const std::vector<std::vector<std::string>> orders = {
+        {"tag", "i", "l"}, {"tag", "i", "l"}, {"l", "tag", "i"},
+        {"l", "i", "tag"}, {"tag", "i"},      {"tag", "i", "l"}};
+    for (size_t batch = 0; batch < orders.size(); ++batch) {
+        const auto& names = orders[batch];
+        std::vector<TSDataType> types;
+        std::vector<ColumnCategory> categories;
+        for (const auto& name : names) {
+            types.push_back(name == "tag" ? STRING
+                            : name == "i" ? INT32
+                                          : INT64);
+            categories.push_back(name == "tag" ? ColumnCategory::TAG
+                                               : ColumnCategory::FIELD);
+        }
+        for (const auto& table : {"cache_a", "cache_b"}) {
+            // Repeating a single device exercises hits; A/B/A in one tablet
+            // also checks the write contexts survive cache replacement.
+            for (int repeat = 0; repeat < 2; ++repeat) {
+                const int count = batch == 2 ? 3 : 1;
+                auto write_names = names;
+                auto write_types = types;
+                auto write_categories = categories;
+                if (batch == 3 && repeat == 1) {
+                    // Reorder FIELDs while this table/device's cache is warm.
+                    std::rotate(write_names.begin(), write_names.begin() + 1,
+                                write_names.end());
+                    std::rotate(write_types.begin(), write_types.begin() + 1,
+                                write_types.end());
+                    std::rotate(write_categories.begin(),
+                                write_categories.begin() + 1,
+                                write_categories.end());
+                }
+                Tablet tablet(table, write_names, write_types, write_categories,
+                              count);
+                for (int r = 0; r < count; ++r) {
+                    int64_t time = batch * 10 + repeat * 3 + r;
+                    String tag(r == 1 ? "b" : "a", 1);
+                    ASSERT_EQ(tablet.add_timestamp(r, time), E_OK);
+                    ASSERT_EQ(tablet.add_value(r, "tag", tag), E_OK);
+                    ASSERT_EQ(tablet.add_value(r, "i", int32_t(100 + time)),
+                              E_OK);
+                    if (batch != 4) {
+                        ASSERT_EQ(tablet.add_value(
+                                      r, "l", int64_t(5000000000LL + time)),
+                                  E_OK);
+                    }
+                }
+                ASSERT_EQ(tsfile_writer_->write_table(tablet), E_OK);
+            }
+        }
+        TsRecord tree("root.tree", batch);
+        ASSERT_EQ(tree.add_point("i", int32_t(batch)), E_OK);
+        ASSERT_EQ(tsfile_writer_->write_tree(tree), E_OK);
+        ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    }
+    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+    TsFileReader reader;
+    ASSERT_EQ(reader.open(file_name_), E_OK);
+    for (const auto& table : {"cache_a", "cache_b"}) {
+        ResultSet* result = nullptr;
+        ASSERT_EQ(reader.query(table, {"tag", "i", "l"}, INT64_MIN, INT64_MAX,
+                               result),
+                  E_OK);
+        bool has_next = false;
+        int ret = E_OK;
+        int rows = 0;
+        std::set<int64_t> remaining_times = {0,  3,  10, 13, 20, 21, 22, 23,
+                                             24, 25, 30, 33, 40, 43, 50, 53};
+        while ((ret = result->next(has_next)) == E_OK && has_next) {
+            const int64_t time = result->get_value<int64_t>(1);
+            EXPECT_EQ(remaining_times.erase(time), 1U);
+            EXPECT_EQ(result->get_value<int32_t>(3), 100 + time);
+            EXPECT_EQ(result->is_null(4), time / 10 == 4);
+            if (!result->is_null(4))
+                EXPECT_EQ(result->get_value<int64_t>(4), 5000000000LL + time);
+            const auto* tag = result->get_value<String*>(2);
+            EXPECT_EQ(std::string(tag->buf_, tag->len_),
+                      time == 21 || time == 24 ? "b" : "a");
+            ++rows;
+        }
+        EXPECT_EQ(ret, E_OK);
+        EXPECT_EQ(rows, 16);
+        EXPECT_TRUE(remaining_times.empty());
+        reader.destroy_query_data_set(result);
+    }
+    EXPECT_EQ(query_all({make_path("root.tree", "i")}),
+              (std::vector<std::vector<std::string>>{{"0", "0"},
+                                                     {"1", "1"},
+                                                     {"2", "2"},
+                                                     {"3", "3"},
+                                                     {"4", "4"},
+                                                     {"5", "5"}}));
+}
+
+class SparseAlignedSchemaTest : public SchemaCheckCacheTest,
+                                public ::testing::WithParamInterface<bool> {
+   protected:
+    ConfigValue saved_config_;
+    void SetUp() override {
+        saved_config_ = g_config_value_;
+        SchemaCheckCacheTest::SetUp();
+        g_config_value_.page_writer_max_point_num_ = 4;
+        g_config_value_.page_writer_max_memory_bytes_ = 1024 * 1024;
+        g_config_value_.parallel_write_enabled_ = GetParam();
+        g_config_value_.parallel_read_enabled_ = GetParam();
+    }
+    void TearDown() override {
+        SchemaCheckCacheTest::TearDown();
+        g_config_value_ = saved_config_;
+    }
+};
+
+INSTANTIATE_TEST_SUITE_P(SerialAndParallel, SparseAlignedSchemaTest,
+                         ::testing::Bool());
+
+TEST_P(SparseAlignedSchemaTest, MissingFieldsWithinPagesAndAcrossChunks) {
+    const std::string device = "root.sparse";
+    for (const auto& name : {"x", "y"}) {
+        ASSERT_EQ(tsfile_writer_->register_aligned_timeseries(
+                      device, int32_schema(name)),
+                  E_OK);
+    }
+    const std::vector<ColumnSchema> columns = {
+        ColumnSchema("tag", STRING, UNCOMPRESSED, PLAIN, ColumnCategory::TAG),
+        ColumnSchema("x", INT32, UNCOMPRESSED, PLAIN, ColumnCategory::FIELD),
+        ColumnSchema("y", INT32, UNCOMPRESSED, PLAIN, ColumnCategory::FIELD)};
+    ASSERT_EQ(tsfile_writer_->register_table(
+                  std::make_shared<TableSchema>("sparse", columns)),
+              E_OK);
+    const std::vector<std::vector<std::string>> fields = {
+        {"x"}, {"x"}, {"y", "x"}, {"y"}, {}, {"x"}};
+    std::vector<std::vector<std::string>> expected_tree;
+    for (size_t batch = 0; batch < fields.size(); ++batch) {
+        const auto& names = fields[batch];
+        const std::vector<TSDataType> types(names.size(), INT32);
+        Tablet tree(device, &names, &types, 7);
+        auto table_names = names;
+        auto table_types = types;
+        std::vector<ColumnCategory> categories(names.size(),
+                                               ColumnCategory::FIELD);
+        table_names.push_back("tag");
+        table_types.push_back(STRING);
+        categories.push_back(ColumnCategory::TAG);
+        Tablet table("sparse", table_names, table_types, categories, 14);
+        for (int r = 0; r < 7; ++r) {
+            const int64_t time = batch * 7 + r;
+            TsRecord record(device, time);
+            ASSERT_EQ(tree.add_timestamp(r, time), E_OK);
+            std::vector<std::string> expected = {std::to_string(time), "NULL",
+                                                 "NULL"};
+            for (const auto& name : names) {
+                const int32_t value = (name == "x" ? 100 : 200) + time;
+                ASSERT_EQ(record.add_point(name, value), E_OK);
+                ASSERT_EQ(tree.add_value(r, name, value), E_OK);
+                expected[name == "x" ? 1 : 2] = std::to_string(value);
+            }
+            if (batch % 2 == 0)
+                ASSERT_EQ(tsfile_writer_->write_tree(record), E_OK);
+            expected_tree.push_back(expected);
+            for (int d = 0; d < 2; ++d) {
+                const int row = r * 2 + d;
+                ASSERT_EQ(table.add_timestamp(row, time), E_OK);
+                ASSERT_EQ(
+                    table.add_value(row, "tag", String(d == 0 ? "a" : "b", 1)),
+                    E_OK);
+                for (const auto& name : names) {
+                    ASSERT_EQ(table.add_value(
+                                  row, name,
+                                  int32_t((name == "x" ? 100 : 200) + time)),
+                              E_OK);
+                }
+            }
+        }
+        if (batch % 2 == 1) ASSERT_EQ(tsfile_writer_->write_tree(tree), E_OK);
+        ASSERT_EQ(tsfile_writer_->write_table(table), E_OK);
+        if (batch % 2 == 1) ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    }
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+    EXPECT_EQ(query_all({make_path(device, "x"), make_path(device, "y")}),
+              expected_tree);
+
+    TsFileReader reader;
+    ASSERT_EQ(reader.open(file_name_), E_OK);
+    // A sparse-only projection must preserve even the all-null table rows.
+    for (const auto& projection : std::vector<std::vector<std::string>>{
+             {"tag", "x", "y"}, {"tag", "y"}}) {
+        for (const auto& range :
+             std::vector<std::pair<int64_t, int64_t>>{{0, 41}, {5, 36}}) {
+            ResultSet* result = nullptr;
+            ASSERT_EQ(reader.query("sparse", projection, range.first,
+                                   range.second, result),
+                      E_OK);
+            std::set<std::pair<int64_t, std::string>> rows;
+            bool next = false;
+            int ret = E_OK;
+            while ((ret = result->next(next)) == E_OK && next) {
+                const int64_t time = result->get_value<int64_t>(1);
+                EXPECT_GE(time, range.first);
+                EXPECT_LE(time, range.second);
+                const auto* tag = result->get_value<String*>(2);
+                EXPECT_TRUE(
+                    rows.emplace(time, std::string(tag->buf_, tag->len_))
+                        .second);
+                for (size_t i = 1; i < projection.size(); ++i) {
+                    const auto& name = projection[i];
+                    const bool present = name == "x"
+                                             ? time / 7 <= 2 || time / 7 == 5
+                                             : time / 7 == 2 || time / 7 == 3;
+                    EXPECT_EQ(result->is_null(i + 2), !present)
+                        << time << ":" << name;
+                    if (present && !result->is_null(i + 2)) {
+                        EXPECT_EQ(result->get_value<int32_t>(i + 2),
+                                  (name == "x" ? 100 : 200) + time);
+                    }
+                }
+            }
+            EXPECT_EQ(ret, E_OK);
+            EXPECT_EQ(rows.size(), 2U * (range.second - range.first + 1));
+            reader.destroy_query_data_set(result);
+        }
+    }
+}
+
+TEST_P(SparseAlignedSchemaTest, LateFieldBackfillsSealedAndOpenPages) {
+    std::vector<std::string> devices;
+    for (int count : {2, 4, 9, 13}) {
+        const std::string device = "root.late" + std::to_string(count);
+        devices.push_back(device);
+        ASSERT_EQ(tsfile_writer_->register_aligned_timeseries(
+                      device, int32_schema("x")),
+                  E_OK);
+        for (int64_t time = 0; time < count; ++time) {
+            TsRecord record(device, time);
+            ASSERT_EQ(record.add_point("x", int32_t(100 + time)), E_OK);
+            // The unresolved cache entry must be rechecked after registration.
+            ASSERT_EQ(record.add_point("y", int32_t(200 + time)), E_OK);
+            ASSERT_EQ(tsfile_writer_->write_tree(record), E_OK);
+        }
+        ASSERT_EQ(tsfile_writer_->register_aligned_timeseries(
+                      device, int32_schema("y")),
+                  E_OK);
+        for (int64_t time = count; time < 13; ++time) {
+            TsRecord record(device, time);
+            ASSERT_EQ(record.add_point("x", int32_t(100 + time)), E_OK);
+            if (time % 2)
+                ASSERT_EQ(record.add_point("y", int32_t(200 + time)), E_OK);
+            ASSERT_EQ(tsfile_writer_->write_tree(record), E_OK);
+        }
+    }
+    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    for (const auto& device : devices) {
+        EXPECT_EQ(tsfile_writer_->register_aligned_timeseries(
+                      device, int32_schema("z")),
+                  E_NOT_SUPPORT);
+    }
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+    for (int count : {2, 4, 9, 13}) {
+        const std::string device = "root.late" + std::to_string(count);
+        std::vector<std::vector<std::string>> expected;
+        for (int64_t time = 0; time < 13; ++time) {
+            expected.push_back(
+                {std::to_string(time), std::to_string(100 + time),
+                 time >= count && time % 2 ? std::to_string(200 + time)
+                                           : "NULL"});
+        }
+        EXPECT_EQ(query_all({make_path(device, "x"), make_path(device, "y")}),
+                  expected);
+    }
+}
+
+TEST_P(SparseAlignedSchemaTest,
+       RecoveryKeepsSingleEmptyPageAndFollowingChunks) {
+    const std::string device = "root.recovered_late";
+    ASSERT_EQ(
+        tsfile_writer_->register_aligned_timeseries(device, int32_schema("x")),
+        E_OK);
+    for (int64_t time = 0; time < 4; ++time) {
+        TsRecord record(device, time);
+        ASSERT_EQ(record.add_point("x", int32_t(100 + time)), E_OK);
+        ASSERT_EQ(tsfile_writer_->write_tree(record), E_OK);
+    }
+    // Exactly one time page is sealed. Registration followed immediately by
+    // flush produces a value chunk containing just one empty-page header.
+    ASSERT_EQ(
+        tsfile_writer_->register_aligned_timeseries(device, int32_schema("y")),
+        E_OK);
+    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    TsRecord record(device, 4);
+    ASSERT_EQ(record.add_point("x", int32_t(104)), E_OK);
+    ASSERT_EQ(record.add_point("y", int32_t(204)), E_OK);
+    ASSERT_EQ(tsfile_writer_->write_tree(record), E_OK);
+    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    // Leave the flushed chunks without a footer to exercise crash recovery.
+    tsfile_writer_->destroy();
+    int64_t flushed_size = 0;
+    {
+        std::ifstream file(file_name_, std::ios::binary | std::ios::ate);
+        ASSERT_TRUE(file.is_open());
+        flushed_size = static_cast<int64_t>(file.tellg());
+    }
+    {
+        RestorableTsFileIOWriter recovered;
+        ASSERT_EQ(recovered.open(file_name_, true), E_OK);
+        ASSERT_EQ(recovered.get_truncated_size(), flushed_size);
+        ASSERT_EQ(recovered.get_recovered_chunk_group_metas().size(), 2U);
+        TsFileWriter resumed;
+        ASSERT_EQ(resumed.init(&recovered), E_OK);
+        ASSERT_EQ(resumed.close(), E_OK);
+    }
+    std::vector<std::vector<std::string>> expected;
+    for (int64_t time = 0; time < 5; ++time) {
+        expected.push_back({std::to_string(time), std::to_string(100 + time),
+                            time >= 4 ? std::to_string(200 + time) : "NULL"});
+    }
+    EXPECT_EQ(query_all({make_path(device, "x"), make_path(device, "y")}),
+              expected);
+}
+
+TEST_P(SparseAlignedSchemaTest,
+       RecordAfterFullTabletKeepsOmittedColumnAligned) {
+    const std::string device = "root.tablet_record";
+    ASSERT_EQ(
+        tsfile_writer_->register_aligned_timeseries(device, int32_schema("x")),
+        E_OK);
+    ASSERT_EQ(
+        tsfile_writer_->register_aligned_timeseries(device, int32_schema("y")),
+        E_OK);
+    const std::vector<std::string> names = {"x"};
+    const std::vector<TSDataType> types = {INT32};
+    Tablet tablet(device, &names, &types, 4);
+    for (int r = 0; r < 4; ++r) {
+        ASSERT_EQ(tablet.add_timestamp(r, r), E_OK);
+        ASSERT_EQ(tablet.add_value(r, "x", int32_t(100 + r)), E_OK);
+    }
+    ASSERT_EQ(tsfile_writer_->write_tree(tablet), E_OK);
+    std::vector<std::vector<std::string>> expected;
+    for (int64_t time = 0; time < 7; ++time) {
+        if (time >= 4) {
+            TsRecord record(device, time);
+            ASSERT_EQ(record.add_point("x", int32_t(100 + time)), E_OK);
+            if (time == 5) ASSERT_EQ(record.add_point("y", int32_t(205)), E_OK);
+            ASSERT_EQ(tsfile_writer_->write_tree(record), E_OK);
+        }
+        expected.push_back({std::to_string(time), std::to_string(100 + time),
+                            time == 5 ? "205" : "NULL"});
+    }
+    ASSERT_EQ(tsfile_writer_->flush(), E_OK);
+    ASSERT_EQ(tsfile_writer_->close(), E_OK);
+    EXPECT_EQ(query_all({make_path(device, "x"), make_path(device, "y")}),
+              expected);
+}
+
+}  // namespace


### PR DESCRIPTION
<!--

    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

        http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.

-->

Repeated writes currently resolve each measurement name through a per-device schema map. This PR reuses those lookups through one bounded cache owned by `TsFileWriter`, covering tree records, tree tablets, and table FIELD columns.

Related to #885 and the earlier tree-only implementation in #934. This is an alternative implementation based on the current `develop` branch; the initial cache regression cases build on #934.

## Changes

- Keep an LRU of at most 64 device entries per writer, with a fast path for the most recent device. Entries hold non-owning schema pointers and preserve the input column order; positional names are checked on every call, and unresolved columns are looked up again after registration.
- Share the cache across aligned/non-aligned tree writes and table FIELD lookup. Clear it before schema destruction; flush preserves the schema objects. Eviction does not invalidate the chunk writers already saved in a table write context.
- Keep omitted aligned fields synchronized with time rows, pages, and chunks. Cache the omitted-field list so repeated full-schema writes avoid rescanning all registered fields. Fields registered before the first flush receive the preceding empty pages and null positions; adding a new aligned field after the device's first flush returns `E_NOT_SUPPORT` rather than producing incomplete historical alignment.
- Read the existing one-varint empty aligned-page representation and reset the corresponding reader state. Preserve a single empty aligned value page during crash recovery so later valid chunks are not truncated.

The entry-count bound is 64 devices, not a byte limit: each entry retains vectors sized for its device's schema. This does not add support for concurrent public calls on one writer; internal parallel encoding continues to use the existing thread pool.

## Validation

- macOS arm64, Apple Clang 21; Release build with bundled compression dependencies and LZMA2 enabled.
- Full C++ test binary: 957 passed, 3 skipped because their external fixture environment variables were unset; 10 existing disabled tests were not run.
- Explicitly instrumented Debug ASan/UBSan run: all 92 targeted tests completed successfully with no ASan findings (`detect_leaks=0`). UBSan reported existing null-pointer arithmetic at `common/allocator/page_arena.h:92`; a standalone `PageArena::alloc(2048)` followed by `alloc(8)` with a 1024-byte page reproduces it without any writer or cache. The allocator is unchanged from the base, and this is not a clean UBSan run.
- All ten changed C++ files pass clang-format 17.0.6 verification and `git diff --check`.

The regression suite checks row values and timestamps across repeated writes, changed names/order/width, late registration, multiple devices and writers, destroy/re-init, eviction beyond 64 devices, table TAG/FIELD layouts, sparse aligned fields, serial/parallel page boundaries, and recovery preserving an empty-page backfill and the following valid chunks.
