### PR TITLE
fix(cpp): correct wide INT64 decoding and SIMD statistic reductions

### DIFF
--- a/cpp/src/common/statistic.h
+++ b/cpp/src/common/statistic.h
@@ -864,10 +864,10 @@ class Int64Statistic : public Statistic {
                 vsum = simde_mm_add_pd(vsum,
                                        simde_mm_set_pd((double)v1, (double)v0));
             }
-            min_value_ = std::min(simde_mm_cvtsi128_si64(vmin),
-                                  simde_mm_extract_epi64(vmin, 1));
-            max_value_ = std::max(simde_mm_cvtsi128_si64(vmax),
-                                  simde_mm_extract_epi64(vmax, 1));
+            min_value_ = std::min<int64_t>(simde_mm_cvtsi128_si64(vmin),
+                                           simde_mm_extract_epi64(vmin, 1));
+            max_value_ = std::max<int64_t>(simde_mm_cvtsi128_si64(vmax),
+                                           simde_mm_extract_epi64(vmax, 1));
             sum_value_ += simde_mm_cvtsd_f64(vsum) +
                           simde_mm_cvtsd_f64(simde_mm_unpackhi_pd(vsum, vsum));
         }

--- a/cpp/src/encoding/ts2diff_decoder.h
+++ b/cpp/src/encoding/ts2diff_decoder.h
@@ -201,6 +201,19 @@ static inline int64_t scalar_read_bits(const uint8_t* data, int32_t bit_pos,
     return value;
 }
 
