### PR TITLE
Add batched null and bitmap-offset writes to ValuePageWriter

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/write/page/ValuePageWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/page/ValuePageWriter.java
@@ -28,6 +28,7 @@ import org.apache.tsfile.file.metadata.enums.CompressionType;
 import org.apache.tsfile.file.metadata.enums.EncryptionType;
 import org.apache.tsfile.file.metadata.statistics.Statistics;
 import org.apache.tsfile.utils.Binary;
+import org.apache.tsfile.utils.BitMap;
 import org.apache.tsfile.utils.PublicBAOS;
 import org.apache.tsfile.utils.ReadWriteForEncodingUtils;
 
@@ -265,6 +266,108 @@ public class ValuePageWriter {
     for (int i = arrayOffset; i < batchSize + arrayOffset; i++) {
       setBit(isNull[i]);
       if (!isNull[i]) {
+        valueEncoder.encode(values[i], valueOut);
+        statistics.update(timestamps[i], values[i]);
+      }
+    }
+  }
+
+  public void write(
+      long[] timestamps,
+      boolean[] values,
+      BitMap bitMap,
+      int bitMapOffset,
+      int batchSize,
+      int arrayOffset) {
+    for (int i = arrayOffset; i < batchSize + arrayOffset; i++) {
+      boolean isNull = bitMap.isMarked(bitMapOffset + i - arrayOffset);
+      setBit(isNull);
+      if (!isNull) {
+        valueEncoder.encode(values[i], valueOut);
+        statistics.update(timestamps[i], values[i]);
+      }
+    }
+  }
+
+  public void write(
+      long[] timestamps,
+      int[] values,
+      BitMap bitMap,
+      int bitMapOffset,
+      int batchSize,
+      int arrayOffset) {
+    for (int i = arrayOffset; i < batchSize + arrayOffset; i++) {
+      boolean isNull = bitMap.isMarked(bitMapOffset + i - arrayOffset);
+      setBit(isNull);
+      if (!isNull) {
+        valueEncoder.encode(values[i], valueOut);
+        statistics.update(timestamps[i], values[i]);
+      }
+    }
+  }
+
+  public void write(
+      long[] timestamps,
+      long[] values,
+      BitMap bitMap,
+      int bitMapOffset,
+      int batchSize,
+      int arrayOffset) {
+    for (int i = arrayOffset; i < batchSize + arrayOffset; i++) {
+      boolean isNull = bitMap.isMarked(bitMapOffset + i - arrayOffset);
+      setBit(isNull);
+      if (!isNull) {
+        valueEncoder.encode(values[i], valueOut);
+        statistics.update(timestamps[i], values[i]);
+      }
+    }
+  }
+
+  public void write(
+      long[] timestamps,
+      float[] values,
+      BitMap bitMap,
+      int bitMapOffset,
+      int batchSize,
+      int arrayOffset) {
+    for (int i = arrayOffset; i < batchSize + arrayOffset; i++) {
+      boolean isNull = bitMap.isMarked(bitMapOffset + i - arrayOffset);
+      setBit(isNull);
+      if (!isNull) {
+        valueEncoder.encode(values[i], valueOut);
+        statistics.update(timestamps[i], values[i]);
+      }
+    }
+  }
+
+  public void write(
+      long[] timestamps,
+      double[] values,
+      BitMap bitMap,
+      int bitMapOffset,
+      int batchSize,
+      int arrayOffset) {
+    for (int i = arrayOffset; i < batchSize + arrayOffset; i++) {
+      boolean isNull = bitMap.isMarked(bitMapOffset + i - arrayOffset);
+      setBit(isNull);
+      if (!isNull) {
+        valueEncoder.encode(values[i], valueOut);
+        statistics.update(timestamps[i], values[i]);
+      }
+    }
+  }
+
+  public void write(
+      long[] timestamps,
+      Binary[] values,
+      BitMap bitMap,
+      int bitMapOffset,
+      int batchSize,
+      int arrayOffset) {
+    for (int i = arrayOffset; i < batchSize + arrayOffset; i++) {
+      boolean isNull = bitMap.isMarked(bitMapOffset + i - arrayOffset);
+      setBit(isNull);
+      if (!isNull) {
         valueEncoder.encode(values[i], valueOut);
         statistics.update(timestamps[i], values[i]);
       }

--- a/java/tsfile/src/main/java/org/apache/tsfile/write/page/ValuePageWriter.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/write/page/ValuePageWriter.java
@@ -69,6 +69,8 @@ public class ValuePageWriter {
 
   private static final int MASK = 1 << 7;
 
+  private static final byte[] NULL_BITMAP_BATCH = new byte[1024];
+
   public ValuePageWriter(Encoder valueEncoder, ICompressor compressor, TSDataType dataType) {
     this.valueOut = new PublicBAOS();
     this.bitmap = 0;
@@ -155,6 +157,34 @@ public class ValuePageWriter {
     if (!isNull) {
       valueEncoder.encode(value, valueOut);
       statistics.update(time, value);
+    }
+  }
+
+  /** Write consecutive null values without encoding values or updating statistics. */
+  public void writeNull(int count) {
+    if (count <= 0) {
+      return;
+    }
+
+    int remaining = count;
+    while (remaining > 0 && size % 8 != 0) {
+      setBit(true);
+      remaining--;
+    }
+
+    // At a byte boundary, eight nulls are a zero byte. Reuse a bounded buffer for large runs.
+    int fullByteCount = remaining / 8;
+    while (fullByteCount > 0) {
+      int batchSize = Math.min(fullByteCount, NULL_BITMAP_BATCH.length);
+      bitmapOut.write(NULL_BITMAP_BATCH, 0, batchSize);
+      size += batchSize * 8;
+      fullByteCount -= batchSize;
+      remaining -= batchSize * 8;
+    }
+
+    while (remaining > 0) {
+      setBit(true);
+      remaining--;
     }
   }
 

--- a/java/tsfile/src/test/java/org/apache/tsfile/write/writer/ValuePageWriterTest.java
+++ b/java/tsfile/src/test/java/org/apache/tsfile/write/writer/ValuePageWriterTest.java
@@ -37,10 +37,97 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class ValuePageWriterTest {
+
+  @Test
+  public void testWriteNull() throws IOException {
+    ICompressor compressor = ICompressor.getCompressor(CompressionType.UNCOMPRESSED);
+    // Exercise every bitmap offset and null runs spanning multiple bytes.
+    for (int prefixSize = 0; prefixSize <= 8; prefixSize++) {
+      for (int nullCount = 0; nullCount <= 24; nullCount++) {
+        ValuePageWriter pageWriter =
+            new ValuePageWriter(
+                new PlainEncoder(TSDataType.FLOAT, 0), compressor, TSDataType.FLOAT);
+        ValuePageWriter expectedWriter =
+            new ValuePageWriter(
+                new PlainEncoder(TSDataType.FLOAT, 0), compressor, TSDataType.FLOAT);
+        for (int i = 0; i < prefixSize; i++) {
+          pageWriter.write(i, (float) i, false);
+          expectedWriter.write(i, (float) i, false);
+        }
+        pageWriter.writeNull(nullCount);
+        for (int i = 0; i < nullCount; i++) {
+          expectedWriter.write(prefixSize + i, 0.0f, true);
+        }
+        assertEquals(prefixSize + nullCount, pageWriter.getSize());
+        assertEquals(prefixSize, pageWriter.getPointNumber());
+
+        int lastTime = prefixSize + nullCount;
+        pageWriter.write(lastTime, 42.0f, false);
+        expectedWriter.write(lastTime, 42.0f, false);
+        assertEquals(expectedWriter.getUncompressedBytes(), pageWriter.getUncompressedBytes());
+        PublicBAOS expectedStatistics = new PublicBAOS();
+        PublicBAOS actualStatistics = new PublicBAOS();
+        expectedWriter.getStatistics().serialize(expectedStatistics);
+        pageWriter.getStatistics().serialize(actualStatistics);
+        assertArrayEquals(expectedStatistics.toByteArray(), actualStatistics.toByteArray());
+      }
+    }
+  }
+
+  @Test
+  public void testWriteNullOnlyPageAndReset() throws IOException {
+    ValuePageWriter pageWriter =
+        new ValuePageWriter(
+            new PlainEncoder(TSDataType.FLOAT, 0),
+            ICompressor.getCompressor(CompressionType.UNCOMPRESSED),
+            TSDataType.FLOAT);
+    PublicBAOS pageBuffer = new PublicBAOS();
+    pageWriter.writeNull(0);
+    assertEquals(0, pageWriter.getSize());
+    assertEquals(0, pageWriter.writePageHeaderAndDataIntoBuff(pageBuffer, true));
+    assertEquals(0, pageBuffer.size());
+
+    pageWriter.writeNull(7);
+    pageWriter.writeNull(10);
+    assertEquals(17, pageWriter.getSize());
+    assertEquals(0, pageWriter.getPointNumber());
+    assertEquals(1, pageWriter.writePageHeaderAndDataIntoBuff(pageBuffer, true));
+    assertEquals(1, pageBuffer.size());
+    assertEquals(0, pageBuffer.getBuf()[0]);
+
+    pageWriter.reset(TSDataType.FLOAT);
+    pageWriter.writeNull(1);
+    pageWriter.write(1L, 1.0f, false);
+    ByteBuffer buffer = pageWriter.getUncompressedBytes();
+    assertEquals(2, buffer.getInt());
+    assertEquals((byte) 0x40, buffer.get());
+    assertEquals(1.0f, buffer.getFloat(), 0.0f);
+    assertEquals(0, buffer.remaining());
+  }
+
+  @Test
+  public void testWriteLargeNullBatch() throws IOException {
+    ValuePageWriter pageWriter =
+        new ValuePageWriter(
+            new PlainEncoder(TSDataType.FLOAT, 0),
+            ICompressor.getCompressor(CompressionType.UNCOMPRESSED),
+            TSDataType.FLOAT);
+    pageWriter.writeNull(16393);
+
+    assertEquals(16393, pageWriter.getSize());
+    assertEquals(0, pageWriter.getPointNumber());
+    ByteBuffer buffer = pageWriter.getUncompressedBytes();
+    assertEquals(16393, buffer.getInt());
+    assertEquals(2050, buffer.remaining());
+    while (buffer.hasRemaining()) {
+      assertEquals(0, buffer.get());
+    }
+  }
 
   @Test
   public void testWrite1() {


### PR DESCRIPTION
## Summary
- add ValuePageWriter.writeNull(int) with batched bitmap-byte writes for large null runs
- add Bitmap-based batch write overloads for boolean, int, long, float, double, and Binary values
- support an independent bitMapOffset for each overload

## Validation
- ValuePageWriterTest: 9 tests passed
- Spotless and Checkstyle passed