### PR TITLE
Enable GitHub Discussions

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -32,6 +32,7 @@ github:
   features:
     wiki: true
     issues: true
+    discussions: true
   enabled_merge_buttons:
     # enable squash button:
     squash:  true
@@ -46,6 +47,7 @@ github:
 notifications:
   commits: commits@tsfile.apache.org
   issues: dev@tsfile.apache.org
+  discussions: dev@tsfile.apache.org
   pullrequests_status: notifications@tsfile.apache.org
   pullrequests_comment: notifications@tsfile.apache.org
   pullrequests_bot_dependabot: notifications@tsfile.apache.org


### PR DESCRIPTION
Enable GitHub Discussions for Apache TsFile and forward discussion activity notifications to `dev@tsfile.apache.org`.

Adds `github.features.discussions: true` and `notifications.discussions` to `.asf.yaml`, as required by [ASF Infra](https://infra.apache.org/blog/newsletter_03_25.html). The configuration will be applied after this PR is merged into `develop`.

Validation: parsed `.asf.yaml` with PyYAML, verified that only these two settings changed, and passed `git diff --check`. No application code changes.