+// Reconstruct with modulo-2^64 arithmetic, as in the SIMD additions. A
+// residual plus the previous value can overflow INT64 before a negative
+// minimum delta brings the final value back into range.
+static inline int64_t ts2diff_restore_int64(int64_t residual, int64_t previous,
+                                            int64_t minimum_delta) {
+    const uint64_t bits = static_cast<uint64_t>(residual) +
+                          static_cast<uint64_t>(previous) +
+                          static_cast<uint64_t>(minimum_delta);
+    int64_t value;
+    std::memcpy(&value, &bits, sizeof(value));
+    return value;
+}
+
 namespace ts2diff_java_detail {
 
 inline bool bitmap_marked(const std::vector<uint8_t>& bm, int idx) {
@@ -529,7 +542,7 @@ inline int64_t TS2DIFFDecoder<int64_t>::decode(common::ByteStream& in) {
         return ret_value;
     }
     stored_value_ = (int64_t)read_long(bit_width_, in);
-    ret_value = stored_value_ + first_value_ + delta_min_;
+    ret_value = ts2diff_restore_int64(stored_value_, first_value_, delta_min_);
     first_value_ = ret_value;
     if (current_index_++ >= write_index_) {
         current_index_ = 0;
@@ -796,8 +809,12 @@ inline int TS2DIFFDecoder<int64_t>::read_batch_int64(int64_t* out, int capacity,
         }
 
 #ifdef ENABLE_SIMD
-        // SIMD path: decode 4 INT64 values at a time
-        for (; i + 3 < remaining; i += 4) {
+        // Each SIMD lane gathers eight bytes. Widths 59, 61, 62 and 63 can
+        // start at a bit offset that requires a ninth byte; decode those
+        // blocks with the scalar path below to preserve the low bits.
+        const bool simd_width_fits =
+            bit_width_ <= 58 || bit_width_ == 60 || bit_width_ == 64;
+        for (; simd_width_fits && i + 3 < remaining; i += 4) {
             int32_t need_bytes =
                 ((i + 3) * bit_width_ + bit_width_ + 7) / 8 + 8;
             if (need_bytes > block_bytes) break;
@@ -815,7 +832,7 @@ inline int TS2DIFFDecoder<int64_t>::read_batch_int64(int64_t* out, int capacity,
         for (; i < remaining; ++i) {
             int64_t delta = scalar_read_bits(blk_ptr, bit_pos, bit_width_);
             bit_pos += bit_width_;
-            int64_t val = delta + prev + delta_min_;
+            int64_t val = ts2diff_restore_int64(delta, prev, delta_min_);
             prev = val;
             out[actual++] = val;
         }

--- a/cpp/test/common/statistic_test.cc
+++ b/cpp/test/common/statistic_test.cc
@@ -125,6 +125,34 @@ TEST(Int64StatisticTest, BasicFunctionality) {
     EXPECT_EQ(stat_deserialized.last_value_, stat.last_value_);
 }
 
+TEST(Int64StatisticTest, BatchPreservesWideSignedExtremaAcrossLanes) {
+    const int64_t wide = int64_t{1} << 60;
+    const int64_t timestamps[] = {0, 1, 2, 3, 4, 5, 6, 7, 8};
+    const int64_t values[] = {0,         -wide - 7,  wide + 1,
+                              wide + 9,  -wide - 11, -wide - 17,
+                              wide + 13, 23,         -31};
+    Int64Statistic stat;
+    // Start with an empty statistic; the first value seeds both lanes.
+    stat.update_batch(timestamps, values, 5);
+    EXPECT_EQ(stat.count_, 5);
+    EXPECT_EQ(stat.min_value_, -wide - 11);
+    EXPECT_EQ(stat.max_value_, wide + 9);
+    EXPECT_EQ(stat.first_value_, 0);
+    EXPECT_EQ(stat.last_value_, -wide - 11);
+    EXPECT_EQ(stat.start_time_, 0);
+    EXPECT_EQ(stat.end_time_, 4);
+
+    // The next batch supplies new extrema in opposite SIMD lanes.
+    stat.update_batch(timestamps + 5, values + 5, 4);
+    EXPECT_EQ(stat.count_, 9);
+    EXPECT_EQ(stat.min_value_, -wide - 17);
+    EXPECT_EQ(stat.max_value_, wide + 13);
+    EXPECT_EQ(stat.first_value_, 0);
+    EXPECT_EQ(stat.last_value_, -31);
+    EXPECT_EQ(stat.start_time_, 0);
+    EXPECT_EQ(stat.end_time_, 8);
+}
+
 TEST(FloatStatisticTest, BasicFunctionality) {
     FloatStatistic stat;
 

--- a/cpp/test/encoding/ts2diff_codec_test.cc
+++ b/cpp/test/encoding/ts2diff_codec_test.cc
@@ -320,6 +320,127 @@ TEST_F(TS2DIFFCodecTest, TestLongEncoding2) {
     }
 }
 
+// Wide packed values can start partway through a byte and require nine bytes
+// to decode. Exercise every wide bit width independently of the encoder.
+TEST_F(TS2DIFFCodecTest, ReadBatchInt64WideValuesAcrossByteBoundaries) {
+    const int count = 129;
+    for (int width = 57; width <= 64; ++width) {
+        SCOPED_TRACE(width);
+        const int64_t amplitude = int64_t{1} << std::min(width - 2, 61);
+        std::vector<int64_t> expected(count, 0);
+        std::vector<uint8_t> packed(((count - 1) * width + 7) / 8, 0);
+        for (int i = 0; i < count - 1; ++i) {
+            const int64_t residual = i % 2 == 0 ? 2 * amplitude + i + 1 : 0;
+            expected[i + 1] = expected[i] + (residual - amplitude);
+            for (int bit = 0; bit < width; ++bit) {
+                const int position = i * width + bit;
+                packed[position / 8] |=
+                    ((static_cast<uint64_t>(residual) >> (width - bit - 1)) &
+                     1U)
+                    << (7 - position % 8);
+            }
+        }
+        common::ByteStream encoded(1024, common::MOD_TS2DIFF_OBJ, false);
+        ASSERT_EQ(common::SerializationUtil::write_ui32(count - 1, encoded),
+                  common::E_OK);
+        ASSERT_EQ(common::SerializationUtil::write_ui32(width, encoded),
+                  common::E_OK);
+        ASSERT_EQ(common::SerializationUtil::write_ui64(
+                      static_cast<uint64_t>(-amplitude), encoded),
+                  common::E_OK);
+        ASSERT_EQ(common::SerializationUtil::write_ui64(0, encoded),
+                  common::E_OK);
+        ASSERT_EQ(encoded.write_buf(packed.data(), packed.size()),
+                  common::E_OK);
+        std::vector<uint8_t> page(encoded.total_size());
+        uint32_t read_len = 0;
+        ASSERT_EQ(encoded.read_buf(page.data(), page.size(), read_len),
+                  common::E_OK);
+        ASSERT_EQ(read_len, page.size());
+
+        for (int batch_size : {count, 17}) {
+            SCOPED_TRACE(batch_size);
+            common::ByteStream input;
+            input.wrap_from(reinterpret_cast<const char*>(page.data()),
+                            page.size());
+            LongTS2DIFFDecoder decoder;
+            std::vector<int64_t> actual(count);
+            int offset = 0;
+            while (offset < count) {
+                int decoded = 0;
+                ASSERT_EQ(
+                    decoder.read_batch_int64(
+                        actual.data() + offset,
+                        std::min(batch_size, count - offset), decoded, input),
+                    common::E_OK);
+                ASSERT_GT(decoded, 0);
+                offset += decoded;
+            }
+            ASSERT_EQ(actual, expected);
+            EXPECT_FALSE(decoder.has_remaining(input));
+        }
+    }
+}
+
+TEST_F(TS2DIFFCodecTest, ReadBatchInt64WideResidualWithHighBase) {
+    const int width = 63;
+    const int count = 129;
+    const int64_t base = int64_t{1} << 62;
+    std::vector<uint64_t> residuals(count - 1, static_cast<uint64_t>(base));
+    residuals[0] += 1;
+    residuals[1] = 0;
+    std::vector<int64_t> expected(count, 1);
+    expected[0] = base;
+    expected[1] = base + 1;
+    // Every reconstructed value fits INT64, but residual + previous can
+    // overflow before the negative minimum delta is added.
+    std::vector<uint8_t> packed(((count - 1) * width + 7) / 8, 0);
+    for (int i = 0; i < count - 1; ++i) {
+        for (int bit = 0; bit < width; ++bit) {
+            const int position = i * width + bit;
+            packed[position / 8] |= ((residuals[i] >> (width - bit - 1)) & 1U)
+                                    << (7 - position % 8);
+        }
+    }
+    common::ByteStream encoded(1024, common::MOD_TS2DIFF_OBJ, false);
+    ASSERT_EQ(common::SerializationUtil::write_ui32(count - 1, encoded),
+              common::E_OK);
+    ASSERT_EQ(common::SerializationUtil::write_ui32(width, encoded),
+              common::E_OK);
+    ASSERT_EQ(common::SerializationUtil::write_ui64(
+                  static_cast<uint64_t>(-base), encoded),
+              common::E_OK);
+    ASSERT_EQ(common::SerializationUtil::write_ui64(base, encoded),
+              common::E_OK);
+    ASSERT_EQ(encoded.write_buf(packed.data(), packed.size()), common::E_OK);
+    std::vector<uint8_t> page(encoded.total_size());
+    uint32_t read_len = 0;
+    ASSERT_EQ(encoded.read_buf(page.data(), page.size(), read_len),
+              common::E_OK);
+    ASSERT_EQ(read_len, page.size());
+
+    for (int batch_size : {count, 17, 1}) {
+        SCOPED_TRACE(batch_size);
+        common::ByteStream input;
+        input.wrap_from(reinterpret_cast<const char*>(page.data()),
+                        page.size());
+        LongTS2DIFFDecoder decoder;
+        std::vector<int64_t> actual(count);
+        int offset = 0;
+        while (offset < count) {
+            int decoded = 0;
+            ASSERT_EQ(decoder.read_batch_int64(
+                          actual.data() + offset,
+                          std::min(batch_size, count - offset), decoded, input),
+                      common::E_OK);
+            ASSERT_GT(decoded, 0);
+            offset += decoded;
+        }
+        ASSERT_EQ(actual, expected);
+        EXPECT_FALSE(decoder.has_remaining(input));
+    }
+}
+
 TEST_F(TS2DIFFCodecTest, TestRandomEncoding) {
     common::ByteStream out_stream(1024, common::MOD_TS2DIFF_OBJ, false);
     const int row_num = 10000;


### PR DESCRIPTION
<!--

    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

        http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.

-->

The C++ TS2DIFF INT64 batch decoder can silently lose low bits when a packed value spans nine bytes. During a large-file benchmark, C++ returned `4382462187900922485` for a value that Java correctly read as `4382462187900922519` from the same file.

The SIMD gather reads eight bytes per value. Packed widths 59, 61, 62 and 63 can require a ninth byte because of the starting bit offset. Route these blocks through the existing scalar decoder and keep the SIMD path for widths that fit. This trades SIMD speed for correctness in the affected blocks without changing the wire format or write path.

Scalar INT64 reconstruction now adds the residual, previous value and minimum delta with unsigned modulo-2^64 arithmetic and preserves the signed bit pattern. This prevents an intermediate signed overflow when a negative minimum delta brings the final value back into range, including when reads split a block.

The same benchmark also exposed a Linux compilation failure in the INT64 SIMD statistic reduction: the two lane-extraction intrinsics can return different signed 64-bit C++ types. Use explicit `std::min<int64_t>` and `std::max<int64_t>` to avoid conflicting `long`/`long long` template deduction.

## Tests

- A manually packed fixture exercises widths 57–64, comparing exact INT64 values for both whole-block and split-batch reads. The fixture is independent of the encoder. On the unmodified develop decoder, it fails at width 59; with this fix it passes.
- A width-63 fixture starts at `2^62` and reconstructs values that all fit INT64 despite an overflowing signed intermediate sum. It checks whole-block, split-batch and one-value reads; UBSan reproduced the failure before the reconstruction fix.
- A batch-statistic regression checks wide positive/negative extrema in both SIMD lanes, including a subsequent batch with new extrema.
- Full Release C++ suite: 937 passed, 3 skipped because external fixture environment variables were unset; 10 existing disabled tests were not run.
- Explicitly instrumented Debug ASan/UBSan: all 40 TS2DIFF and INT64-statistic tests passed with `halt_on_error=1` and leak detection disabled; no sanitizer findings.
- clang-format 17.0.6 verification and `git diff --check` passed for all four changed files.

Local validation uses macOS arm64 / Apple Clang 21. Linux compiler portability will also be exercised by the repository CI matrix; a local Linux container was not available.
