### PR TITLE
Cache type service readers in page readers

### DIFF
--- a/java/tsfile/src/main/java/org/apache/tsfile/read/reader/page/PageReader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/reader/page/PageReader.java
@@ -60,6 +60,11 @@ public class PageReader implements IPageReader {
   /** decoder for value column */
   private final Decoder valueDecoder;
 
+  // Reuse type-specific readers and the deletion predicate across repeated page reads.
+  private PageDataValueReader batchDataValueReader;
+  private PageDataBlockValueReader blockValueReader;
+  private final LongPredicate deletePredicate = this::isDeleted;
+
   /** decoder for time column */
   private final Decoder timeDecoder;
 
@@ -156,13 +161,20 @@ public class PageReader implements IPageReader {
     uncompressDataIfNecessary();
     BatchData pageData = BatchDataFactory.createBatchData(dataType, ascending, false);
     boolean allSatisfy = recordFilter == null || recordFilter.allSatisfy(this);
-    PageDataValueReader valueReader =
-        TypeServices.READ_PAGE_VALUE_TO_BATCHDATA_SERVICE.call(Type.fromTsDataType(dataType));
-    LongPredicate isDeleted = this::isDeleted;
+    if (batchDataValueReader == null) {
+      batchDataValueReader =
+          TypeServices.READ_PAGE_VALUE_TO_BATCHDATA_SERVICE.call(Type.fromTsDataType(dataType));
+    }
     while (timeDecoder.hasNext(timeBuffer)) {
       long timestamp = timeDecoder.readLong(timeBuffer);
-      valueReader.read(
-          valueDecoder, valueBuffer, recordFilter, pageData, timestamp, allSatisfy, isDeleted);
+      batchDataValueReader.read(
+          valueDecoder,
+          valueBuffer,
+          recordFilter,
+          pageData,
+          timestamp,
+          allSatisfy,
+          deletePredicate);
     }
     return pageData.flip();
   }
@@ -185,20 +197,21 @@ public class PageReader implements IPageReader {
 
     long allFilteredRows = 0;
     boolean allSatisfy = recordFilter == null || recordFilter.allSatisfy(this);
-    PageDataBlockValueReader valueReader =
-        TypeServices.READ_PAGE_VALUE_TO_TSBLOCK_SERVICE.call(Type.fromTsDataType(dataType));
-    LongPredicate isDeleted = this::isDeleted;
+    if (blockValueReader == null) {
+      blockValueReader =
+          TypeServices.READ_PAGE_VALUE_TO_TSBLOCK_SERVICE.call(Type.fromTsDataType(dataType));
+    }
     while (timeDecoder.hasNext(timeBuffer)) {
       long timestamp = timeDecoder.readLong(timeBuffer);
       PageDataReadStatus status =
-          valueReader.read(
+          blockValueReader.read(
               valueDecoder,
               valueBuffer,
               recordFilter,
               builder,
               timestamp,
               allSatisfy,
-              isDeleted,
+              deletePredicate,
               paginationController);
       if (status == PageDataReadStatus.FILTERED) {
         allFilteredRows++;

--- a/java/tsfile/src/main/java/org/apache/tsfile/read/reader/page/ValuePageReader.java
+++ b/java/tsfile/src/main/java/org/apache/tsfile/read/reader/page/ValuePageReader.java
@@ -54,6 +54,16 @@ public class ValuePageReader {
   /** decoder for value column */
   private final Decoder valueDecoder;
 
+  // Reuse the type-specific reader across per-row nextValue calls.
+  private PageDataTsPrimitiveValueReader valueReader;
+
+  // Reuse readers for batch and column-builder APIs across repeated page reads.
+  private PageDataValueReader batchDataValueReader;
+  private PageDataColumnBuilderValueReader columnBuilderValueReader;
+
+  // Reuse the bound predicate across page reads instead of creating a method reference per call.
+  private final LongPredicate deletePredicate = this::isDeleted;
+
   private byte[] bitmap;
 
   private int size;
@@ -118,17 +128,18 @@ public class ValuePageReader {
       throws IOException {
     uncompressDataIfNecessary();
     BatchData pageData = BatchDataFactory.createBatchData(dataType, ascending, false);
-    PageDataValueReader valueReader =
-        TypeServices.READ_PAGE_VALUE_TO_BATCHDATA_SERVICE.call(Type.fromTsDataType(dataType));
+    if (batchDataValueReader == null) {
+      batchDataValueReader =
+          TypeServices.READ_PAGE_VALUE_TO_BATCHDATA_SERVICE.call(Type.fromTsDataType(dataType));
+    }
     boolean allSatisfy = filter == null;
-    LongPredicate isDeleted = this::isDeleted;
     for (int i = 0; i < timeBatch.length; i++) {
       if (((bitmap[i / 8] & 0xFF) & (MASK >>> (i % 8))) == 0) {
         continue;
       }
       long timestamp = timeBatch[i];
-      valueReader.read(
-          valueDecoder, valueBuffer, filter, pageData, timestamp, allSatisfy, isDeleted);
+      batchDataValueReader.read(
+          valueDecoder, valueBuffer, filter, pageData, timestamp, allSatisfy, deletePredicate);
     }
     return pageData.flip();
   }
@@ -138,9 +149,12 @@ public class ValuePageReader {
     if (valueBuffer == null || ((bitmap[timeIndex / 8] & 0xFF) & (MASK >>> (timeIndex % 8))) == 0) {
       return null;
     }
-    PageDataTsPrimitiveValueReader valueReader =
-        TypeServices.READ_PAGE_VALUE_TO_TSPRIMITIVETYPE_SERVICE.call(Type.fromTsDataType(dataType));
-    return valueReader.read(valueDecoder, valueBuffer, timestamp, this::isDeleted);
+    if (valueReader == null) {
+      valueReader =
+          TypeServices.READ_PAGE_VALUE_TO_TSPRIMITIVETYPE_SERVICE.call(
+              Type.fromTsDataType(dataType));
+    }
+    return valueReader.read(valueDecoder, valueBuffer, timestamp, deletePredicate);
   }
 
   /**
@@ -153,14 +167,16 @@ public class ValuePageReader {
     if (valueBuffer == null) {
       return valueBatch;
     }
-    PageDataTsPrimitiveValueReader valueReader =
-        TypeServices.READ_PAGE_VALUE_TO_TSPRIMITIVETYPE_SERVICE.call(Type.fromTsDataType(dataType));
-    LongPredicate isDeleted = this::isDeleted;
+    if (valueReader == null) {
+      valueReader =
+          TypeServices.READ_PAGE_VALUE_TO_TSPRIMITIVETYPE_SERVICE.call(
+              Type.fromTsDataType(dataType));
+    }
     for (int i = 0; i < size; i++) {
       if (((bitmap[i / 8] & 0xFF) & (MASK >>> (i % 8))) == 0) {
         continue;
       }
-      valueBatch[i] = valueReader.read(valueDecoder, valueBuffer, timeBatch[i], isDeleted);
+      valueBatch[i] = valueReader.read(valueDecoder, valueBuffer, timeBatch[i], deletePredicate);
     }
     return valueBatch;
   }
@@ -177,8 +193,10 @@ public class ValuePageReader {
       }
       return;
     }
-    PageDataColumnBuilderValueReader valueReader =
-        TypeServices.READ_PAGE_VALUE_TO_COLUMNBUILDER_SERVICE.call(Type.fromTsDataType(dataType));
+    if (columnBuilderValueReader == null) {
+      columnBuilderValueReader =
+          TypeServices.READ_PAGE_VALUE_TO_COLUMNBUILDER_SERVICE.call(Type.fromTsDataType(dataType));
+    }
     for (int i = 0; i < readEndIndex; i++) {
       if (((bitmap[i / 8] & 0xFF) & (MASK >>> (i % 8))) == 0) {
         if (keepCurrentRow[i]) {
@@ -186,7 +204,8 @@ public class ValuePageReader {
         }
         continue;
       }
-      valueReader.read(valueDecoder, valueBuffer, columnBuilder, keepCurrentRow[i], isDeleted[i]);
+      columnBuilderValueReader.read(
+          valueDecoder, valueBuffer, columnBuilder, keepCurrentRow[i], isDeleted[i]);
     }
   }
 
@@ -201,8 +220,10 @@ public class ValuePageReader {
       }
       return;
     }
-    PageDataColumnBuilderValueReader valueReader =
-        TypeServices.READ_PAGE_VALUE_TO_COLUMNBUILDER_SERVICE.call(Type.fromTsDataType(dataType));
+    if (columnBuilderValueReader == null) {
+      columnBuilderValueReader =
+          TypeServices.READ_PAGE_VALUE_TO_COLUMNBUILDER_SERVICE.call(Type.fromTsDataType(dataType));
+    }
     for (int i = 0; i < readEndIndex; i++) {
       if (((bitmap[i / 8] & 0xFF) & (MASK >>> (i % 8))) == 0) {
         if (keepCurrentRow[i]) {
@@ -210,7 +231,8 @@ public class ValuePageReader {
         }
         continue;
       }
-      valueReader.read(valueDecoder, valueBuffer, columnBuilder, keepCurrentRow[i], false);
+      columnBuilderValueReader.read(
+          valueDecoder, valueBuffer, columnBuilder, keepCurrentRow[i], false);
     }
   }
 
@@ -221,12 +243,14 @@ public class ValuePageReader {
       columnBuilder.appendNull(readEndIndex - readStartIndex);
       return;
     }
-    PageDataColumnBuilderValueReader valueReader =
-        TypeServices.READ_PAGE_VALUE_TO_COLUMNBUILDER_SERVICE.call(Type.fromTsDataType(dataType));
+    if (columnBuilderValueReader == null) {
+      columnBuilderValueReader =
+          TypeServices.READ_PAGE_VALUE_TO_COLUMNBUILDER_SERVICE.call(Type.fromTsDataType(dataType));
+    }
     // skip useless data
     for (int i = 0; i < readStartIndex; i++) {
       if (((bitmap[i / 8] & 0xFF) & (MASK >>> (i % 8))) != 0) {
-        valueReader.read(valueDecoder, valueBuffer, columnBuilder, false, false);
+        columnBuilderValueReader.read(valueDecoder, valueBuffer, columnBuilder, false, false);
       }
     }
     for (int i = readStartIndex; i < readEndIndex; i++) {
@@ -234,7 +258,7 @@ public class ValuePageReader {
         columnBuilder.appendNull();
         continue;
       }
-      valueReader.read(valueDecoder, valueBuffer, columnBuilder, true, false);
+      columnBuilderValueReader.read(valueDecoder, valueBuffer, columnBuilder, true, false);
     }
   }
 


### PR DESCRIPTION
## Summary

Cache type-specific page value readers and the bound deletion predicate in `PageReader` and `ValuePageReader`.

Repeated reads reuse the type dispatch result, and each page reader binds its deletion predicate once. Service readers are initialized lazily when the corresponding API is first used; the predicate is initialized during construction.

## Performance

Local JMH 1.37 measurements on Windows 11, Intel Core i9-12900, JBR/OpenJDK 21.0.8. JVM arguments: `-Xms512m -Xmx512m -XX:+UseG1GC -XX:ActiveProcessorCount=2`. Each scenario uses one thread and five independent JVM runs, with four 500 ms warmup iterations and six 500 ms measurement iterations per run, using `-prof gc`. Values below are medians of the five per-run means. Lower ns/op and B/op are better; time reduction is `(baseline - cached) / baseline`.

**Measurement scope:** these results were collected for the earlier `ValuePageReader` snapshot with cached `valueReader` and `deletePredicate`, before adding the batch/column-builder caches and the `PageReader` changes in commit `4fabada0`. They characterize the `nextValue` optimization, not the exact final PR revision or its other APIs. The measured snapshot is identified by source SHA-256 `b0694ce4ef3e75a4bf1a3a0d5ad6e9c0f7a5ed43441b35b78c85337eb4cc35b0`.

`scan` reuses four PLAIN-encoded pages of 1,024 rows, calling `nextValue` in row/column order and consuming results with a JMH Blackhole. Its 4,096 calls include bitmap-null and deleted rows; buffer rewinds are included and amortized across those calls. `MIXED` uses INT32, INT64, DOUBLE, and BOOLEAN columns. `MIXED_NULL_DELETE` additionally has 25% bitmap-null rows per column and a deletion interval covering the last quarter of timestamps. This measures in-memory decoding, without file I/O or decompression.

### Compared with the implementation before caching

Baseline: `e00a1e43969efb9f3a9725fbd8e6d75595fd7e5d`, after the type-service refactor. These variants use the same dependency classes.

| Scenario | Baseline ns/op | Reader only ns/op | Reader + predicate ns/op | Time reduction vs baseline | B/op: baseline → cached |
| --- | ---: | ---: | ---: | ---: | ---: |
| INT64 | 4.577 | 5.034 | 4.793 | -4.7% | 24 → 24 |
| INT32 | 6.903 | 8.177 | 6.850 | +0.8% | 24 → 24 |
| DOUBLE | 4.527 | 5.767 | 4.831 | -6.7% | 24 → 24 |
| MIXED | 8.993 | 8.060 | 6.853 | +23.8% | 38 → 22 |
| MIXED_NULL_DELETE | 8.811 | 7.311 | 6.089 | +30.9% | 24.375 → 12.375 |

Reader-only allocation matches the baseline in every scenario. Caching the predicate additionally reduces allocation in the mixed scenarios. The single-type measurements do not show a consistent speedup.

### Compared with the version before the type-service refactor

Baseline: `9be35b9bea2c95dd6f0201aeb8f04255775f2a9f`, the parent of `02b503b92416a04fcfb360f446c08ef3e0978ed2`. Its complete `java/common` and `java/tsfile` modules were built and used with the same harness and JMH settings.

| Scenario | Pre-refactor ns/op | Reader + predicate ns/op | Time reduction | B/op: pre-refactor → cached |
| --- | ---: | ---: | ---: | ---: |
| INT64 | 5.797 | 4.793 | +17.3% | 24 → 24 |
| INT32 | 8.151 | 6.850 | +16.0% | 24 → 24 |
| DOUBLE | 5.736 | 4.831 | +15.8% | 24 → 24 |
| MIXED | 6.322 | 6.853 | -8.4% | 22 → 22 |
| MIXED_NULL_DELETE | 6.433 | 6.089 | +5.4% | 12.375 → 12.375 |

The pre-refactor runs were collected later, rather than interleaved with the cached variants, and include changes in dependency classes. These percentages are descriptive comparisons, not an isolated causal estimate of the refactor. Run-to-run variability is substantial: MIXED ranges from 5.639–8.969 ns/op before the refactor and 6.674–7.976 ns/op with caching. The overlapping ranges do not establish a consistent 8.4% regression.

### New-page first value

This separate INT64 benchmark includes buffer wrapping, decoder/reader construction, bitmap parsing, and the first `nextValue` call. It measures a new reader in a warmed JVM, not cold JVM startup.

| Version | Median ns/op | Run range ns/op | B/op |
| --- | ---: | ---: | ---: |
| Pre-refactor | 37.040 | 32.682–41.444 | 344 |
| Before caching | 43.743 | 34.128–51.905 | 344 |
| Reader only | 40.986 | 35.652–44.871 | 352 |
| Reader + predicate | 37.988 | 32.469–55.177 | 368 |

The timing ranges overlap, while allocation increases by 24 B per new reader in the measured cached variant. All four variants passed value-by-value checks for all five scenarios, two complete page replays, and the first value of a new page. These microbenchmarks do not establish end-to-end query throughput gains.

## Validation

- `mvn.cmd -P with-java -pl java/tsfile -am test '-Dtest=PageReaderTest,TsFileLastReaderTest' '-Dsurefire.failIfNoSpecifiedTests=false'`
- 19 tests reported: 18 passed, 1 skipped, 0 failures, 0 errors
- Checkstyle passed
- Spotless passed
- `git diff --check` passed
